### PR TITLE
User_id support (via user_vars)

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -120,9 +120,9 @@ app conf reqBody req =
               login <- signInRole (cs $ userId u)
                               (cs $ userPass u)
               case login of
-                LoginSuccess role ->
+                LoginSuccess role uid ->
                   return $ responseLBS status201 [ jsonH ] $
-                    encode . object $ [("token", String $ tokenJWT jwtSecret (cs $ userId u) role)]
+                    encode . object $ [("token", String $ tokenJWT jwtSecret uid role)]
                 _  -> return $ responseLBS status401 [jsonH] $
                   encode . object $ [("message", String "Failed authentication.")]
 

--- a/test/Unit/PgQuerySpec.hx
+++ b/test/Unit/PgQuerySpec.hx
@@ -79,7 +79,7 @@ spec = around dbWithSchema $ do
     addUser user pass role conn
     return conn) $ do
     it "accepts correct credentials and return the role" $ \conn ->
-      signInRole user pass conn `shouldReturn` LoginSuccess role
+      signInRole user pass conn `shouldReturn` LoginSuccess role user
 
     it "returns nothing with bad creds" $ \conn -> do
       signInRole "not-a-user" pass conn `shouldReturn` LoginFailed


### PR DESCRIPTION
As per title, with this PR a `user_vars.user_id` containing the user's `id` will be set.
The variable is scoped on the [connection](http://postgresql.nabble.com/can-I-define-own-variables-td1889836.html).

It can then be used in triggers with:

    SELECT current_setting('user_vars.user_id');

The fixture and test I added should be quite easy to follow.

Should close #123 