### PR TITLE
Fix count=none when we have filters

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -66,11 +66,9 @@ app conf reqBody req =
             from = fromMaybe 0 $ rangeOffset <$> range
             count = if hasPrefer "count=none" 
                       then countNone
-                      else countRows qt
+                      else whereT qt qq $ countRows qt
             query = B.Stmt "select " V.empty True <>
-                parentheticT (
-                  whereT qt qq count
-                ) <> commaq <> (
+                parentheticT count <> commaq <> (
                 bodyForAccept contentType qt
                 . limitT range
                 . orderT (orderParse qq)

--- a/test/Feature/RangeSpec.hs
+++ b/test/Feature/RangeSpec.hs
@@ -37,6 +37,15 @@ spec = beforeAll (clearTable "items" >> createItems 15) . afterAll_ (clearTable 
             , matchHeaders = ["Content-Range" <:> "0-14/*"]
             }
 
+        it "returns range Content-Range with range/* even using other filters" $
+          request methodGet "/items?id=eq.1&order=id"
+                  [("Prefer", "count=none")] ""
+            `shouldRespondWith` ResponseMatcher {
+              matchBody    = Just [json| [{"id":1}] |]
+            , matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "0-0/*"]
+            }
+
     context "with range headers" $ do
 
       context "of acceptable range" $ do


### PR DESCRIPTION
The where clause should be discarded when count=none.
This was generating a database run time error for we did not have a test case for filters with count=none, so I modified one of the test cases I've included in the previous PR