### PR TITLE
Prefer count none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Filter columns, e.g. `?select=col1,col2` - @ruslantalpa
+- Does not execute the count total if header "Prefer: count=none" - @diogob
 
 ## [0.2.11.1] - 2015-09-01
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -40,7 +40,7 @@ executable postgrest
                      , bytestring, text, split, string-conversions
                      , stringsearch
                      , containers, unordered-containers
-                     , optparse-applicative == 0.11.*
+                     , optparse-applicative >= 0.11 && < 0.13
                      , regex-base, regex-tdfa
                      , Ranged-sets
                      , transformers, MissingH

--- a/src/PostgREST/PgQuery.hs
+++ b/src/PostgREST/PgQuery.hs
@@ -101,6 +101,9 @@ countT s =
 countRows :: QualifiedIdentifier  -> PStmt
 countRows t = B.Stmt ("select pg_catalog.count(1) from " <> fromQi t) empty True
 
+countNone :: PStmt
+countNone = B.Stmt "select null" empty True
+
 asCsvWithCount :: QualifiedIdentifier -> StatementT
 asCsvWithCount table = withCount . asCsv table
 

--- a/test/Feature/RangeSpec.hs
+++ b/test/Feature/RangeSpec.hs
@@ -12,10 +12,20 @@ spec = beforeAll (clearTable "items" >> createItems 15) . afterAll_ (clearTable 
   . around withApp $
   describe "GET /items" $ do
 
-    context "without range headers" $
+    context "without range headers" $ do
       context "with response under server size limit" $
         it "returns whole range with status 200" $
           get "/items" `shouldRespondWith` 200
+
+      context "when I don't want the count" $
+        it "returns range Content-Range with /*" $
+          request methodGet "/menagerie"
+                  [("Prefer", "count=none")] ""
+            `shouldRespondWith` ResponseMatcher {
+              matchBody    = Just "[]"
+            , matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "*/*"]
+            }
 
     context "with range headers" $ do
 

--- a/test/Feature/RangeSpec.hs
+++ b/test/Feature/RangeSpec.hs
@@ -2,6 +2,7 @@ module Feature.RangeSpec where
 
 import Test.Hspec
 import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
 import Network.HTTP.Types
 import Network.Wai.Test (SResponse(simpleHeaders,simpleStatus))
 
@@ -17,7 +18,7 @@ spec = beforeAll (clearTable "items" >> createItems 15) . afterAll_ (clearTable 
         it "returns whole range with status 200" $
           get "/items" `shouldRespondWith` 200
 
-      context "when I don't want the count" $
+      context "when I don't want the count" $ do
         it "returns range Content-Range with /*" $
           request methodGet "/menagerie"
                   [("Prefer", "count=none")] ""
@@ -25,6 +26,15 @@ spec = beforeAll (clearTable "items" >> createItems 15) . afterAll_ (clearTable 
               matchBody    = Just "[]"
             , matchStatus  = 200
             , matchHeaders = ["Content-Range" <:> "*/*"]
+            }
+
+        it "returns range Content-Range with range/*" $
+          request methodGet "/items?order=id"
+                  [("Prefer", "count=none")] ""
+            `shouldRespondWith` ResponseMatcher {
+              matchBody    = Just [json| [{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}] |]
+            , matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "0-14/*"]
             }
 
     context "with range headers" $ do


### PR DESCRIPTION
Implements ```Prefer``` header ```count=none``` as discussed in #273
This is already incredibly useful for us even without the ```estimated``` option.

Also changed all ```lookupHeaders "Prefer"``` for ```hasPrefer``` since the this header can have multiple occurrences.
