### PR TITLE
Make "postgrest" string configurable

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -102,7 +102,7 @@ app conf reqBody req =
           Nothing -> return $ responseLBS status400 [jsonH] $
             encode . object $ [("message", String "Failed to parse user.")]
           Just u -> do
-            _ <- addUser (cs $ userId u)
+            _ <- addUser serverName (cs $ userId u)
               (cs $ userPass u) (cs $ userRole u)
             return $ responseLBS status201
               [ jsonH
@@ -124,7 +124,8 @@ app conf reqBody req =
                 encode . object $ [("message", String "Failed to parse user.")]
               Just u -> do
                 setRole authenticator
-                login <- signInRole (cs $ userId u)
+                login <- signInRole serverName 
+                                (cs $ userId u)
                                 (cs $ userPass u)
                 case login of
                   LoginSuccess role uid ->
@@ -236,7 +237,7 @@ app conf reqBody req =
     authenticator = cs $ configDbUser conf
     jwtSecret = cs $ configJwtSecret conf
     serverName = cs $ configServerName conf ::Text
-    authPath = cs $ configAuthPath conf ::Text
+    authPath = cs $ configServerName conf ::Text
     
     range  = rangeRequested hdrs
     allOrigins = ("Access-Control-Allow-Origin", "*") :: Header

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -26,7 +26,6 @@ data AppConfig = AppConfig {
   , configJwtSecret :: String
   , configServerString :: String
   , configServerName :: String
-  , configAuthPath :: String
   }
 
 argParser :: Parser AppConfig
@@ -45,7 +44,6 @@ argParser = AppConfig
   <*> strOption (long "jwt-secret" <> metavar "SECRET" <> value "secret" <> help "Secret used to encrypt and decrypt JWT tokens)" <> showDefault)
   <*> strOption (long "server-string" <> metavar "SERVERSTRING" <> value "" <> help "Server string exposed through headers (default: \"SERVERNAME/VERSION\")")
   <*> strOption (long "server-name" <> metavar "SERVERNAME" <> value "postgrest" <> help "Server name used in the application" <> showDefault)
-  <*> strOption (long "auth-path" <> metavar "AUTHPATH" <> value "postgrest" <> help "Path used to expose authentication function and reserved table name" <> showDefault)
 
 defaultCorsPolicy :: CorsResourcePolicy
 defaultCorsPolicy =  CorsResourcePolicy Nothing

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -24,6 +24,8 @@ data AppConfig = AppConfig {
   , configV1Schema :: String
   
   , configJwtSecret :: String
+  , configServerName :: String
+  , configAuthPath :: String
   }
 
 argParser :: Parser AppConfig
@@ -40,6 +42,8 @@ argParser = AppConfig
   <*> option auto (long "db-pool" <> metavar "COUNT" <> value 10 <> help "Max connections in database pool" <> showDefault)
   <*> strOption (long "v1schema" <> metavar "NAME" <> value "1" <> help "Schema to use for nonspecified version (or explicit v1)" <> showDefault)
   <*> strOption (long "jwt-secret" <> metavar "SECRET" <> value "secret" <> help "Secret used to encrypt and decrypt JWT tokens)" <> showDefault)
+  <*> strOption (long "server-name" <> metavar "SERVERNAME" <> value "postgrest" <> help "Server name exposed through headers" <> showDefault)
+  <*> strOption (long "auth-path" <> metavar "AUTHPATH" <> value "postgrest" <> help "Path used to expose authentication function and reserver table name" <> showDefault)
 
 defaultCorsPolicy :: CorsResourcePolicy
 defaultCorsPolicy =  CorsResourcePolicy Nothing

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -24,6 +24,7 @@ data AppConfig = AppConfig {
   , configV1Schema :: String
   
   , configJwtSecret :: String
+  , configServerString :: String
   , configServerName :: String
   , configAuthPath :: String
   }
@@ -42,8 +43,9 @@ argParser = AppConfig
   <*> option auto (long "db-pool" <> metavar "COUNT" <> value 10 <> help "Max connections in database pool" <> showDefault)
   <*> strOption (long "v1schema" <> metavar "NAME" <> value "1" <> help "Schema to use for nonspecified version (or explicit v1)" <> showDefault)
   <*> strOption (long "jwt-secret" <> metavar "SECRET" <> value "secret" <> help "Secret used to encrypt and decrypt JWT tokens)" <> showDefault)
-  <*> strOption (long "server-name" <> metavar "SERVERNAME" <> value "postgrest" <> help "Server name exposed through headers" <> showDefault)
-  <*> strOption (long "auth-path" <> metavar "AUTHPATH" <> value "postgrest" <> help "Path used to expose authentication function and reserver table name" <> showDefault)
+  <*> strOption (long "server-string" <> metavar "SERVERSTRING" <> value "" <> help "Server string exposed through headers (default: \"SERVERNAME/VERSION\")")
+  <*> strOption (long "server-name" <> metavar "SERVERNAME" <> value "postgrest" <> help "Server name used in the application" <> showDefault)
+  <*> strOption (long "auth-path" <> metavar "AUTHPATH" <> value "postgrest" <> help "Path used to expose authentication function and reserved table name" <> showDefault)
 
 defaultCorsPolicy :: CorsResourcePolicy
 defaultCorsPolicy =  CorsResourcePolicy Nothing

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -49,7 +49,7 @@ main = do
                      (cs $ configDbPass conf)
                      (cs $ configDbName conf)
       appSettings = setPort port
-                  . setServerName (cs $ "postgrest/" <> prettyVersion)
+                  . setServerName (cs $ (cs $ configServerName conf) <> "/" <> prettyVersion)
                   $ defaultSettings
       middle = logStdout
         . (if configSecure conf then redirectInsecure else id)

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -42,6 +42,14 @@ main = do
     putStrLn "WARNING, running in insecure mode, JWT secret is the default value"
   Prelude.putStrLn $ "Listening on port " ++
     (show $ configPort conf :: String)
+    
+  let userServerString = cs $ configServerString conf
+      userServerName = cs $ configServerName conf
+      serverString = 
+        if userServerString /= "" then 
+          userServerString
+        else 
+          cs $ userServerName <> "/" <> prettyVersion
 
   let pgSettings = P.ParamSettings (cs $ configDbHost conf)
                      (fromIntegral $ configDbPort conf)
@@ -49,7 +57,7 @@ main = do
                      (cs $ configDbPass conf)
                      (cs $ configDbName conf)
       appSettings = setPort port
-                  . setServerName (cs $ (cs $ configServerName conf) <> "/" <> prettyVersion)
+                  . setServerName serverString
                   $ defaultSettings
       middle = logStdout
         . (if configSecure conf then redirectInsecure else id)

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -42,13 +42,14 @@ authenticated conf app req = do
    jwtSecret = cs $ configJwtSecret conf
    currentRole = cs $ configDbUser conf
    anon = cs $ configAnonRole conf
+   serverName = cs $ configServerName conf ::Text
    httpRequesterRole :: RequestHeaders -> H.Tx P.Postgres s LoginAttempt
    httpRequesterRole hdrs = do
     let auth = fromMaybe "" $ lookup hAuthorization hdrs
     case split (==' ') (cs auth) of
       ("Basic" : b64 : _) ->
         case split (==':') (cs . decode . cs $ b64) of
-          (u:p:_) -> signInRole u p
+          (u:p:_) -> signInRole serverName u p
           _ -> return MalformedAuth
       ("Bearer" : jwt : _) ->
         return $ signInWithJWT jwtSecret jwt

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -36,7 +36,7 @@ isLeft (Left _ ) = True
 isLeft _ = False
 
 cfg :: AppConfig
-cfg = AppConfig "postgrest_test" 5432 "postgrest_test" "" "localhost" 3000 "postgrest_anonymous" False 10 "1" "safe" "" "postgrest" "postgrest"
+cfg = AppConfig "postgrest_test" 5432 "postgrest_test" "" "localhost" 3000 "postgrest_anonymous" False 10 "1" "safe" "" "postgrest"
 
 testPoolOpts :: PoolSettings
 testPoolOpts = fromMaybe (error "bad settings") $ H.poolSettings 1 30

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -36,7 +36,7 @@ isLeft (Left _ ) = True
 isLeft _ = False
 
 cfg :: AppConfig
-cfg = AppConfig "postgrest_test" 5432 "postgrest_test" "" "localhost" 3000 "postgrest_anonymous" False 10 "1" "safe"
+cfg = AppConfig "postgrest_test" 5432 "postgrest_test" "" "localhost" 3000 "postgrest_anonymous" False 10 "1" "safe" "postgrest" "postgrest"
 
 testPoolOpts :: PoolSettings
 testPoolOpts = fromMaybe (error "bad settings") $ H.poolSettings 1 30

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -36,7 +36,7 @@ isLeft (Left _ ) = True
 isLeft _ = False
 
 cfg :: AppConfig
-cfg = AppConfig "postgrest_test" 5432 "postgrest_test" "" "localhost" 3000 "postgrest_anonymous" False 10 "1" "safe" "postgrest" "postgrest"
+cfg = AppConfig "postgrest_test" 5432 "postgrest_test" "" "localhost" 3000 "postgrest_anonymous" False 10 "1" "safe" "" "postgrest" "postgrest"
 
 testPoolOpts :: PoolSettings
 testPoolOpts = fromMaybe (error "bad settings") $ H.poolSettings 1 30


### PR DESCRIPTION
The goal is to make the postgrest string completely configurable and invisible from the outside (#197)
[This PR is still a WIP]

Done:
 - `server-name` variable to replace occurrences of "postgrest"
 - `server-string` variable to replace postgres/VERSION
 - if `server-string` is undefined the default is SERVERNAME/VERSION
 - use `server-name` in the multipart boundary
 - `auth-path` variable to replace the path where users log in (eg: `/postgrest/users`)

What's missing:
 - Use a different schema for auth (instead of `postgrest`) based on the auth-path variable
 - Maybe join `server-name` and `auth-path` in a single variable?