### PR TITLE
Adds materialized views to list of relations in GET / [#242]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Allow filters by computed columns
 
 ### Fixed
+- Add materialized views to results in GET /
 - Indicate insertable=true for views that are insertable through triggers
 - Builds under GHC 7.10
 

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -20,6 +20,7 @@ spec = around withApp $ do
         , {"schema":"1","name":"insertable_view_with_join","insertable":true}
         , {"schema":"1","name":"items","insertable":true}
         , {"schema":"1","name":"json","insertable":true}
+        , {"schema":"1","name":"materialized_view","insertable":false}
         , {"schema":"1","name":"menagerie","insertable":true}
         , {"schema":"1","name":"no_pk","insertable":true}
         , {"schema":"1","name":"nullable_integer","insertable":true}

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -169,6 +169,12 @@ ALTER TABLE "1".has_fk_id_seq OWNER TO postgrest_test;
 
 ALTER SEQUENCE has_fk_id_seq OWNED BY has_fk.id;
 
+CREATE MATERIALIZED VIEW "1".materialized_view AS
+ SELECT 
+    version();
+
+ALTER TABLE "1".materialized_view OWNER TO postgrest_test;
+
 CREATE VIEW "1".insertable_view_with_join AS
  SELECT has_fk.id,
     has_fk.auto_inc_fk,
@@ -557,6 +563,11 @@ REVOKE ALL ON TABLE tsearch FROM PUBLIC;
 REVOKE ALL ON TABLE tsearch FROM postgrest_test;
 GRANT ALL ON TABLE tsearch TO postgrest_test;
 GRANT ALL ON TABLE tsearch TO postgrest_anonymous;
+
+REVOKE ALL ON TABLE materialized_view FROM PUBLIC;
+REVOKE ALL ON TABLE materialized_view FROM postgrest_test;
+GRANT ALL ON TABLE materialized_view TO postgrest_test;
+GRANT ALL ON TABLE materialized_view TO postgrest_anonymous;
 
 REVOKE ALL ON TABLE insertable_view_with_join FROM PUBLIC;
 REVOKE ALL ON TABLE insertable_view_with_join FROM postgrest_test;


### PR DESCRIPTION
Still does not implement the OPTIONS for materialized views, but I figured that could go on another PR.

A nice side effect of using the pg_catalog is:
```
Planning time: 0.721 ms
Execution time: 0.655 ms
```

Whereas the previous implementation using information_schema in the same system was:
```
Planning time: 2.063 ms
Execution time: 1.245 ms
```