### PR TITLE
Tolerate missing role in user creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 db
 dist
 .cabal-sandbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Filter columns, e.g. `?select=col1,col2` - @ruslantalpa
 - Does not execute the count total if header "Prefer: count=none" - @diogob
 
+### Fixed
+- Tolerate a missing role in user creation - @calebmer
+
 ## [0.2.11.1] - 2015-09-01
 
 ### Fixed

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -101,7 +101,7 @@ app conf reqBody req =
           encode . object $ [("message", String "Failed to parse user.")]
         Just u -> do
           _ <- addUser (cs $ userId u)
-            (cs $ userPass u) (cs $ userRole u)
+            (cs $ userPass u) (cs <$> userRole u)
           return $ responseLBS status201
             [ jsonH
             , (hLocation, "/postgrest/users?id=eq." <> cs (userId u))

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -23,14 +23,14 @@ import System.IO.Unsafe
 data AuthUser = AuthUser {
     userId :: String
   , userPass :: String
-  , userRole :: String
+  , userRole :: Maybe String
   } deriving (Show)
 
 instance FromJSON AuthUser where
   parseJSON (Object v) = AuthUser <$>
                          v .: "id" <*>
                          v .: "pass" <*>
-                         v .:? "role" .!= ""
+                         v .:? "role"
   parseJSON _ = mzero
 
 instance ToJSON AuthUser where
@@ -64,7 +64,7 @@ setUserId uid =
 resetUserId :: H.Tx P.Postgres s ()
 resetUserId = H.unitEx [H.stmt|reset user_vars.user_id|]
 
-addUser :: Text -> Text -> Text -> H.Tx P.Postgres s ()
+addUser :: Text -> Text -> Maybe Text -> H.Tx P.Postgres s ()
 addUser identity pass role = do
   let Just hashed = unsafePerformIO $ hashPasswordUsingPolicy fastBcryptHashingPolicy (cs pass)
   H.unitEx $

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -29,7 +29,7 @@ spec = beforeAll
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 200
 
-  it "respects database constraints for role" $ do
+  it "respects database constraints for role" $
     post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234", "role": "SUPER_ADMIN_TRUNCATE_POWERS" } |]
       `shouldRespondWith` 400
 

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -29,6 +29,10 @@ spec = beforeAll
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 200
 
+  it "respects database constraints for role" $ do
+    post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234", "role": "SUPER_ADMIN_TRUNCATE_POWERS" } |]
+      `shouldRespondWith` 400
+
   it "does not send a value when no role is provided" $ do
     _ <- post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234" } |]
     let auth = authHeaderBasic "jdoe" "1234"

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -24,27 +24,27 @@ spec = beforeAll
       `shouldRespondWith` 401
 
   it "allows users with permissions to see their tables (BasicAuth)" $ do
-    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
+    _ <- post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
     let auth = authHeaderBasic "jdoe" "1234"
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 200
 
-  it "does not require users to provide a role" $ do
-    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234" } |]
+  it "does not send a value when no role is provided" $ do
+    _ <- post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234" } |]
     let auth = authHeaderBasic "jdoe" "1234"
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 200
 
   it "recovers after 400 error with logged in user" $ do
-    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
+    _ <- post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
     let auth = authHeaderBasic "jdoe" "1234"
     _ <- request methodPost "/rpc/problem" [auth] ""
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 200
 
   it "allows users to login (JWT)" $ do
-    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
-    post "/postgrest/tokens" [json| { "id":"jdoe", "pass": "1234" } |]
+    _ <- post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
+    post "/postgrest/tokens" [json| { "id": "jdoe", "pass": "1234" } |]
       `shouldRespondWith` ResponseMatcher {
           matchBody = Just [json| {"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"} |]
         , matchStatus = 201
@@ -52,8 +52,8 @@ spec = beforeAll
         }
 
   it "indicates login failure (JWT)" $ do
-    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
-    post "/postgrest/tokens" [json| { "id":"jdoe", "pass": "NOPE" } |]
+    _ <- post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
+    post "/postgrest/tokens" [json| { "id": "jdoe", "pass": "NOPE" } |]
       `shouldRespondWith` ResponseMatcher {
           matchBody = Just [json| {"message":"Failed authentication."} |]
         , matchStatus = 401
@@ -61,7 +61,7 @@ spec = beforeAll
         }
 
   it "allows users with permissions to see their tables (JWT)" $ do
-    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
+    _ <- post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
     let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 200

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -29,6 +29,12 @@ spec = beforeAll
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 200
 
+  it "does not require users to provide a role" $ do
+    _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234" } |]
+    let auth = authHeaderBasic "jdoe" "1234"
+    request methodGet "/authors_only" [auth] ""
+      `shouldRespondWith` 200
+
   it "recovers after 400 error with logged in user" $ do
     _ <- post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
     let auth = authHeaderBasic "jdoe" "1234"

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -30,11 +30,12 @@ spec = beforeAll
       `shouldRespondWith` 200
 
   it "respects database constraints for role" $
-    post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234", "role": "SUPER_ADMIN_TRUNCATE_POWERS" } |]
+    post "/postgrest/users" [json| { "id": "ssmith", "pass": "1234", "role": "SUPER_ADMIN_TRUNCATE_POWERS" } |]
       `shouldRespondWith` 400
 
   it "does not send a value when no role is provided" $ do
-    _ <- post "/postgrest/users" [json| { "id": "jdoe", "pass": "1234" } |]
+    post "/postgrest/users" [json| { "id": "bdeey", "pass": "1234" } |]
+      `shouldRespondWith` 201
     let auth = authHeaderBasic "jdoe" "1234"
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 200

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -305,7 +305,7 @@ SET search_path = postgrest, pg_catalog;
 
 CREATE TABLE auth (
     id character varying NOT NULL,
-    rolname name NOT NULL,
+    rolname name NOT NULL DEFAULT 'postgrest_test_author',
     pass character(60) NOT NULL
 );
 


### PR DESCRIPTION
The changes you made were very helpful for me to better understand the code base, but didn't exactly solve the problem. As the role value (even when `Nothing`) was still being pushed to the database through the prepared statement. This pull request fixes this and adds a test case.

If the code style/quality needs improvement, let me know :relaxed:

This fixes #290