### PR TITLE
Add 'Location' to exposed headers

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -47,7 +47,7 @@ corsPolicy req = case lookup "origin" headers of
     , corsRequestHeaders = "Authentication":accHeaders
     , corsExposedHeaders = Just [
           "Content-Encoding", "Content-Location", "Content-Range", "Content-Type"
-        , "Date", "Server", "Transfer-Encoding", "Range-Unit"
+        , "Date", "Location", "Server", "Transfer-Encoding", "Range-Unit"
         ]
     }
   Nothing -> Nothing

--- a/test/Feature/CorsSpec.hs
+++ b/test/Feature/CorsSpec.hs
@@ -59,7 +59,7 @@ spec = around withApp $ describe "CORS" $ do
         liftIO $ simpleHeaders r `shouldSatisfy` matchHeader
           "Access-Control-Expose-Headers"
           "Content-Encoding, Content-Location, Content-Range, Content-Type, \
-            \Date, Server, Transfer-Encoding, Range-Unit"
+            \Date, Location, Server, Transfer-Encoding, Range-Unit"
 
     describe "postflight request" $
       it "allows INFO body through even with CORS request headers present" $ do


### PR DESCRIPTION
Usefull if we want to redirect to show view (in ng-admin for instance) after creating a new entity.