### PR TITLE
Changes the insertable to true in views that are insertable through triggers [fixes #206]

### DIFF
--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -17,6 +17,7 @@ spec = around withApp $ do
           {"schema":"1","name":"auto_incrementing_pk","insertable":true}
         , {"schema":"1","name":"compound_pk","insertable":true}
         , {"schema":"1","name":"has_fk","insertable":true}
+        , {"schema":"1","name":"insertable_view_with_join","insertable":true}
         , {"schema":"1","name":"items","insertable":true}
         , {"schema":"1","name":"json","insertable":true}
         , {"schema":"1","name":"menagerie","insertable":true}

--- a/test/Unit/PgStructureSpec.hx
+++ b/test/Unit/PgStructureSpec.hx
@@ -14,7 +14,7 @@ spec = around dbWithSchema $ beforeWith setRole $ do
     it "shows all the tables" $ \conn -> do
       ts <- tables "1" conn
       map tableName ts `shouldBe` ["authors_only","auto_incrementing_pk",
-        "compound_pk","has_fk","items","menagerie","no_pk", "simple_pk"]
+        "compound_pk","has_fk","insertable_view_with_join","items","menagerie","no_pk", "simple_pk"]
 
   describe "columns" $ do
     it "responds with each column for the table" $ \conn -> do


### PR DESCRIPTION
On important remark is that as far as I've tested the current code reports insertable as false in these cases but still sends the INSERT commands. But I believe that making the "insertable" field in postgrest true in these cases makes it more consistent with the actual behaviour.

I also converted the value to boolean in PostgreSQL for convenience.