### PR TITLE
Enable log capture if stdout is not a terminal (issue #229)

### DIFF
--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -24,6 +24,8 @@ import qualified Hasql as H
 import qualified Hasql.Postgres as P
 import Options.Applicative hiding (columns)
 
+import System.IO (stderr, stdin, stdout, hSetBuffering, BufferMode(..))
+
 import PostgREST.Config (AppConfig(..), argParser, corsPolicy)
 
 isServerVersionSupported = do
@@ -32,6 +34,10 @@ isServerVersionSupported = do
 
 main :: IO ()
 main = do
+  hSetBuffering stdout LineBuffering
+  hSetBuffering stdin  LineBuffering
+  hSetBuffering stderr NoBuffering
+
   let opts = info (helper <*> argParser) $
                 fullDesc
                 <> progDesc (


### PR DESCRIPTION
This appears to enable capturing of log messages with "postgrest >> log"