### PR TITLE
Moves all config related code to PostgREST.Config module and sets default db-pass

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -94,6 +94,7 @@ library
                      , errors
                      , bifunctors
 
+  Other-Modules:       Paths_postgrest
   Exposed-Modules:     PostgREST.App
                      , PostgREST.Types
                      , PostgREST.Parsers
@@ -130,6 +131,7 @@ Test-Suite spec
                      , PostgREST.RangeQuery
                      , Spec
                      , SpecHelper
+                     , Paths_postgrest
   Build-Depends:       base, hspec == 2.1.*, QuickCheck
                      , hspec-wai, hspec-wai-json
                      , hasql, hasql-backend

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -1,14 +1,22 @@
-module PostgREST.Config where
+module PostgREST.Config ( prettyVersion
+                        , readOptions
+                        , corsPolicy
+                        , AppConfig (..)
+                        )
+       where
 
 
 import           Control.Applicative
 import qualified Data.ByteString.Char8       as BS
 import qualified Data.CaseInsensitive        as CI
+import           Data.List                   (intercalate)
 import           Data.String.Conversions     (cs)
 import           Data.Text                   (strip)
+import           Data.Version                (versionBranch)
 import           Network.Wai
 import           Network.Wai.Middleware.Cors (CorsResourcePolicy (..))
 import           Options.Applicative         hiding (columns)
+import           Paths_postgrest             (version)
 import           Prelude
 
 data AppConfig = AppConfig {
@@ -63,3 +71,18 @@ corsPolicy req = case lookup "origin" headers of
     accHeaders = case lookup "access-control-request-headers" headers of
       Just hdrs -> map (CI.mk . cs . strip . cs) $ BS.split ',' hdrs
       Nothing -> []
+
+prettyVersion :: String
+prettyVersion = intercalate "." $ map show $ versionBranch version
+
+readOptions :: IO AppConfig
+readOptions = customExecParser parserPrefs opts
+  where
+    opts = info (helper <*> argParser) $
+                    fullDesc
+                    <> progDesc (
+                    "PostgREST "
+                    <> prettyVersion
+                    <> " / create a REST API to an existing Postgres database"
+                    )
+    parserPrefs = prefs showHelpOnError

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -1,3 +1,14 @@
+{-|
+Module      : PostgREST.Config
+Description : Manages PostgREST configuration options.
+
+This module provides a helper function to read the command line arguments using the optparse-applicative
+and the AppConfig type to store them.
+It also can be used to define other middleware configuration that may be delegated to some sort of
+external configuration.
+
+It currently includes a hardcoded CORS policy but this could easly be turned in configurable behaviour if needed.
+-}
 module PostgREST.Config ( prettyVersion
                         , readOptions
                         , corsPolicy
@@ -19,6 +30,7 @@ import           Options.Applicative         hiding (columns)
 import           Paths_postgrest             (version)
 import           Prelude
 
+-- | Data type to store all command line options
 data AppConfig = AppConfig {
     configDbName    :: String
   , configDbPort    :: Int
@@ -31,7 +43,6 @@ data AppConfig = AppConfig {
   , configSecure    :: Bool
   , configPool      :: Int
   , configV1Schema  :: String
-
   , configJwtSecret :: String
   }
 
@@ -55,6 +66,7 @@ defaultCorsPolicy =  CorsResourcePolicy Nothing
   ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"] ["Authorization"] Nothing
   (Just $ 60*60*24) False False True
 
+-- | CORS policy to be used in by Wai Cors middleware
 corsPolicy :: Request -> Maybe CorsResourcePolicy
 corsPolicy req = case lookup "origin" headers of
   Just origin -> Just defaultCorsPolicy {
@@ -72,9 +84,11 @@ corsPolicy req = case lookup "origin" headers of
       Just hdrs -> map (CI.mk . cs . strip . cs) $ BS.split ',' hdrs
       Nothing -> []
 
+-- | User friendly version number
 prettyVersion :: String
 prettyVersion = intercalate "." $ map show $ versionBranch version
 
+-- | Function to read and parse options from the command line
 readOptions :: IO AppConfig
 readOptions = customExecParser parserPrefs opts
   where

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -40,7 +40,7 @@ argParser = AppConfig
   <$> strOption (long "db-name" <> short 'd' <> metavar "NAME" <> help "name of database")
   <*> option auto (long "db-port" <> short 'P' <> metavar "PORT" <> value 5432 <> help "postgres server port" <> showDefault)
   <*> strOption (long "db-user" <> short 'U' <> metavar "ROLE" <> help "postgres authenticator role")
-  <*> strOption (long "db-pass" <> metavar "PASS" <> help "password for authenticator role")
+  <*> strOption (long "db-pass" <> metavar "PASS" <> value "" <> help "password for authenticator role")
   <*> strOption (long "db-host" <> metavar "HOST" <> value "localhost" <> help "postgres server hostname" <> showDefault)
 
   <*> option auto (long "port" <> short 'p' <> metavar "PORT" <> value 3000 <> help "port number on which to run HTTP server" <> showDefault)

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -1,7 +1,6 @@
 module Main where
 
 
-import           Paths_postgrest                      (version)
 import           PostgREST.PgStructure
 import           PostgREST.Types
 import           Network.Wai
@@ -13,22 +12,21 @@ import           PostgREST.Middleware
 import           Control.Monad                        (unless)
 import           Control.Monad.IO.Class               (liftIO)
 import           Data.Functor.Identity
-import           Data.List                            (intercalate)
-import           Data.String.Conversions              (cs)
+import           Data.String.Conversions              (cs,
+                                                       (<>))
 import           Data.Text                            (Text)
-import           Data.Version                         (versionBranch)
 import qualified Hasql                                as H
 import qualified Hasql.Postgres                       as P
 import           Network.Wai.Handler.Warp             hiding (Connection)
 import           Network.Wai.Middleware.RequestLogger (logStdout)
-import           Options.Applicative                  hiding (columns)
 
 import           System.IO                            (BufferMode (..),
                                                        hSetBuffering, stderr,
                                                        stdin, stdout)
 
 import           PostgREST.Config                     (AppConfig (..),
-                                                       argParser)
+                                                       prettyVersion,
+                                                       readOptions)
 
 isServerVersionSupported :: H.Session P.Postgres IO Bool
 isServerVersionSupported = do
@@ -41,15 +39,7 @@ main = do
   hSetBuffering stdin  LineBuffering
   hSetBuffering stderr NoBuffering
 
-  let opts = info (helper <*> argParser) $
-               fullDesc
-               <> progDesc (
-                 "PostgREST "
-                 <> prettyVersion
-                 <> " / create a REST API to an existing Postgres database"
-               )
-      parserPrefs = prefs showHelpOnError
-  conf <- customExecParser parserPrefs opts
+  conf <- readOptions
   let port = configPort conf
 
   unless (configSecure conf) $
@@ -104,6 +94,3 @@ main = do
     resOrError <- liftIO $ H.session pool $ H.tx txSettings $
       authenticated conf (app dbstructure conf body) req
     either (respond . errResponse) respond resOrError
-
-  where
-    prettyVersion = intercalate "." $ map show $ versionBranch version

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -12,8 +12,8 @@ import           PostgREST.Middleware
 import           Control.Monad                        (unless)
 import           Control.Monad.IO.Class               (liftIO)
 import           Data.Functor.Identity
-import           Data.String.Conversions              (cs,
-                                                       (<>))
+import           Data.Monoid                          ((<>))
+import           Data.String.Conversions              (cs)
 import           Data.Text                            (Text)
 import qualified Hasql                                as H
 import qualified Hasql.Postgres                       as P


### PR DESCRIPTION
I tried to better encapsulate the config functionality.

This PR sets a default password as empty string, which renders unnecessary the parameter --db-pass for development environments where the authentication method is usually done without passwords.

I also changed the Config module to use an explicit list of exported module as it seems that in this way we have a better self-documented code and gives us more confidence to refactor private members.

I was also thinking of documenting the code with haddock, any opinions on this topic?