### PR TITLE
Encode JWT when proc return types end in jwt_claims

### DIFF
--- a/src/PostgREST/PgStructure.hs
+++ b/src/PostgREST/PgStructure.hs
@@ -45,7 +45,7 @@ doesProcReturnJWT = doesProc [H.stmt|
       ON     pronamespace = n.oid
       WHERE  nspname = ?
       AND    proname = ?
-      AND    pg_catalog.pg_get_function_result(p.oid) = 'jwt_claims'
+      AND    pg_catalog.pg_get_function_result(p.oid) like '%jwt_claims'
     |]
 
 tableFromRow :: (Text, Text, Bool, Maybe Text) -> Table


### PR DESCRIPTION
Fixes it when the jwt_claims type is defined in a non-default schema