### PR TITLE
Add --serverstring command line flag (see issue #197)

### DIFF
--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -1,11 +1,15 @@
 module PostgREST.Config where
 
+import Paths_postgrest (version)
+
 import Network.Wai
 import Control.Applicative
 import Data.Text (strip)
 import qualified Data.CaseInsensitive as CI
 import qualified Data.ByteString.Char8 as BS
+import Data.List (intercalate)
 import Data.String.Conversions (cs)
+import Data.Version (versionBranch)
 import Options.Applicative hiding (columns)
 import Network.Wai.Middleware.Cors (CorsResourcePolicy(..))
 import Prelude
@@ -22,6 +26,7 @@ data AppConfig = AppConfig {
   , configSecure :: Bool
   , configPool :: Int
   , configV1Schema :: String
+  , configServerString :: String
   
   , configJwtSecret :: String
   }
@@ -39,6 +44,7 @@ argParser = AppConfig
   <*> switch (long "secure" <> short 's' <> help "Redirect all requests to HTTPS")
   <*> option auto (long "db-pool" <> metavar "COUNT" <> value 10 <> help "Max connections in database pool" <> showDefault)
   <*> strOption (long "v1schema" <> metavar "NAME" <> value "1" <> help "Schema to use for nonspecified version (or explicit v1)" <> showDefault)
+  <*> strOption (long "serverstring" <> metavar "STRING" <> value defaultServerString <> help "Descriptive string for the PostgREST server" <> showDefault)
   <*> strOption (long "jwt-secret" <> metavar "SECRET" <> value "secret" <> help "Secret used to encrypt and decrypt JWT tokens)" <> showDefault)
 
 defaultCorsPolicy :: CorsResourcePolicy
@@ -62,3 +68,9 @@ corsPolicy req = case lookup "origin" headers of
     accHeaders = case lookup "access-control-request-headers" headers of
       Just hdrs -> map (CI.mk . cs . strip . cs) $ BS.split ',' hdrs
       Nothing -> []
+
+prettyVersion :: String
+prettyVersion = intercalate "." $ map show $ versionBranch version
+
+defaultServerString :: String
+defaultServerString = "postgrest/" <> prettyVersion

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -1,7 +1,5 @@
 module Main where
 
-import Paths_postgrest (version)
-
 import PostgREST.App
 import PostgREST.Middleware
 import PostgREST.Error(errResponse)
@@ -15,13 +13,11 @@ import Network.Wai.Handler.Warp hiding (Connection)
 import Network.Wai.Middleware.Gzip (gzip, def)
 import Network.Wai.Middleware.Static (staticPolicy, only)
 import Network.Wai.Middleware.RequestLogger (logStdout)
-import Data.List (intercalate)
-import Data.Version (versionBranch)
 import qualified Hasql as H
 import qualified Hasql.Postgres as P
 import Options.Applicative hiding (columns)
 
-import PostgREST.Config (AppConfig(..), argParser, corsPolicy)
+import PostgREST.Config (AppConfig(..), argParser, corsPolicy, prettyVersion)
 
 main :: IO ()
 main = do
@@ -49,7 +45,7 @@ main = do
                      (cs $ configDbPass conf)
                      (cs $ configDbName conf)
       appSettings = setPort port
-                  . setServerName (cs $ "postgrest/" <> prettyVersion)
+                  . setServerName (cs $ configServerString conf)
                   $ defaultSettings
       middle = logStdout
         . (if configSecure conf then redirectInsecure else id)
@@ -66,6 +62,3 @@ main = do
     resOrError <- liftIO $ H.session pool $ H.tx Nothing $
       authenticated conf (app conf body) req
     either (respond . errResponse) respond resOrError
-
-  where
-    prettyVersion = intercalate "." $ map show $ versionBranch version

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -36,7 +36,7 @@ isLeft (Left _ ) = True
 isLeft _ = False
 
 cfg :: AppConfig
-cfg = AppConfig "postgrest_test" 5432 "postgrest_test" "" "localhost" 3000 "postgrest_anonymous" False 10 "1" "safe"
+cfg = AppConfig "postgrest_test" 5432 "postgrest_test" "" "localhost" 3000 "postgrest_anonymous" False 10 "1" "PostgREST" "safe"
 
 testPoolOpts :: PoolSettings
 testPoolOpts = fromMaybe (error "bad settings") $ H.poolSettings 1 30


### PR DESCRIPTION
Hi, this adds a new (optional) command line flag, which enables the user to modify the server string:

--serverstring STRING     Descriptive string for the PostgREST server (default: "postgrest/0.2.9.1")            