### PR TITLE
Fixes error code 42803 when trying to query a view with a column named count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Indicate insertable=true for views that are insertable through triggers
 - Builds under GHC 7.10
+- Allow the use of columns named "count" in relations queried
 
 ## [0.2.10.0] - 2015-06-03
 ### Added

--- a/src/PostgREST/PgQuery.hs
+++ b/src/PostgREST/PgQuery.hs
@@ -95,14 +95,14 @@ iffNotT (B.Stmt aq ap apre) (B.Stmt bq bp bpre) =
 
 countT :: StatementT
 countT s =
-  s { B.stmtTemplate = "WITH qqq AS (" <> B.stmtTemplate s <> ") SELECT count(1) FROM qqq" }
+  s { B.stmtTemplate = "WITH qqq AS (" <> B.stmtTemplate s <> ") SELECT pg_catalog.count(1) FROM qqq" }
 
 countRows :: QualifiedTable -> PStmt
-countRows t = B.Stmt ("select count(1) from " <> fromQt t) empty True
+countRows t = B.Stmt ("select pg_catalog.count(1) from " <> fromQt t) empty True
 
 asJsonWithCount :: StatementT
 asJsonWithCount s = s { B.stmtTemplate =
-     "count(t), array_to_json(array_agg(row_to_json(t)))::character varying from ("
+     "pg_catalog.count(t), array_to_json(array_agg(row_to_json(t)))::character varying from ("
   <> B.stmtTemplate s <> ") t" }
 
 asJsonRow :: StatementT

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -18,6 +18,11 @@ spec =
        createJsonData)
    . afterAll_ (clearTable "items" >> clearTable "no_pk" >> clearTable "simple_pk")
    . around withApp $ do
+
+  describe "Querying a table with a column called count" $
+    it "should not confuse count column with pg_catalog.count aggregate" $
+      get "/has_count_column" `shouldRespondWith` 200
+
   describe "Querying a nonexistent table" $
     it "causes a 404" $
       get "/faketable" `shouldRespondWith` 404

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -16,6 +16,7 @@ spec = around withApp $ do
         `shouldRespondWith` [json| [
           {"schema":"1","name":"auto_incrementing_pk","insertable":true}
         , {"schema":"1","name":"compound_pk","insertable":true}
+        , {"schema":"1","name":"has_count_column","insertable":false}
         , {"schema":"1","name":"has_fk","insertable":true}
         , {"schema":"1","name":"insertable_view_with_join","insertable":true}
         , {"schema":"1","name":"items","insertable":true}

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -182,6 +182,11 @@ CREATE VIEW "1".insertable_view_with_join AS
 
 ALTER TABLE "1".insertable_view_with_join OWNER TO postgrest_test;
 
+CREATE VIEW "1".has_count_column AS
+ SELECT 1 AS count;
+
+ALTER TABLE "1".insertable_view_with_join OWNER TO postgrest_test;
+
 
 CREATE TABLE items (
     id bigint NOT NULL
@@ -562,6 +567,11 @@ REVOKE ALL ON TABLE insertable_view_with_join FROM PUBLIC;
 REVOKE ALL ON TABLE insertable_view_with_join FROM postgrest_test;
 GRANT ALL ON TABLE insertable_view_with_join TO postgrest_test;
 GRANT ALL ON TABLE insertable_view_with_join TO postgrest_anonymous;
+
+REVOKE ALL ON TABLE has_count_column FROM PUBLIC;
+REVOKE ALL ON TABLE has_count_column FROM postgrest_test;
+GRANT ALL ON TABLE has_count_column TO postgrest_test;
+GRANT ALL ON TABLE has_count_column TO postgrest_anonymous;
 
 REVOKE ALL ON FUNCTION public.always_true("1".items) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.always_true("1".items) FROM postgrest_test;


### PR DESCRIPTION
Just adds a test case and prefixes the uses of the count function with pg_catalog.