### PR TITLE
Use postgres connection string instead of 5+ options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Embed associations, e.g. `/film?select=*,director(*)` - @ruslantalpa
 - Filter columns, e.g. `?select=col1,col2` - @ruslantalpa
 - Does not execute the count total if header "Prefer: count=none" - @diogob
+- Postgres connection string argument - @calebmer
 
 ### Removed
 - API versioning feature - @calebmer
+- `--db-x` command line arguments - @calebmer
 
 ### Fixed
 - Tolerate a missing role in user creation - @calebmer

--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@ your own projects.
 Download the binary ([latest release](https://github.com/begriffs/postgrest/releases/latest)) and invoke like so:
 
 ```bash
-postgrest  --db-host localhost  --db-port 5432     \
-           --db-name my_db      --db-user postgres \
-           --db-pass foobar     --db-pool 200      \
-           --anonymous postgres --port 3000        \
-           --schema public
+postgrest postgres://postgres:foobar@localhost:5432/my_db
+          --port 3000          \
+          --schema public      \
+          --anonymous postgres \
+          --pool 200
 ```
+
+For more information on valid connection strings see the
+[Postgres docs](http://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNSTRING).
 
 In production include the `--secure` option which redirects all
 requests to HTTPS. Note that PostgREST does not handle the SSL

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ your own projects.
 Download the binary ([latest release](https://github.com/begriffs/postgrest/releases/latest)) and invoke like so:
 
 ```bash
-postgrest postgres://postgres:foobar@localhost:5432/my_db
-          --port 3000          \
-          --schema public      \
+postgrest postgres://postgres:foobar@localhost:5432/my_db \
+          --port 3000 \
+          --schema public \
           --anonymous postgres \
           --pool 200
 ```

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -57,8 +57,8 @@ import           PostgREST.Types
 
 import           Prelude
 
-app :: DbStructure -> AppConfig -> BL.ByteString -> DbRole -> Request -> H.Tx P.Postgres s Response
-app dbstructure conf reqBody dbrole req =
+app :: DbStructure -> AppConfig -> Text -> BL.ByteString -> DbRole -> Request -> H.Tx P.Postgres s Response
+app dbstructure conf authenticator reqBody dbrole req =
   case (path, verb) of
 
     ([], _) -> do
@@ -295,7 +295,6 @@ app dbstructure conf reqBody dbrole req =
     hasPrefer val = any (\(h,v) -> h == "Prefer" && v == val) hdrs
     accept        = lookupHeader hAccept
     schema        = cs $ configSchema conf
-    authenticator = cs $ configDbUser conf
     jwtSecret     = cs $ configJwtSecret conf
     range         = rangeRequested hdrs
     allOrigins    = ("Access-Control-Allow-Origin", "*") :: Header

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -45,7 +45,7 @@ data AppConfig = AppConfig {
 
 argParser :: Parser AppConfig
 argParser = AppConfig
-  <$> argument str (help "database connection string" <> metavar "URL")
+  <$> argument str (help "database connection string" <> metavar "STRING")
 
   <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
   <*> strOption    (long "anonymous"  <> short 'a' <> help "postgres role to use for non-authenticated requests" <> metavar "ROLE")

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -34,34 +34,25 @@ import           Prelude
 
 -- | Data type to store all command line options
 data AppConfig = AppConfig {
-    configDbName    :: String
-  , configDbPort    :: Int
-  , configDbUser    :: String
-  , configDbPass    :: String
-  , configDbHost    :: String
-
+    configDatabase  :: String
   , configPort      :: Int
   , configAnonRole  :: String
-  , configSecure    :: Bool
-  , configPool      :: Int
   , configSchema    :: String
+  , configSecure    :: Bool
   , configJwtSecret :: String
+  , configPool      :: Int
   }
 
 argParser :: Parser AppConfig
 argParser = AppConfig
-  <$> strOption (long "db-name" <> short 'd' <> metavar "NAME" <> help "name of database")
-  <*> option auto (long "db-port" <> short 'P' <> metavar "PORT" <> value 5432 <> help "postgres server port" <> showDefault)
-  <*> strOption (long "db-user" <> short 'U' <> metavar "ROLE" <> help "postgres authenticator role")
-  <*> strOption (long "db-pass" <> metavar "PASS" <> value "" <> help "password for authenticator role")
-  <*> strOption (long "db-host" <> metavar "HOST" <> value "localhost" <> help "postgres server hostname" <> showDefault)
+  <$> argument str (help "database connection string" <> metavar "URL")
 
-  <*> option auto (long "port" <> short 'p' <> metavar "PORT" <> value 3000 <> help "port number on which to run HTTP server" <> showDefault)
-  <*> strOption (long "anonymous" <> short 'a' <> metavar "ROLE" <> help "postgres role to use for non-authenticated requests")
-  <*> switch (long "secure" <> short 's' <> help "Redirect all requests to HTTPS")
-  <*> option auto (long "db-pool" <> metavar "COUNT" <> value 10 <> help "Max connections in database pool" <> showDefault)
-  <*> strOption (long "schema" <> short 'S' <> metavar "NAME" <> value "public" <> help "Schema to use for API routes" <> showDefault)
-  <*> strOption (long "jwt-secret" <> metavar "SECRET" <> value "secret" <> help "Secret used to encrypt and decrypt JWT tokens)" <> showDefault)
+  <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
+  <*> strOption    (long "anonymous"  <> short 'a' <> help "postgres role to use for non-authenticated requests" <> metavar "ROLE")
+  <*> strOption    (long "schema"     <> short 'S' <> help "schema to use for API routes" <> metavar "NAME" <> value "1" <> showDefault)
+  <*> switch       (long "secure"     <> short 's' <> help "redirect all requests to HTTPS")
+  <*> strOption    (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET" <> value "secret" <> showDefault)
+  <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)
 
 defaultCorsPolicy :: CorsResourcePolicy
 defaultCorsPolicy =  CorsResourcePolicy Nothing


### PR DESCRIPTION
I propose we remove the `--db-x` options for v3. First because they are ugly, second because the Postgres [connection string format](http://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNSTRING) is much more expressive. It allows for multiple styles and more configuration options (`connect_timeout`, `application_name`) than we could ever logically allow.

The new syntax would be:
```bash
postgrest postgres://authenticator@localhost:5432/database -a anonymous -S public…
```

For those who store all the information in separate variables the syntax is also simpler for them too:
```bash
postgrest postgres://$DB_USER:$DB_PASS@$DB_HOST:$DB_PORT/$DB_NAME…
```

The one point of difficulty is that doing so removes `configDbUser` which is used as the PostgREST authenticator in the old auth system (in #311 the need for `configDbUser` in all code but connection parameters is removed). So similar to the `DbStructure` approach, the authenticator role is cached (retrieved with `SELECT SESSION_USER`) and given to subsequent request calls. Again, the need for this could be completely removed with #311.