### PR TITLE
Reduce ambiguity in select query (#354)

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -25,7 +25,7 @@ executable postgrest
   if flag(ci)
     ghc-options:       -Wall -W -Werror
   else
-    ghc-options:       -Wall -W -O2
+    ghc-options:       -Wall -W
 
   main-is:             PostgREST/Main.hs
   default-extensions:  OverloadedStrings, ScopedTypeVariables, QuasiQuotes
@@ -78,7 +78,7 @@ library
   if flag(ci)
     ghc-options:       -Wall -W -Werror
   else
-    ghc-options:       -Wall -W -O2
+    ghc-options:       -Wall -W
 
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, ScopedTypeVariables, QuasiQuotes
@@ -146,7 +146,7 @@ Test-Suite spec
   if flag(ci)
     ghc-options:       -Wall -W -Werror
   else
-    ghc-options:       -Wall -W -O2
+    ghc-options:       -Wall -W
   Main-Is:             Main.hs
   Other-Modules:       Feature.AuthSpec
                      , Feature.CorsSpec

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -18,7 +18,7 @@ pRequestSelect rootNodeName = do
     treeEntry (Node fld@((fn, _),_) fldForest) (Node (q, i) rForest) =
       case fldForest of
         [] -> Node (q {select=fld:select q}, i) rForest
-        _  -> Node (q, i) (foldr treeEntry (Node (Select [] [fn] [] Nothing, (qiName fn, Nothing)) []) fldForest:rForest)
+        _  -> Node (q, i) (foldr treeEntry (Node (Select [] [] [] Nothing, (qiName fn, Nothing)) []) fldForest:rForest)
 
 pRequestFilter :: (String, String) -> Either ParseError (Path, Filter)
 pRequestFilter (k, v) = (,) <$> path <*> (Filter <$> fld <*> op <*> val)

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -26,7 +26,7 @@ data Table = Table {
 } deriving (Show, Ord)
 
 tableQi :: Table -> QualifiedIdentifier
-tableQi t = [tableSchema t, tableName t]
+tableQi t = QualifiedIdentifier (Just $ tableSchema t) (tableName t) Nothing
 
 data ForeignKey = ForeignKey { fkCol :: Column } deriving (Show, Eq, Ord)
 
@@ -47,7 +47,7 @@ data Column = Column {
 } deriving (Show, Ord)
 
 colQi :: Column -> QualifiedIdentifier
-colQi c = tableQi (colTable c) ++ [colName c]
+colQi c = QualifiedIdentifier (Just $ (tableSchema . colTable) c) ((tableName . colTable) c) (Just $ colName c)
 
 type Synonym = (Column,Column)
 
@@ -74,7 +74,14 @@ data Relation = Relation {
 , relLCols2   :: Maybe [Column]
 } deriving (Show, Eq)
 
-type QualifiedIdentifier = [Text]
+data QualifiedIdentifier = QualifiedIdentifier {
+  qiSchema :: Maybe Schema
+, qiTable  :: Text
+, qiColumn :: Maybe Text
+} | UnqualifiedIdentifier {
+  qiName   :: Text
+} deriving (Show, Eq, Ord)
+
 type Path = [Text]
 type JsonPath = [Text]
 type Operator = Text

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -25,24 +25,29 @@ data Table = Table {
 , tableInsertable :: Bool
 } deriving (Show, Ord)
 
+tableQi :: Table -> QualifiedIdentifier
+tableQi t = [tableSchema t, tableName t]
+
 data ForeignKey = ForeignKey { fkCol :: Column } deriving (Show, Eq, Ord)
 
-data Column =
-    Column {
-      colTable     :: Table
-    , colName      :: Text
-    , colPosition  :: Int
-    , colNullable  :: Bool
-    , colType      :: Text
-    , colUpdatable :: Bool
-    , colMaxLen    :: Maybe Int
-    , colPrecision :: Maybe Int
-    , colDefault   :: Maybe Text
-    , colEnum      :: [Text]
-    , colFK        :: Maybe ForeignKey
-    }
-  | Star { colTable :: Table }
-  deriving (Show, Ord)
+data Column = Column {
+  colTable     :: Table
+, colName      :: Text
+, colPosition  :: Int
+, colNullable  :: Bool
+, colType      :: Text
+, colUpdatable :: Bool
+, colMaxLen    :: Maybe Int
+, colPrecision :: Maybe Int
+, colDefault   :: Maybe Text
+, colEnum      :: [Text]
+, colFK        :: Maybe ForeignKey
+} | Star {
+  colTable :: Table
+} deriving (Show, Ord)
+
+colQi :: Column -> QualifiedIdentifier
+colQi c = tableQi (colTable c) ++ [colName c]
 
 type Synonym = (Column,Column)
 
@@ -57,12 +62,6 @@ data OrderTerm = OrderTerm {
 , otNullOrder :: Maybe BS.ByteString
 } deriving (Show, Eq)
 
-data QualifiedIdentifier = QualifiedIdentifier {
-  qiSchema :: Schema
-, qiName   :: TableName
-} deriving (Show, Eq)
-
-
 data RelationType = Child | Parent | Many deriving (Show, Eq)
 data Relation = Relation {
   relTable    :: Table
@@ -75,21 +74,40 @@ data Relation = Relation {
 , relLCols2   :: Maybe [Column]
 } deriving (Show, Eq)
 
-
-type Operator = Text
-data FValue = VText Text | VForeignKey QualifiedIdentifier ForeignKey deriving (Show, Eq)
-type FieldName = Text
+type QualifiedIdentifier = [Text]
+type Path = [Text]
 type JsonPath = [Text]
-type Field = (FieldName, Maybe JsonPath)
+type Operator = Text
+data FValue = VText Text | VForeignKey QualifiedIdentifier deriving (Show, Eq)
+type Field = (QualifiedIdentifier, Maybe JsonPath)
 type Cast = Text
 type NodeName = Text
 type SelectItem = (Field, Maybe Cast)
-type Path = [Text]
-data Query = Select { select::[SelectItem], from::[Text], where_::[Filter], order::Maybe [OrderTerm] }
-           | Insert { into::Text, fields::[Field], values::[[Value]] }
-           | Delete { from::[Text], where_::[Filter] }
-           | Update { into::Text, set::Map Field Value, where_::[Filter] } deriving (Show, Eq)
-data Filter = Filter {field::Field, operator::Operator, value::FValue} deriving (Show, Eq)
+
+data Query = Select {
+  select :: [SelectItem]
+, from   :: [QualifiedIdentifier]
+, where_ :: [Filter]
+, order  :: Maybe [OrderTerm]
+} | Insert {
+  into   :: QualifiedIdentifier
+, fields :: [Field]
+, values :: [[Value]]
+} | Delete {
+  from   :: [QualifiedIdentifier]
+, where_ :: [Filter]
+} | Update {
+  into   :: QualifiedIdentifier
+, set    :: Map Field Value
+, where_ :: [Filter]
+} deriving (Show, Eq)
+
+data Filter = Filter {
+  field    :: Field
+, operator :: Operator
+, value    :: FValue
+} deriving (Show, Eq)
+
 type ApiNode = (Query, (NodeName, Maybe Relation))
 type ApiRequest = Tree ApiNode
 
@@ -126,8 +144,7 @@ instance ToJSON Table where
     , "insertable" .= tableInsertable v ]
 
 instance Eq Table where
-  Table{tableSchema=s1,tableName=n1} == Table{tableSchema=s2,tableName=n2} = s1 == s2 && n1 == n2
+  t1 == t2 = tableQi t1 == tableQi t2
 
 instance Eq Column where
-  Column{colTable=t1,colName=n1} == Column{colTable=t2,colName=n2} = t1 == t2 && n1 == n2
-  _ == _ = False
+  c1 == c2 = colQi c1 == colQi c2

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -214,6 +214,10 @@ spec =
       get "/users_tasks?user_id=eq.2&task_id=eq.6&select=*, comments(content)" `shouldRespondWith`
         "[{\"user_id\":2,\"task_id\":6,\"comments\":[{\"content\":\"Needs to be delivered ASAP\"}]}]"
 
+    it "can select by column name" $
+      get "/projects?id=in.1,3&select=id,name,client_id,client_id(id,name)" `shouldRespondWith`
+        "[{\"id\":1,\"name\":\"Windows 7\",\"client_id\":1,\"client_id\":{\"id\":1,\"name\":\"Microsoft\"}},{\"id\":3,\"name\":\"IOS\",\"client_id\":2,\"client_id\":{\"id\":2,\"name\":\"Apple\"}}]"
+
 
   describe "ordering response" $ do
     it "by a column asc" $


### PR DESCRIPTION
As I write this, the code in this PR does not actually provide a solution for #354. Rather it is a refactor which is meant to facilitate the implementation of a solution to #354. I PR this first half now to start the discussion on the implementation.

The major refactor change is that all of the types involving the `Query` type were rather ambiguous in its location specifications. Either it only had the table name or the column name and `VForeignKey` was really weird. It had the schema and table name for the `Filter` type it was an object of.

All of these types now use a modified `QualifiedIdentifier` type which is now just an alias for `[Text]`. The new `QualifiedIdentifier` is meant to be a path to whatever bit of data the code is looking for.

One strange part is in order to keep the Parser.hs code "pure" (it shouldn't require knowledge of the database) the head of `QualifiedIdentifier` will be an empty string to represent that it is unqualified. Later they will be qualified [here](https://github.com/calebmer/postgrest/blob/df7ac5139b6d4ff53c11c2e0c0952eebb3caa7ec/src/PostgREST/App.hs#L413-L435). I didn't want to use a data type because it was so handy to be able to use all of the list functions on `QualifiedIdentifier`s.

Maybe give this initial refactor a look (or wait until the solution for #354 is implemented to review). Also, would you rather merge this independently of our solution? Finally, definitely give your opinion on how we fix #354 in the issue.