### PR TITLE
NOT IN queries

### DIFF
--- a/src/PostgREST/PgQuery.hs
+++ b/src/PostgREST/PgQuery.hs
@@ -192,6 +192,7 @@ wherePred table (col, predicate) =
             "like" -> unknownLiteral $ T.map star value
             "ilike" -> unknownLiteral $ T.map star value
             "in" -> "(" <> T.intercalate ", " (map unknownLiteral $ T.split (==',') value) <> ") "
+            "notin" -> "(" <> T.intercalate ", " (map unknownLiteral $ T.split (==',') value) <> ") "
             "@@" -> "to_tsquery(" <> unknownLiteral value <> ") "
             _    -> unknownLiteral value
 
@@ -205,6 +206,7 @@ wherePred table (col, predicate) =
          "like"-> "like"
          "ilike"-> "ilike"
          "in"  -> "in"
+         "notin" -> "not in"
          "is"    -> "is"
          "isnot" -> "is not"
          "@@" -> "@@"

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -89,7 +89,7 @@ spec = afterAll_ resetDb $ around withApp $ do
       it "fails with 400 and error" $
         post "/simple_pk" "}{ x = 2"
           `shouldRespondWith` ResponseMatcher {
-            matchBody    = Just [json| {"message":"Failed to parse JSON payload. Failed reading: satisfy"} |]
+            matchBody    = Just [json| {"message":"Failed to parse JSON payload. Failed reading: not a valid json value"} |]
           , matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -45,6 +45,14 @@ spec =
         , matchHeaders = ["Content-Range" <:> "0-2/3"]
         }
 
+    it "matches items NOT IN" $
+      get "/items?id=notin.2,4,6,7,8,9,10,11,12,13,14,15"
+        `shouldRespondWith` ResponseMatcher {
+          matchBody    = Just [json| [{"id":1},{"id":3},{"id":5}] |]
+        , matchStatus  = 200
+        , matchHeaders = ["Content-Range" <:> "0-2/3"]
+        }
+
     it "matches nulls in varchar and numeric fields alike" $ do
       get "/no_pk?a=is.null" `shouldRespondWith`
         [json| [{"a": null, "b": null}] |]


### PR DESCRIPTION
This adds a "NOT IN" query to the postgrest routing.

In #173 I was asking for an api change to allow any route to be negated with a NOT. This small change handles my current use case. 

If it's acceptable to handle each negative route by adding an opCode to the case statement as I did here then I'm more than happy to add them all to this, or another PR.