### PR TITLE
Get csv response improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ cabal.sandbox.config
 hscope.out
 codex.tags
 .anvil
+
+tags

--- a/test/Feature/CorsSpec.hs
+++ b/test/Feature/CorsSpec.hs
@@ -22,7 +22,7 @@ spec = around withApp $ describe "CORS" $ do
           ("Host", "localhost:3000"),
           ("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:32.0) Gecko/20100101 Firefox/32.0"),
           ("Origin", "http://localhost:8000"),
-          ("Accept", "text/plain, */*; q=0.01"),
+          ("Accept", "text/csv, */*; q=0.01"),
           ("Accept-Language", "en-US,en;q=0.5"),
           ("Accept-Encoding", "gzip, deflate"),
           ("Referer", "http://localhost:8000/"),

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -122,13 +122,23 @@ spec =
     it "without other constraints" $
       get "/items?order=asc.id" `shouldRespondWith` 200
 
-  describe "Accept headers" $
+  describe "Accept headers" $ do
+    it "should respond an unknown accept type with 415" $
+      request methodGet "/simple_pk"
+              (acceptHdrs "text/unknowntype") ""
+        `shouldRespondWith` 415
+
+    it "should respond correctly to multiple types in accept header" $
+      request methodGet "/simple_pk"
+              (acceptHdrs "text/unknowntype, text/csv") ""
+        `shouldRespondWith` 200
+
     it "should respond with CSV to 'text/csv' request" $
       request methodGet "/simple_pk"
-              (acceptHdrs "text/csv") ""
+              (acceptHdrs "text/csv; version=1") ""
         `shouldRespondWith` ResponseMatcher {
-          matchBody = Just "k,extra\rxyyx,u\rxYYx,v"
-        , matchStatus = 200
+          matchBody    = Just "k,extra\rxyyx,u\rxYYx,v"
+        , matchStatus  = 200
         , matchHeaders = ["Content-Type" <:> "text/csv"]
         }
 

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -21,13 +21,12 @@ import Data.CaseInsensitive (CI(..))
 import Data.Maybe (fromMaybe)
 import Text.Regex.TDFA ((=~))
 import qualified Data.ByteString.Char8 as BS
-import Network.Wai.Middleware.Cors (cors)
 import System.Process (readProcess)
 
 import qualified Data.Aeson.Types as J
 
 import PostgREST.App (app)
-import PostgREST.Config (AppConfig(..), corsPolicy)
+import PostgREST.Config (AppConfig(..))
 import PostgREST.Middleware
 import PostgREST.Error(errResponse)
 
@@ -59,7 +58,7 @@ withApp perform = do
       $ authenticated cfg (app cfg body) req
     either (resp . errResponse) resp result
 
-  where middle = cors corsPolicy
+  where middle = defaultMiddle False
 
 
 resetDb :: IO ()


### PR DESCRIPTION
* Uses ```parseHttpAccept``` so we can recognize Accept headers with multiple types
* Allow the use of API versioning with text/csv type.
* Adds 415 response for Accept headers that are non empty and have no compatible type.

So my doubt here is if we should take this strict approach to Accept headers. It seems a good idea and I believe the whole API gets more consistent and future-proof.

Actually there was a spec failing that shows exactly this case, a request for a 'text/plain' response.