### PR TITLE
Tsearch operator

### DIFF
--- a/src/PostgREST/PgQuery.hs
+++ b/src/PostgREST/PgQuery.hs
@@ -175,6 +175,7 @@ wherePred (col, predicate) =
             "like" -> unknownLiteral $ T.map star value
             "ilike" -> unknownLiteral $ T.map star value
             "in" -> "(" <> T.intercalate ", " (map unknownLiteral $ T.split (==',') value) <> ") "
+            "@@" -> "to_tsquery(" <> unknownLiteral value <> ") "
             _    -> unknownLiteral value
 
     op = case opCode of
@@ -189,6 +190,7 @@ wherePred (col, predicate) =
          "in"  -> "in"
          "is"    -> "is"
          "isnot" -> "is not"
+         "@@" -> "@@"
          _     -> "="
 
 orderParse :: Net.Query -> [OrderTerm]

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -56,6 +56,10 @@ spec =
       get "/simple_pk?k=ilike.*YY*&order=extra.asc" `shouldRespondWith`
         "[{\"k\":\"xyyx\",\"extra\":\"u\"},{\"k\":\"xYYx\",\"extra\":\"v\"}]"
 
+    it "matches with tsearch @@" $
+      get "/tsearch?text_search_vector=@@.foo" `shouldRespondWith`
+        "[{\"text_search_vector\":\"'bar':2 'foo':1\"}]"
+
   describe "ordering response" $ do
     it "by a column asc" $
       get "/items?id=lte.2&order=id.asc"

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -22,6 +22,7 @@ spec = around withApp $ do
         , {"schema":"1","name":"menagerie","insertable":true}
         , {"schema":"1","name":"no_pk","insertable":true}
         , {"schema":"1","name":"simple_pk","insertable":true}
+        , {"schema":"1","name":"tsearch","insertable":true}
         ] |]
         {matchStatus = 200}
 

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -212,6 +212,12 @@ CREATE TABLE json
 ALTER TABLE "1".json OWNER TO postgrest_test;
 
 
+CREATE TABLE tsearch (
+    text_search_vector tsvector
+);
+
+ALTER TABLE "1".tsearch OWNER TO postgrest_test;
+
 SET search_path = postgrest, pg_catalog;
 
 
@@ -299,14 +305,8 @@ INSERT INTO items (id) VALUES (1);
 SELECT pg_catalog.setval('items_id_seq', 1, true);
 
 
-
-
-
-
-
-
-
-
+INSERT INTO tsearch (text_search_vector) VALUES ('''bar'':2 ''foo'':1');
+INSERT INTO tsearch (text_search_vector) VALUES ('''baz'':1 ''qux'':2');
 
 SET search_path = postgrest, pg_catalog;
 
@@ -489,6 +489,13 @@ REVOKE ALL ON TABLE json FROM PUBLIC;
 REVOKE ALL ON TABLE json FROM postgrest_test;
 GRANT ALL ON TABLE json TO postgrest_test;
 GRANT ALL ON TABLE json TO postgrest_anonymous;
+
+
+
+REVOKE ALL ON TABLE tsearch FROM PUBLIC;
+REVOKE ALL ON TABLE tsearch FROM postgrest_test;
+GRANT ALL ON TABLE tsearch TO postgrest_test;
+GRANT ALL ON TABLE tsearch TO postgrest_anonymous;
 
 
 SET search_path = postgrest, pg_catalog;


### PR DESCRIPTION
Implements the @@ with a to_tsquery wrapped arount the input value, so we can use some of PostgreSQL full text search cababilities. Although is a very limited support it seems to be the the least intrusive way to implement and have at least some functionality.
Maybe in the future the unknownLiteral value could be wrapped with an arbitrary function defined by the query.