### PR TITLE
Add global basic auth support

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -21,6 +21,8 @@ data AppConfig = AppConfig {
   , configSecure :: Bool
   , configPool :: Int
   , configV1Schema :: String
+  , configBasicAuthUser :: String
+  , configBasicAuthPassword :: String
   }
 
 argParser :: Parser AppConfig
@@ -36,6 +38,8 @@ argParser = AppConfig
   <*> switch (long "secure" <> short 's' <> help "Redirect all requests to HTTPS")
   <*> option auto (long "db-pool" <> metavar "COUNT" <> value 10 <> help "Max connections in database pool" <> showDefault)
   <*> strOption (long "v1schema" <> metavar "NAME" <> value "1" <> help "Schema to use for nonspecified version (or explicit v1)" <> showDefault)
+  <*> strOption (long "basic-auth-user" <> metavar "BASICAUTHUSER" <> help "HTTP Basic Auth for the whole app")
+  <*> strOption (long "basic-auth-password" <> metavar "BASICAUTHPASSWORD" <> help "HTTP Basic Auth (password) for the whole app")
 
 defaultCorsPolicy :: CorsResourcePolicy
 defaultCorsPolicy =  CorsResourcePolicy Nothing

--- a/src/Middleware.hs
+++ b/src/Middleware.hs
@@ -26,14 +26,7 @@ authenticated :: forall s. Text -> Text ->
                  (Request -> H.Tx P.Postgres s Response) ->
                  Request -> H.Tx P.Postgres s Response
 authenticated currentRole anon app req = do
-  attempt <- httpRequesterRole (requestHeaders req)
-  case attempt of
-    MalformedAuth ->
-      return $ responseLBS status400 [] "Malformed basic auth header"
-    LoginFailed ->
-      return $ responseLBS status401 [] "Invalid username or password"
-    LoginSuccess role -> if role /= currentRole then runInRole role else app req
-    NoCredentials ->     if anon /= currentRole then runInRole anon else app req
+    if anon /= currentRole then runInRole anon else app req
 
  where
    httpRequesterRole :: RequestHeaders -> H.Tx P.Postgres s LoginAttempt


### PR DESCRIPTION
I'm opening this pull request for two purposes:

* Receive feedback on better ways than commenting out the code in Middleware.hs
* See if the maintainer will be open to do this.

I don't care about the current role based system. I'm the only user, and I want something that just works against Heroku postgres. Using `--anonymous <mydbuser>` works, with the only pending feature being protecting everything using basic auth, which is what this PR does. If it won't be accepted, I'll have to maintain my fork.

(The second feature I'd like to add is to customize the static files whitelist to include index.html, but that may not land as PR)