### PR TITLE
Removes toBool function as we now cast the 'YES/NO' values to boolean in PostgreSQL's queries

### DIFF
--- a/src/PostgREST/PgStructure.hs
+++ b/src/PostgREST/PgStructure.hs
@@ -58,8 +58,8 @@ columns table = do
   cols <- H.listEx $ [H.stmt|
       select info.table_schema as schema, info.table_name as table_name,
              info.column_name as name, info.ordinal_position as position,
-             info.is_nullable as nullable, info.data_type as col_type,
-             info.is_updatable as updatable,
+             info.is_nullable::boolean as nullable, info.data_type as col_type,
+             info.is_updatable::boolean as updatable,
              info.character_maximum_length as max_len,
              info.numeric_precision as precision,
              info.column_default as default_value,
@@ -108,9 +108,6 @@ primaryKeyColumns table = do
   return $ map runIdentity r
 
 
-toBool :: Text -> Bool
-toBool = (== "YES")
-
 data Table = Table {
   tableSchema :: Text
 , tableName :: Text
@@ -140,12 +137,12 @@ tableFromRow :: (Text, Text, Bool) -> Table
 tableFromRow (s, n, i) = Table s n i
 
 columnFromRow :: (Text,       Text,      Text,
-                  Int,        Text,      Text,
-                  Text,       Maybe Int, Maybe Int,
+                  Int,        Bool,      Text,
+                  Bool,       Maybe Int, Maybe Int,
                   Maybe Text, Maybe Text)
               -> Column
 columnFromRow (s, t, n, pos, nul, typ, u, l, p, d, e) =
-  Column s t n pos (toBool nul) typ (toBool u) l p d (parseEnum e) Nothing
+  Column s t n pos nul typ u l p d (parseEnum e) Nothing
 
   where
     parseEnum :: Maybe Text -> [Text]


### PR DESCRIPTION
I've just applied the same solution to boolean conversion from the information schema which I have used in my previous PR thus eliminating the need for a haskell toBool function.