### PR TITLE
Show long help output with defaults on usage errors

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -32,7 +32,8 @@ main = do
                     <> prettyVersion
                     <> " / create a REST API to an existing Postgres database"
                 )
-  conf <- execParser opts
+      parserPrefs = prefs showHelpOnError
+  conf <- customExecParser parserPrefs opts
   let port = configPort conf
 
   unless (configSecure conf) $


### PR DESCRIPTION
This makes optparse-applicative show the long version of help output.
Its default behavior is not to do this since the showHelpOnError
setting defaults to False.  This turns it on.