### PR TITLE
JWT support

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -19,8 +19,8 @@ executable postgrest
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, ScopedTypeVariables, QuasiQuotes
   build-depends:       base >=4.6 && <5
-                     , hasql == 0.7.3, hasql-backend == 0.4.1
-                     , hasql-postgres == 0.10.3
+                     , hasql == 0.7.3.1, hasql-backend == 0.4.1
+                     , hasql-postgres == 0.10.3.1
                      , warp >= 3.0.2, wai >= 3.0.1
                      , wai-extra, wai-cors
                      , wai-middleware-static >= 0.6.0
@@ -43,6 +43,7 @@ executable postgrest
                      , vector
                      , mtl
                      , cassava
+                     , jwt
   Other-Modules:       App
                      , Auth
                      , Config
@@ -74,8 +75,8 @@ Test-Suite spec
                      , SpecHelper
   Build-Depends:       base, hspec >= 2.1.2, QuickCheck
                      , hspec-wai >= 0.5.0, hspec-wai-json
-                     , hasql == 0.7.3, hasql-backend == 0.4.1
-                     , hasql-postgres == 0.10.3
+                     , hasql == 0.7.3.1, hasql-backend == 0.4.1
+                     , hasql-postgres == 0.10.3.1
                      , warp, wai
                      , packdeps, hlint
                      , HTTP, convertible
@@ -102,3 +103,4 @@ Test-Suite spec
                      , cassava
                      , process
                      , heredoc
+                     , jwt

--- a/src/App.hs
+++ b/src/App.hs
@@ -34,13 +34,16 @@ import qualified Hasql as H
 import qualified Hasql.Backend as B
 import qualified Hasql.Postgres as P
 
+import Config (AppConfig(..))
 import Auth
 import PgQuery
 import RangeQuery
 import PgStructure
 
-app :: Text -> BL.ByteString -> Request -> H.Tx P.Postgres s Response
-app v1schema reqBody req =
+import Prelude
+
+app :: AppConfig -> BL.ByteString -> Request -> H.Tx P.Postgres s Response
+app conf reqBody req =
   case (path, verb) of
     ([], _) -> do
       body <- encode <$> tables (cs schema)
@@ -101,6 +104,27 @@ app v1schema reqBody req =
             [ jsonH
             , (hLocation, "/postgrest/users?id=eq." <> cs (userId u))
             ] ""
+
+    (["postgrest", "tokens"], "POST") -> 
+      case jwtSecret of
+        "secret" -> return $ responseLBS status500 [jsonH] $
+          encode . object $ [("message", String "JWT Secret is set as \"secret\" which is an unsafe default.")]
+        _ -> do
+          let user = decode reqBody :: Maybe AuthUser
+          
+          case user of
+            Nothing -> return $ responseLBS status400 [jsonH] $
+              encode . object $ [("message", String "Failed to parse user.")]
+            Just u -> do
+              setRole authenticator
+              login <- signInRole (cs $ userId u)
+                              (cs $ userPass u)
+              case login of
+                LoginSuccess role -> 
+                  return $ responseLBS status201 [ jsonH ] $
+                    encode . object $ [("token", String $ tokenJWT jwtSecret (cs $ userId u) role)]
+                _  -> return $ responseLBS status401 [jsonH] $
+                  encode . object $ [("message", String "Failed authentication.")]
 
     ([table], "POST") -> do
       let qt = QualifiedTable schema (cs table)
@@ -201,7 +225,9 @@ app v1schema reqBody req =
     verb   = requestMethod req
     qq     = queryString req
     hdrs   = requestHeaders req
-    schema = requestedSchema v1schema hdrs
+    schema = requestedSchema (cs $ configV1Schema conf) hdrs
+    authenticator = cs $ configDbUser conf
+    jwtSecret = cs $ configJwtSecret conf
     range  = rangeRequested hdrs
     allOrigins = ("Access-Control-Allow-Origin", "*") :: Header
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -8,6 +8,7 @@ import qualified Data.ByteString.Char8 as BS
 import Data.String.Conversions (cs)
 import Options.Applicative hiding (columns)
 import Network.Wai.Middleware.Cors (CorsResourcePolicy(..))
+import Prelude
 
 data AppConfig = AppConfig {
     configDbName :: String
@@ -21,6 +22,8 @@ data AppConfig = AppConfig {
   , configSecure :: Bool
   , configPool :: Int
   , configV1Schema :: String
+  
+  , configJwtSecret :: String
   }
 
 argParser :: Parser AppConfig
@@ -36,6 +39,7 @@ argParser = AppConfig
   <*> switch (long "secure" <> short 's' <> help "Redirect all requests to HTTPS")
   <*> option auto (long "db-pool" <> metavar "COUNT" <> value 10 <> help "Max connections in database pool" <> showDefault)
   <*> strOption (long "v1schema" <> metavar "NAME" <> value "1" <> help "Schema to use for nonspecified version (or explicit v1)" <> showDefault)
+  <*> strOption (long "jwt-secret" <> metavar "SECRET" <> value "secret" <> help "Secret used to encrypt and decrypt JWT tokens)" <> showDefault)
 
 defaultCorsPolicy :: CorsResourcePolicy
 defaultCorsPolicy =  CorsResourcePolicy Nothing

--- a/src/PgQuery.hs
+++ b/src/PgQuery.hs
@@ -17,13 +17,15 @@ import qualified Data.ByteString.Char8 as BS
 import Data.Monoid
 import Data.Vector (empty)
 import Data.Maybe (fromMaybe, mapMaybe)
-import Data.Functor ( (<$>) )
+import Data.Functor
 import Control.Monad (join)
 import Data.String.Conversions (cs)
 import qualified Data.Aeson as JSON
 import qualified Data.List as L
 import qualified Data.Vector as V
 import Data.Scientific (isInteger, formatScientific, FPFormat(..))
+
+import Prelude
 
 type PStmt = H.Stmt P.Postgres
 instance Monoid PStmt where

--- a/src/PgStructure.hs
+++ b/src/PgStructure.hs
@@ -9,12 +9,14 @@ import Data.Aeson
 import Data.Functor.Identity
 import Data.String.Conversions (cs)
 import Data.Maybe (fromMaybe)
-import Control.Applicative ( (<$>) )
+import Control.Applicative
 
 import qualified Data.Map as Map
 
 import qualified Hasql as H
 import qualified Hasql.Postgres as P
+
+import Prelude
 
 foreignKeys :: QualifiedTable -> H.Tx P.Postgres s (Map.Map Text ForeignKey)
 foreignKeys table = do

--- a/src/RangeQuery.hs
+++ b/src/RangeQuery.hs
@@ -20,6 +20,8 @@ import Text.Read (readMaybe)
 
 import Data.Maybe (fromMaybe, listToMaybe)
 
+import Prelude
+
 type NonnegRange = Range Int
 
 rangeParse :: BS.ByteString -> Maybe NonnegRange

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -18,13 +18,37 @@ spec = beforeAll
   it "hides tables that anonymous does not own" $
     get "/authors_only" `shouldRespondWith` 404
 
-  it "indicates login failure" $ do
-    let auth = authHeader "postgrest_test_author" "fakefake"
+  it "indicates login failure (BasicAuth)" $ do
+    let auth = authHeaderBasic "postgrest_test_author" "fakefake"
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 401
 
-  it "allows users with permissions to see their tables" $ do
+  it "allows users with permissions to see their tables (BasicAuth)" $ do
     _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
-    let auth = authHeader "jdoe" "1234"
+    let auth = authHeaderBasic "jdoe" "1234"
+    request methodGet "/authors_only" [auth] ""
+      `shouldRespondWith` 200
+      
+  it "allows users to login (JWT)" $ do
+    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
+    post "/postgrest/tokens" [json| { "id":"jdoe", "pass": "1234" } |] 
+      `shouldRespondWith` ResponseMatcher {
+          matchBody = Just [json| {"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"} |]
+        , matchStatus = 201
+        , matchHeaders = ["Content-Type" <:> "application/json"]
+        }
+      
+  it "indicates login failure (JWT)" $ do
+    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
+    post "/postgrest/tokens" [json| { "id":"jdoe", "pass": "NOPE" } |] 
+      `shouldRespondWith` ResponseMatcher {
+          matchBody = Just [json| {"message":"Failed authentication."} |]
+        , matchStatus = 401
+        , matchHeaders = ["Content-Type" <:> "application/json"]
+        }
+
+  it "allows users with permissions to see their tables (JWT)" $ do
+    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
+    let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 200

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -27,7 +27,7 @@ spec = around withApp $ do
 
     it "lists only views user has permission to see" $ do
       _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
-      let auth = authHeader "jdoe" "1234"
+      let auth = authHeaderBasic "jdoe" "1234"
 
       request methodGet "/" [auth] ""
         `shouldRespondWith` [json| [

--- a/test/TestTypes.hs
+++ b/test/TestTypes.hs
@@ -8,8 +8,10 @@ module TestTypes (
 import qualified Data.Aeson as JSON
 import Data.Aeson ((.:))
 -- import Data.Maybe (fromJust)
-import Control.Applicative ((<$>), (<*>))
+import Control.Applicative
 import Control.Monad (mzero)
+
+import Prelude
 
 data IncPK = IncPK {
   incId :: Int


### PR DESCRIPTION
Hi guys,

This PR brings support for logging in through JSON Web Tokens.
Should close #163.

We have a new dependency on `jwt`

There is a new option `--jwt-secret secret` which can be used to change the secret used to encryp and decrypt the JWT

I've added a new route on `POST /postgrest/sessions` which accept `id` and `pass` and returns a JSON Web Token:

    {
        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYWRtaW5pc3RyYXRvciIsImlkIjoiZnJhbXAifQ.qKwM3TFSrK9eLZ2OvR9p1yMWwx32QoMgw2KANgBGtv4"
    }

Or:

    {
        "message": "Failed authentication."
    }


Adding a 

    Authorization:Bearer JWT_TOKEN
 to a request (with a valid JWT token of course) will authenticate the user.

I've made a couple of changes on how the config is passed across the application: now `authenticated` and `app` have full access to config (which was needed to pass the secret around).

I've also upgraded hasql and hasql-postgres as they were failing the circle build.

Looking at the future, the next step could be adding support for a `iat` (creation timestamp) and `exp` (expiration timestamp).

As an aside note: I'm working with GHC 7.10 and the test suite can't run without temporarily disabling `-Werror` (we have a couple of warnings - more specifically the imports marked with `--7.10 redundant` are redundant). 
I didn't fix them because it was out of the scope of the PR and because I'm not sure what's the best way to deal with this problem while maintaining compatibility with previous versions.