### PR TITLE
Clearer errors

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -37,6 +37,7 @@ executable postgrest
                      , case-insensitive
                      , scientific, time
                      , aeson >= 0.8, network >= 2.6
+                     , aeson-pretty >= 0.7 && < 0.8
                      , bytestring, text, split, string-conversions
                      , stringsearch
                      , containers, unordered-containers

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -57,7 +57,7 @@ import           PostgREST.Types
 
 import           Prelude
 
-app :: DbStructure -> AppConfig -> Text -> BL.ByteString -> DbRole -> Request -> H.Tx P.Postgres s Response
+app :: DbStructure -> AppConfig -> DbRole -> BL.ByteString -> DbRole -> Request -> H.Tx P.Postgres s Response
 app dbstructure conf authenticator reqBody dbrole req =
   case (path, verb) of
 

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -1,38 +1,40 @@
 module Main where
 
 
+import           PostgREST.App
+import           PostgREST.Config                     (AppConfig (..),
+                                                       minimumPgVersion,
+                                                       prettyVersion,
+                                                       readOptions)
+import           PostgREST.Error                      (errResponse, PgError)
+import           PostgREST.Middleware
 import           PostgREST.PgStructure
 import           PostgREST.Types
-import           Network.Wai
-
-import           PostgREST.App
-import           PostgREST.Error                      (errResponse)
-import           PostgREST.Middleware
 
 import           Control.Monad                        (unless)
 import           Control.Monad.IO.Class               (liftIO)
+import           Data.Aeson.Encode.Pretty             (encodePretty)
 import           Data.Functor.Identity
 import           Data.Monoid                          ((<>))
 import           Data.String.Conversions              (cs)
 import           Data.Text                            (Text)
 import qualified Hasql                                as H
 import qualified Hasql.Postgres                       as P
+import           Network.Wai
 import           Network.Wai.Handler.Warp             hiding (Connection)
 import           Network.Wai.Middleware.RequestLogger (logStdout)
-
 import           System.IO                            (BufferMode (..),
                                                        hSetBuffering, stderr,
                                                        stdin, stdout)
 
-import           PostgREST.Config                     (AppConfig (..),
-                                                       prettyVersion,
-                                                       readOptions,
-                                                       minimumPgVersion)
 
 isServerVersionSupported :: H.Session P.Postgres IO Bool
 isServerVersionSupported = do
   Identity (row :: Text) <- H.tx Nothing $ H.singleEx [H.stmt|SHOW server_version_num|]
   return $ read (cs row) >= minimumPgVersion
+
+hasqlError :: PgError -> IO a
+hasqlError = error . cs . encodePretty
 
 main :: IO ()
 main = do
@@ -61,15 +63,17 @@ main = do
   pool :: H.Pool P.Postgres <- H.acquirePool pgSettings poolSettings
 
   supportedOrError <- H.session pool isServerVersionSupported
-  either (fail . show)
+  either hasqlError
     (\supported ->
       unless supported $
-        fail "Cannot run in this PostgreSQL version, PostgREST needs at least 9.2.0"
+        error "Cannot run in this PostgreSQL version, PostgREST needs at least 9.2.0"
     ) supportedOrError
 
-  Right authenticator <- H.session pool $ do
-    Identity (role :: Text) <- H.tx Nothing $ H.singleEx [H.stmt|SELECT SESSION_USER|]
+  roleOrError <- H.session pool $ do
+    Identity (role :: Text) <- H.tx Nothing $ H.singleEx
+      [H.stmt|SELECT SESSION_USER|]
     return role
+  authenticator <- either hasqlError return roleOrError
 
   let txSettings = Just (H.ReadCommitted, Just True)
   metadata <- H.session pool $ H.tx txSettings $ do
@@ -79,15 +83,15 @@ main = do
     keys <- allPrimaryKeys
     return (tabs, rels, cols, keys)
 
-  dbstructure <- case metadata of
-    Left e -> fail $ show e
-    Right (tabs, rels, cols, keys) ->
+  dbstructure <- either hasqlError
+    (\(tabs, rels, cols, keys) ->
       return DbStructure {
           tables=tabs
         , columns=cols
         , relations=rels
         , primaryKeys=keys
         }
+    ) metadata
 
   runSettings appSettings $ middle $ \ req respond -> do
     body <- strictRequestBody req

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -66,7 +66,9 @@ main = do
   either hasqlError
     (\supported ->
       unless supported $
-        error "Cannot run in this PostgreSQL version, PostgREST needs at least 9.2.0"
+        error (
+          "Cannot run in this PostgreSQL version, PostgREST needs at least "
+          <> show minimumPgVersion)
     ) supportedOrError
 
   roleOrError <- H.session pool $ do

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -33,7 +33,7 @@ import           PostgREST.Config              (AppConfig (..), corsPolicy)
 
 import           Prelude
 
-authenticated :: forall s. AppConfig -> Text ->
+authenticated :: forall s. AppConfig -> DbRole ->
                  (DbRole -> Request -> H.Tx P.Postgres s Response) ->
                  Request -> H.Tx P.Postgres s Response
 authenticated conf authenticator app req = do


### PR DESCRIPTION
This prints out a full error message on startup if there are problems connecting to the database or if postgrest issues a bad query.

It should help with debugging problems. Only thing I'm not totally happy about is that it outputs the results as a pretty-printed JSON object. This output style doesn't match the usual logging convention which is line based with timestamps.