### PR TITLE
Update stack resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,8 @@ packages:
 extra-deps: 
   - Ranged-sets-0.3.0
   - packdeps-0.4.1
-resolver: lts-3.7
+  - hspec-2.2.0
+  - hspec-core-2.2.0
+  - hspec-discover-2.2.0
+  - hspec-expectations-0.7.2
+resolver: lts-3.10


### PR DESCRIPTION
Also adds new hspec to custom build plan (since 2.2.0) is not included in Stackage 3.10.

The 2.2.0 version is already in the Stockage Nightly, so we will be able to remove then from the custom plan as soon as the next version is released. 