### PR TITLE
Qualifies columns of WHERE clauses so we can use computed columns as filters

### DIFF
--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -266,6 +266,12 @@ spec = afterAll_ resetDb $ around withApp $ do
         liftIO $ simpleHeaders g
           `shouldSatisfy` matchHeader "Content-Range" "0-9/10"
 
+      it "can update based on a computed column" $
+        request methodPatch
+          "/items?always_true=eq.false"
+          [("Prefer", "return=representation")]
+          [json| { id: 100 } |]
+          `shouldRespondWith` 404
       it "can provide a representation" $ do
         _ <- post "/items"
           [json| { id: 1 } |]

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -63,6 +63,10 @@ spec =
       get "/tsearch?text_search_vector=@@.foo" `shouldRespondWith`
         "[{\"text_search_vector\":\"'bar':2 'foo':1\"}]"
 
+    it "matches with computed column" $
+      get "/items?always_true=eq.true" `shouldRespondWith`
+        "[{\"id\":1},{\"id\":2},{\"id\":3},{\"id\":4},{\"id\":5},{\"id\":6},{\"id\":7},{\"id\":8},{\"id\":9},{\"id\":10},{\"id\":11},{\"id\":12},{\"id\":13},{\"id\":14},{\"id\":15}]"
+
   describe "ordering response" $ do
     it "by a column asc" $
       get "/items?id=lte.2&order=id.asc"

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -72,7 +72,6 @@ $$;
 
 ALTER FUNCTION postgrest.update_owner() OWNER TO postgrest_test;
 
-
 CREATE FUNCTION set_authors_only_owner() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -368,6 +367,13 @@ SELECT pg_catalog.setval('articles_id_seq', 1, false);
 
 SET search_path = "1", pg_catalog;
 
+CREATE FUNCTION public.always_true("1".items) RETURNS boolean
+    LANGUAGE sql STABLE
+    AS $$ SELECT true $$;
+
+ALTER FUNCTION public.always_true("1".items) OWNER TO postgrest_test;
+
+
 
 ALTER TABLE ONLY authors_only
     ADD CONSTRAINT authors_only_pkey PRIMARY KEY (secret);
@@ -556,6 +562,11 @@ REVOKE ALL ON TABLE insertable_view_with_join FROM PUBLIC;
 REVOKE ALL ON TABLE insertable_view_with_join FROM postgrest_test;
 GRANT ALL ON TABLE insertable_view_with_join TO postgrest_test;
 GRANT ALL ON TABLE insertable_view_with_join TO postgrest_anonymous;
+
+REVOKE ALL ON FUNCTION public.always_true("1".items) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.always_true("1".items) FROM postgrest_test;
+GRANT ALL ON FUNCTION public.always_true("1".items) TO postgrest_test;
+GRANT ALL ON FUNCTION public.always_true("1".items) TO postgrest_anonymous;
 
 
 SET search_path = postgrest, pg_catalog;


### PR DESCRIPTION
This PR allows the use of [computed columns](http://www.postgresql.org/docs/9.4/interactive/xfunc-sql.html#XFUNC-SQL-COMPOSITE-FUNCTIONS) as filters in GET and PATCH calls without including these fields in the view being queried.

I know that it's not a super elegant solution but it's the least invasive I could think of.

With the current code to query for any function applied to the rows I need to include this function as a field in the view. Sometimes this is undesirable, for these columns can be quite large and I may want to keep a leaner response body.

The case I ran into was filtering by a concatenation of text fields like:
```sql
SELECT * 
FROM projects 
WHERE name || ' ' || author || ' ' || description ILIKE '%search string%';
```

So instead of modelling the above concatenation as a field in my view I want to create a function such as
```sql
CREATE FUNCTION search_text(projects) RETURNS text AS $$
SELECT $1.name || ' ' || $1.author || ' ' || $1.description
$$ STABLE LANGUAGE SQL;
```

AND query it with:
```sql
SELECT * 
FROM projects 
WHERE projects.search_text ILIKE '%search string%';
```