### PR TITLE
Do not redirect insecure requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - API versioning feature - @calebmer
 - `--db-x` command line arguments - @calebmer
-- Secure flag responds with 403 instead of redirect - @calebmer
+- Remove secure flag - @calebmer
 
 ### Fixed
 - Tolerate a missing role in user creation - @calebmer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - API versioning feature - @calebmer
 - `--db-x` command line arguments - @calebmer
+- Secure flag responds with 403 instead of redirect - @calebmer
 
 ### Fixed
 - Tolerate a missing role in user creation - @calebmer

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -38,7 +38,6 @@ data AppConfig = AppConfig {
   , configPort      :: Int
   , configAnonRole  :: String
   , configSchema    :: String
-  , configSecure    :: Bool
   , configJwtSecret :: String
   , configPool      :: Int
   }
@@ -49,8 +48,7 @@ argParser = AppConfig
 
   <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
   <*> strOption    (long "anonymous"  <> short 'a' <> help "postgres role to use for non-authenticated requests" <> metavar "ROLE")
-  <*> strOption    (long "schema"     <> short 'S' <> help "schema to use for API routes" <> metavar "NAME" <> value "1" <> showDefault)
-  <*> switch       (long "secure"     <> short 's' <> help "redirect all requests to HTTPS")
+  <*> strOption    (long "schema"     <> short 's' <> help "schema to use for API routes" <> metavar "NAME" <> value "1" <> showDefault)
   <*> strOption    (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET" <> value "secret" <> showDefault)
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)
 

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -46,8 +46,6 @@ main = do
   conf <- readOptions
   let port = configPort conf
 
-  unless (configSecure conf) $
-    putStrLn "WARNING, running in insecure mode, auth will be in plaintext"
   unless ("secret" /= configJwtSecret conf) $
     putStrLn "WARNING, running in insecure mode, JWT secret is the default value"
   Prelude.putStrLn $ "Listening on port " ++
@@ -57,7 +55,7 @@ main = do
       appSettings = setPort port
                   . setServerName (cs $ "postgrest/" <> prettyVersion)
                   $ defaultSettings
-      middle = logStdout . defaultMiddle (configSecure conf)
+      middle = logStdout . defaultMiddle
 
   poolSettings <- maybe (fail "Improper session settings") return $
     H.poolSettings (fromIntegral $ configPool conf) 30

--- a/src/PostgREST/MainTest.hs
+++ b/src/PostgREST/MainTest.hs
@@ -54,8 +54,6 @@ main = do
   conf <- readOptions
   let port = configPort conf
 
-  unless (configSecure conf) $
-    putStrLn "WARNING, running in insecure mode, auth will be in plaintext"
   unless ("secret" /= configJwtSecret conf) $
     putStrLn "WARNING, running in insecure mode, JWT secret is the default value"
   Prelude.putStrLn $ "Listening on port " ++
@@ -65,7 +63,7 @@ main = do
       appSettings = setPort port
                   . setServerName (cs $ "postgrest/" <> prettyVersion)
                   $ defaultSettings
-      middle = logStdout . defaultMiddle (configSecure conf)
+      middle = logStdout . defaultMiddle
 
   poolSettings <- maybe (fail "Improper session settings") return $
     H.poolSettings (fromIntegral $ configPool conf) 30

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -41,7 +41,7 @@ isLeft (Left _ ) = True
 isLeft _ = False
 
 cfg :: AppConfig
-cfg = AppConfig dbString 3000 "postgrest_anonymous" "test" False "safe" 10
+cfg = AppConfig dbString 3000 "postgrest_anonymous" "test" "safe" 10
 
 testPoolOpts :: PoolSettings
 testPoolOpts = fromMaybe (error "bad settings") $ H.poolSettings 1 30
@@ -78,7 +78,7 @@ withApp perform = do
       $ runWithClaims cfg (app dbstructure cfg body) req
     either (resp . errResponse) resp result
 
-  where middle = defaultMiddle False
+  where middle = defaultMiddle
 
 
 resetDb :: IO ()


### PR DESCRIPTION
I was recently doing research and came across [this](https://github.com/interagent/http-api-design#require-secure-connections). I'll quote the relevant sections here:

> ### Require Secure Connections
>
> Require secure connections with TLS to access the API, without exception. It’s not worth trying to figure out or explain when it is OK to use TLS and when it’s not. Just require TLS for everything.
>
> Ideally, simply reject any non-TLS requests by not responding to requests for http or port 80 to avoid any insecure data exchange. In environments where this is not possible, respond with `403 Forbidden`.
>
> **Redirects are discouraged** since they allow sloppy/bad client behaviour without providing any clear gain. Clients that rely on redirects double up on server traffic and render TLS useless since sensitive data will already have been exposed during the first call.

Let's discuss potentially not redirecting (as is recommended in the last paragraph) and just responding with a 403. I like the idea 😊