### PR TITLE
Support for &select=col1,col2,col3 as suggested in issue #227

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -64,7 +64,7 @@ app conf reqBody req =
       else do
         let qt = qualify table
             from = fromMaybe 0 $ rangeOffset <$> range
-            select = B.Stmt "select " V.empty True <>
+            query = B.Stmt "select " V.empty True <>
                   parentheticT (
                     whereT qt qq $ countRows qt
                   ) <> commaq <> (
@@ -72,9 +72,9 @@ app conf reqBody req =
                   . limitT range
                   . orderT (orderParse qq)
                   . whereT qt qq
-                  $ selectT qt qq
+                  $ select qt qq
                 )
-        row <- H.maybeEx select
+        row <- H.maybeEx query
         let (tableTotal, queryTotal, body) =
               fromMaybe (0, 0, Just "" :: Maybe Text) row
             to = from+queryTotal-1

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -72,7 +72,7 @@ app conf reqBody req =
                   . limitT range
                   . orderT (orderParse qq)
                   . whereT qt qq
-                  $ selectStar qt
+                  $ selectT qt qq
                 )
         row <- H.maybeEx select
         let (tableTotal, queryTotal, body) =

--- a/src/PostgREST/PgQuery.hs
+++ b/src/PostgREST/PgQuery.hs
@@ -141,7 +141,11 @@ selectT table params =
    cols = filter ((>0) . T.length) $ map T.strip $ T.split (==',') $ cs columnsParam
 
 selectTerm :: QualifiedIdentifier -> T.Text -> PStmt
-selectTerm table col = B.Stmt (pgFmtJsonbPath table (cs col)) empty True
+selectTerm table col = B.Stmt (pgFmtJsonbPath table (cs col) <> asT jsonbPath) empty True
+    where
+        jsonbPath = parseJsonbPath $ cs col
+        asT (Just (DoubleArrow _ (KeyIdentifier key))) = " AS " <> pgFmtIdent key
+        asT _ = ""
 
 returningStarT :: StatementT
 returningStarT s = s { B.stmtTemplate = B.stmtTemplate s <> " RETURNING *" }

--- a/src/PostgREST/PgQuery.hs
+++ b/src/PostgREST/PgQuery.hs
@@ -143,7 +143,8 @@ select table params =
 selectTerm :: QualifiedIdentifier -> T.Text -> PStmt
 selectTerm table col =
     case T.splitOn "::" col of
-        [colName,castTo] -> B.Stmt ("CAST (" <> pgFmtJsonbPath table (cs colName) <> " AS " <> castTo <> " )" <> asT (jsonbPath colName)) empty True
+        [colName,castTo] -> B.Stmt ("CAST (" <> pgFmtJsonbPath table (cs colName) <> " AS " <> castToSafe <> " )" <> asT (jsonbPath colName)) empty True
+            where castToSafe = T.filter ( `elem` ['a'..'z'] ) castTo
         _-> B.Stmt (pgFmtJsonbPath table (cs col) <> asT (jsonbPath col)) empty True
     where
         jsonbPath :: T.Text -> Maybe JsonbPath

--- a/src/PostgREST/PgQuery.hs
+++ b/src/PostgREST/PgQuery.hs
@@ -129,8 +129,8 @@ asJsonRow s = s { B.stmtTemplate = "row_to_json(t) from (" <> B.stmtTemplate s <
 selectStar :: QualifiedIdentifier -> PStmt
 selectStar t = B.Stmt ("select * from " <> fromQi t) empty True
 
-selectT :: QualifiedIdentifier -> Net.Query -> PStmt
-selectT table params =
+select :: QualifiedIdentifier -> Net.Query -> PStmt
+select table params =
  if L.null cols
    then selectStar table
    else B.Stmt "select " empty True <> conjunction <> B.Stmt (" from " <> fromQi table ) empty True

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -152,9 +152,27 @@ spec =
       get "/complex_items?id=eq.1&select=settings->>foo::json" `shouldRespondWith`
         [json| [{"foo":{"int":1,"bar":"baz"}}] |] -- the value of foo here is of type "text"
 
+    it "fails on bad casting (data of the wrong format)" $
+      get "/complex_items?select=settings->foo->>bar::integer"
+        `shouldRespondWith` ResponseMatcher {
+          matchBody    = Just [json| {"hint":null,"details":null,"code":"22P02","message":"invalid input syntax for integer: \"baz\""} |]
+        , matchStatus  = 400
+        , matchHeaders = []
+        }
+
+    it "fails on bad casting (wrong cast type)" $
+      get "/complex_items?select=id::fakecolumntype"
+        `shouldRespondWith` ResponseMatcher {
+          matchBody    = Just [json| {"hint":null,"details":null,"code":"42704","message":"type \"fakecolumntype\" does not exist"} |]
+        , matchStatus  = 400
+        , matchHeaders = []
+        }
+
+
     it "json subfield two levels (string)" $
       get "/complex_items?id=eq.1&select=settings->foo->>bar" `shouldRespondWith`
         [json| [{"bar":"baz"}] |]
+
 
     it "json subfield two levels with casting (int)" $
       get "/complex_items?id=eq.1&select=settings->foo->>int::integer" `shouldRespondWith`

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -15,6 +15,7 @@ spec = around withApp $ do
       request methodGet "/" [] ""
         `shouldRespondWith` [json| [
           {"schema":"1","name":"auto_incrementing_pk","insertable":true}
+        , {"schema":"1","name":"complex_items","insertable":true}
         , {"schema":"1","name":"compound_pk","insertable":true}
         , {"schema":"1","name":"has_count_column","insertable":false}
         , {"schema":"1","name":"has_fk","insertable":true}

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -47,7 +47,7 @@ SET search_path = postgrest, pg_catalog;
 CREATE FUNCTION check_role_exists() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
-begin 
+begin
 if not exists (select 1 from pg_roles as r where r.rolname = new.rolname) then
    raise foreign_key_violation using message = 'Cannot create user with unknown role: ' || new.rolname;
    return null;
@@ -64,7 +64,7 @@ CREATE FUNCTION update_owner() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-   NEW.owner = current_user; 
+   NEW.owner = current_user;
    RETURN NEW;
 END;
 $$;
@@ -75,8 +75,8 @@ ALTER FUNCTION postgrest.update_owner() OWNER TO postgrest_test;
 CREATE FUNCTION set_authors_only_owner() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
-begin 
-  NEW.owner = current_setting('user_vars.user_id'); 
+begin
+  NEW.owner = current_setting('user_vars.user_id');
   RETURN NEW;
 end
 $$;
@@ -170,7 +170,7 @@ ALTER TABLE "1".has_fk_id_seq OWNER TO postgrest_test;
 ALTER SEQUENCE has_fk_id_seq OWNED BY has_fk.id;
 
 CREATE MATERIALIZED VIEW "1".materialized_view AS
- SELECT 
+ SELECT
     version();
 
 ALTER TABLE "1".materialized_view OWNER TO postgrest_test;
@@ -200,6 +200,15 @@ CREATE TABLE items (
 
 
 ALTER TABLE "1".items OWNER TO postgrest_test;
+
+CREATE TABLE complex_items (
+    id bigint NOT NULL,
+    name text,
+    settings json
+);
+
+
+ALTER TABLE "1".complex_items OWNER TO postgrest_test;
 
 
 CREATE SEQUENCE items_id_seq
@@ -407,7 +416,7 @@ ALTER FUNCTION public.always_true("1".items) OWNER TO postgrest_test;
 
 ALTER TABLE ONLY authors_only
     ADD CONSTRAINT authors_only_pkey PRIMARY KEY (secret);
-    
+
 CREATE TRIGGER insert_insertable_view_with_join INSTEAD OF INSERT ON "1".insertable_view_with_join FOR EACH ROW EXECUTE PROCEDURE "1".insert_insertable_view_with_join();
 
 
@@ -437,6 +446,8 @@ ALTER TABLE ONLY has_fk
 ALTER TABLE ONLY items
     ADD CONSTRAINT items_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY complex_items
+    ADD CONSTRAINT complex_items_pkey PRIMARY KEY (id);
 
 
 ALTER TABLE ONLY menagerie
@@ -538,6 +549,11 @@ REVOKE ALL ON TABLE items FROM PUBLIC;
 REVOKE ALL ON TABLE items FROM postgrest_test;
 GRANT ALL ON TABLE items TO postgrest_test;
 GRANT ALL ON TABLE items TO postgrest_anonymous;
+
+REVOKE ALL ON TABLE complex_items FROM PUBLIC;
+REVOKE ALL ON TABLE complex_items FROM postgrest_test;
+GRANT ALL ON TABLE complex_items TO postgrest_test;
+GRANT ALL ON TABLE complex_items TO postgrest_anonymous;
 
 
 REVOKE ALL ON FUNCTION getitemrange(bigint, bigint) FROM PUBLIC;


### PR DESCRIPTION
Additional parameter (for GET requests) that provides the ability to shape the response
At it's core, it is changing the query from "select * " to "select col1, col2" if the parameter is present
Suggestion as to the code style are welcome