### PR TITLE
Fixes 500 when set returning function returns an empty row set [fix #332]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Return empty array instead of 500 when a set returning function returns an empty result set - @diogob
+
 ## [0.2.12.0] - 2015-10-25
 
 ### Added

--- a/src/PostgREST/PgQuery.hs
+++ b/src/PostgREST/PgQuery.hs
@@ -116,7 +116,7 @@ asJsonWithCount = withCount . asJson
 asJson :: StatementT
 asJson s = s {
   B.stmtTemplate =
-    "array_to_json(array_agg(row_to_json(t)))::character varying from ("
+    "array_to_json(coalesce(array_agg(row_to_json(t)), '{}'))::character varying from ("
     <> B.stmtTemplate s <> ") t" }
 
 withCount :: StatementT

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -310,6 +310,11 @@ spec =
         post "/rpc/getitemrange" [json| { "min": 2, "max": 4 } |] `shouldRespondWith`
           [json| [ {"id": 3}, {"id":4} ] |]
 
+    context "a proc that returns an empty rowset" $
+      it "returns empty json array" $
+        post "/rpc/test_empty_rowset" [json| {} |] `shouldRespondWith`
+          [json| [] |]
+
     context "a proc that returns plain text" $
       it "returns proper json" $
         post "/rpc/sayhello" [json| { "name": "world" } |] `shouldRespondWith`

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -297,7 +297,9 @@ CREATE FUNCTION "1".getitemrange(min bigint, max bigint) RETURNS SETOF "1".items
     SELECT * FROM "1".items WHERE id > $1 AND id <= $2;
 $$ LANGUAGE SQL;
 
-
+CREATE FUNCTION "1".test_empty_rowset() RETURNS SETOF int AS $$
+    SELECT null::int FROM (SELECT 1) a WHERE false;
+$$ LANGUAGE SQL;
 
 CREATE FUNCTION "1".sayhello(name text) RETURNS text AS $$
     SELECT 'Hello, ' || $1;
@@ -663,6 +665,10 @@ REVOKE ALL ON FUNCTION getitemrange(bigint, bigint) FROM postgrest_test;
 GRANT EXECUTE ON FUNCTION getitemrange(bigint, bigint) TO postgrest_test;
 GRANT EXECUTE ON FUNCTION getitemrange(bigint, bigint) TO postgrest_anonymous;
 
+REVOKE ALL ON FUNCTION test_empty_rowset() FROM PUBLIC;
+REVOKE ALL ON FUNCTION test_empty_rowset() FROM postgrest_test;
+GRANT EXECUTE ON FUNCTION test_empty_rowset() TO postgrest_test;
+GRANT EXECUTE ON FUNCTION test_empty_rowset() TO postgrest_anonymous;
 
 REVOKE ALL ON FUNCTION sayhello(text) FROM PUBLIC;
 REVOKE ALL ON FUNCTION sayhello(text) FROM postgrest_test;


### PR DESCRIPTION
Our queries usually return a row even when the results is empty.
The /rpc endpoints are an exception, they can actually return an empty row set, and this triggers a 500 error.

I just coalesced the null result to and empty array in the array_to_json call.