### PR TITLE
Support of is / is not null | true | false | unknown

### DIFF
--- a/src/PgQuery.hs
+++ b/src/PgQuery.hs
@@ -139,13 +139,16 @@ update t cols vals = B.Stmt
 wherePred :: Net.QueryItem -> PStmt
 wherePred (col, predicate)
   = B.Stmt (" " <> cs (pgFmtIdent $ cs col) <> " " <> op <> " " <>
-      if opCode `elem` ["is","isnot"] then value
+      if opCode `elem` ["is","isnot"] then whiteList value
                                       else cs (pgFmtLit value) <> "::unknown ")
       empty True
 
   where
     opCode:rest = split (=='.') $ cs $ fromMaybe "." predicate
     value = intercalate "." rest
+    whiteList val = fromMaybe (cs (pgFmtLit val) <> "::unknown ")
+                              (L.find ((==) . toLower $ val)
+                                       ["null","true","false"])
     op = case opCode of
          "eq"    -> "="
          "gt"    -> ">"

--- a/src/PgQuery.hs
+++ b/src/PgQuery.hs
@@ -139,7 +139,7 @@ update t cols vals = B.Stmt
 wherePred :: Net.QueryItem -> PStmt
 wherePred (col, predicate)
   = B.Stmt (" " <> cs (pgFmtIdent $ cs col) <> " " <> op <> " " <>
-      if opCode `elem` ["is","isnot"] then "null"
+      if opCode `elem` ["is","isnot"] then value
                                       else cs (pgFmtLit value) <> "::unknown ")
       empty True
 

--- a/src/PgQuery.hs
+++ b/src/PgQuery.hs
@@ -137,21 +137,25 @@ update t cols vals = B.Stmt
   empty True
 
 wherePred :: Net.QueryItem -> PStmt
-wherePred (col, predicate) = B.Stmt
-  (" " <> cs (pgFmtIdent $ cs col) <> " " <> op <> " " <> cs (pgFmtLit value) <> "::unknown ")
-  empty True
+wherePred (col, predicate)
+  = B.Stmt (" " <> cs (pgFmtIdent $ cs col) <> " " <> op <> " " <>
+      if opCode `elem` ["is","isnot"] then "null"
+                                      else cs (pgFmtLit value) <> "::unknown ")
+      empty True
 
   where
     opCode:rest = split (=='.') $ cs $ fromMaybe "." predicate
     value = intercalate "." rest
     op = case opCode of
-         "eq"  -> "="
-         "gt"  -> ">"
-         "lt"  -> "<"
-         "gte" -> ">="
-         "lte" -> "<="
-         "neq" -> "<>"
-         _     -> "="
+         "eq"    -> "="
+         "gt"    -> ">"
+         "lt"    -> "<"
+         "gte"   -> ">="
+         "lte"   -> "<="
+         "neq"   -> "<>"
+         "is"    -> "is"
+         "isnot" -> "is not"
+         _       -> "="
 
 orderParse :: Net.Query -> [OrderTerm]
 orderParse q =


### PR DESCRIPTION
This adds support for the constructs ```is null```, ```is not null``` and similars (```true```, ```false``` and ```unkwnon```).
These values are not verified neither escaped. Should they be? I am not really familiar with the procedure in this case, so I could use some help here.

This patch, however, does not support the form ```expression IS DISTINCT FROM expression```.

[Source](http://www.postgresql.org/docs/9.4/static/functions-comparison.html)

Thanks