### PR TITLE
Added support for Nulls First / Nulls Last

### DIFF
--- a/src/PgQuery.hs
+++ b/src/PgQuery.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, MultiWayIf #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module PgQuery where
@@ -39,6 +39,7 @@ data QualifiedTable = QualifiedTable {
 data OrderTerm = OrderTerm {
   otTerm :: Text
 , otDirection :: BS.ByteString
+, otNullOrder :: Maybe BS.ByteString
 }
 
 limitT :: Maybe NonnegRange -> StatementT
@@ -67,7 +68,8 @@ orderT ts q =
    queryTerm :: OrderTerm -> PStmt
    queryTerm t = B.Stmt
                    (" " <> cs (pgFmtIdent $ otTerm t) <> " "
-                        <> cs (otDirection t)         <> " ")
+                        <> cs (otDirection t)         <> " "
+                        <> maybe "" cs (otNullOrder t) <> " ")
                    empty True
 
 parentheticT :: StatementT
@@ -162,10 +164,16 @@ orderParse q =
 orderParseTerm :: Text -> Maybe OrderTerm
 orderParseTerm s =
   case split (=='.') s of
-       [c,d] ->
+       (c:d:nls) ->
          if d `elem` ["asc", "desc"]
-            then Just $ OrderTerm c $
-              if d == "asc" then "asc" else "desc"
+            then Just $ OrderTerm c
+              ( if d == "asc" then "asc" else "desc" )
+              ( case nls of
+                  [n] -> if | n == "nullsfirst" -> Just "nulls first"
+                            | n == "nullslast"  -> Just "nulls last"
+                            | otherwise -> Nothing
+                  _   -> Nothing
+              )
             else Nothing
        _ -> Nothing
 

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -4,57 +4,106 @@ import Test.Hspec
 import Test.Hspec.Wai
 
 import SpecHelper
+import Data.Monoid
 
 spec :: Spec
-spec = beforeAll (clearTable "items" >> createItems 15)
-  . afterAll_ (clearTable "items") . around withApp $ do
-  describe "Querying a nonexistent table" $
-    it "causes a 404" $
-      get "/faketable" `shouldRespondWith` 404
+spec = do
+  beforeAll (clearTable "items" >> createItems 15)
+   . beforeAll (clearTable "no_pk" >> createNulls 2)
+   . afterAll_ (clearTable "items" >> clearTable "no_pk")
+   . around withApp $ do
+    describe "Querying a nonexistent table" $
+      it "causes a 404" $
+        get "/faketable" `shouldRespondWith` 404
 
-  describe "Filtering response" $
-    context "column equality" $
+    describe "Filtering response" $
+      context "column equality" $
 
-      it "matches the predicate" $
-        get "/items?id=eq.5"
+        it "matches the predicate" $
+          get "/items?id=eq.5"
+            `shouldRespondWith` ResponseMatcher {
+              matchBody    = Just "[{\"id\":5}]"
+            , matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "0-0/1"]
+            }
+
+    describe "ordering response" $ do
+      it "by a column asc" $
+        get "/items?id=lte.2&order=id.asc"
           `shouldRespondWith` ResponseMatcher {
-            matchBody    = Just "[{\"id\":5}]"
+            matchBody    = Just "[{\"id\":1},{\"id\":2}]"
           , matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-0/1"]
+          , matchHeaders = ["Content-Range" <:> "0-1/2"]
+          }
+      it "by a column desc" $
+        get "/items?id=lte.2&order=id.desc"
+          `shouldRespondWith` ResponseMatcher {
+            matchBody    = Just "[{\"id\":2},{\"id\":1}]"
+          , matchStatus  = 200
+          , matchHeaders = ["Content-Range" <:> "0-1/2"]
           }
 
-  describe "ordering response" $ do
-    it "by a column asc" $
-      get "/items?id=lte.2&order=id.asc"
-        `shouldRespondWith` ResponseMatcher {
-          matchBody    = Just "[{\"id\":1},{\"id\":2}]"
-        , matchStatus  = 200
-        , matchHeaders = ["Content-Range" <:> "0-1/2"]
-        }
-    it "by a column desc" $
-      get "/items?id=lte.2&order=id.desc"
-        `shouldRespondWith` ResponseMatcher {
-          matchBody    = Just "[{\"id\":2},{\"id\":1}]"
-        , matchStatus  = 200
-        , matchHeaders = ["Content-Range" <:> "0-1/2"]
-        }
+      it "by a column asc with nulls first" $
+        get "/no_pk?order=a.asc.nullsfirst"
+          `shouldRespondWith` ResponseMatcher {
+            matchBody = Just $ "[{\"a\":null,\"b\":null}"
+                            <> ",{\"a\":\"1\",\"b\":\"0\"}"
+                            <> ",{\"a\":\"2\",\"b\":\"0\"}]"
+          , matchStatus = 200
+          , matchHeaders = ["Content-Range" <:> "0-2/3"]
+          }
 
-    it "without other constraints" $
-      get "/items?order=asc.id" `shouldRespondWith` 200
+      it "by a column asc with nulls last" $
+        get "/no_pk?order=a.asc.nullslast"
+          `shouldRespondWith` ResponseMatcher {
+            matchBody = Just $ "[{\"a\":\"1\",\"b\":\"0\"}"
+                            <> ",{\"a\":\"2\",\"b\":\"0\"}"
+                            <> ",{\"a\":null,\"b\":null}]"
 
-  describe "Canonical location" $ do
-    it "Sets Content-Location with alphabetized params" $
-      get "/no_pk?b=eq.1&a=eq.1"
-        `shouldRespondWith` ResponseMatcher {
-          matchBody    = Just "[]"
-        , matchStatus  = 200
-        , matchHeaders = ["Content-Location" <:> "/no_pk?a=eq.1&b=eq.1"]
-        }
+          , matchStatus = 200
+          , matchHeaders = ["Content-Range" <:> "0-2/3"]
+          }
 
-    it "Omits question mark when there are no params" $
-      get "/no_pk"
-        `shouldRespondWith` ResponseMatcher {
-          matchBody    = Just "[]"
-        , matchStatus  = 200
-        , matchHeaders = ["Content-Location" <:> "/no_pk"]
-        }
+      it "by a column desc with nulls first" $
+        get "/no_pk?order=a.desc.nullsfirst"
+          `shouldRespondWith` ResponseMatcher {
+            matchBody = Just $ "[{\"a\":null,\"b\":null}"
+                            <> ",{\"a\":\"2\",\"b\":\"0\"}"
+                            <> ",{\"a\":\"1\",\"b\":\"0\"}]"
+          , matchStatus = 200
+          , matchHeaders = ["Content-Range" <:> "0-2/3"]
+          }
+
+      it "by a column desc with nulls last" $
+        get "/no_pk?order=a.desc.nullslast"
+          `shouldRespondWith` ResponseMatcher {
+            matchBody = Just $ "[{\"a\":\"2\",\"b\":\"0\"}"
+                            <> ",{\"a\":\"1\",\"b\":\"0\"}"
+                            <> ",{\"a\":null,\"b\":null}]"
+
+          , matchStatus = 200
+          , matchHeaders = ["Content-Range" <:> "0-2/3"]
+          }
+
+
+      it "without other constraints" $
+        get "/items?order=asc.id" `shouldRespondWith` 200
+
+  beforeAll (clearTable "no_pk") . around withApp $
+    describe "Canonical location" $ do
+      it "Sets Content-Location with alphabetized params" $
+        get "/no_pk?b=eq.1&a=eq.1"
+          `shouldRespondWith` ResponseMatcher {
+            matchBody    = Just "[]"
+          , matchStatus  = 200
+          , matchHeaders = ["Content-Location" <:> "/no_pk?a=eq.1&b=eq.1"]
+          }
+
+
+      it "Omits question mark when there are no params" $
+        get "/no_pk"
+          `shouldRespondWith` ResponseMatcher {
+            matchBody    = Just "[]"
+          , matchStatus  = 200
+          , matchHeaders = ["Content-Location" <:> "/no_pk"]
+          }

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -111,8 +111,20 @@ createItems n = do
     <- H.acquirePool pgSettings testPoolOpts
   void . liftIO $ H.session pool $ H.tx Nothing txn
   where
-    txn = sequence_ $ map H.unitEx stmts
+    txn = mapM_ H.unitEx stmts
     stmts = map [H.stmt|insert into "1".items (id) values (?)|] [1..n]
+
+createNulls :: Int -> IO ()
+createNulls n = do
+  pool :: H.Pool H.Postgres
+    <- H.acquirePool pgSettings testPoolOpts
+  void . liftIO $ H.session pool $ H.tx Nothing txn
+  where
+    txn = mapM_ H.unitEx (stmt':stmts)
+    stmt' = [H.stmt|insert into "1".no_pk (a,b) values (null,null)|]
+    stmts = map [H.stmt|insert into "1".no_pk (a,b) values (?,0)|] [1..n]
+
+
 
 -- for hspec-wai
 pending_ :: WaiSession ()


### PR DESCRIPTION
So, this adds support for an optional ```nullsfirst``` or ```nullslast``` (verbose, I know, but it keeps in line with postgres terminology) parameter to the order parameters. 

So, we can have:

```GET /people?order=age.desc.nullsfirst,height.asc.nullslast```

This is grouped with the previous PR, but as soon as you accept it I can make the necessary adjustments to this one.

I can also add tests, of course, I just would like to know which table should I use... can I add a nullable field to items?

Hope you find this useful, 
Cheers

PS: I am also thinking about adding a ```isnull``` / ```isnotnull``` to the Filters, seems good?