### PR TITLE
Refactor QualifiedIdentifier

### DIFF
--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -1,27 +1,24 @@
-module PostgREST.Parsers
--- ( parseGetRequest
--- )
-where
+module PostgREST.Parsers where
 
-import           Control.Applicative hiding ((<$>))
+import           Control.Applicative           hiding ((<$>))
 import           Data.Monoid
 import           Data.String.Conversions       (cs)
 import           Data.Text                     (Text)
 import           Data.Tree
 import           PostgREST.Types
 import           Text.ParserCombinators.Parsec hiding (many, (<|>))
-import           PostgREST.QueryBuilder (operators)
+import           PostgREST.QueryBuilder        (operators)
 
-pRequestSelect :: Text -> Parser ApiRequest
+pRequestSelect :: QualifiedIdentifier -> Parser ApiRequest
 pRequestSelect rootNodeName = do
   fieldTree <- pFieldForest
-  return $ foldr treeEntry (Node (Select [] [rootNodeName] [] Nothing, (rootNodeName, Nothing)) []) fieldTree
+  return $ foldr treeEntry (Node (Select [] [rootNodeName] [] Nothing, (qiTable rootNodeName, Nothing)) []) fieldTree
   where
     treeEntry :: Tree SelectItem -> ApiRequest -> ApiRequest
     treeEntry (Node fld@((fn, _),_) fldForest) (Node (q, i) rForest) =
       case fldForest of
         [] -> Node (q {select=fld:select q}, i) rForest
-        _  -> Node (q, i) (foldr treeEntry (Node (Select [] [fn] [] Nothing, (fn, Nothing)) []) fldForest:rForest)
+        _  -> Node (q, i) (foldr treeEntry (Node (Select [] [fn] [] Nothing, (qiName fn, Nothing)) []) fldForest:rForest)
 
 pRequestFilter :: (String, String) -> Either ParseError (Path, Filter)
 pRequestFilter (k, v) = (,) <$> path <*> (Filter <$> fld <*> op <*> val)
@@ -45,7 +42,7 @@ pTreePath = do
   jp <- optionMaybe pJsonPath
   let pp = map cs p
       jpp = map cs <$> jp
-  return (init pp, (last pp, jpp))
+  return (init pp, (UnqualifiedIdentifier (last pp), jpp))
 
 pFieldForest :: Parser [Tree SelectItem]
 pFieldForest = pFieldTree `sepBy1` lexeme (char ',')
@@ -68,14 +65,14 @@ pJsonPath :: Parser [Text]
 pJsonPath = (++) <$> many pJsonPathStep <*> ( (:[]) <$> (string "->>" *> pFieldName) )
 
 pField :: Parser Field
-pField = lexeme $ (,) <$> pFieldName <*> optionMaybe pJsonPath
+pField = lexeme $ (,) <$> (UnqualifiedIdentifier <$> pFieldName) <*> optionMaybe pJsonPath
 
 pSelect :: Parser SelectItem
 pSelect = lexeme $
   try ((,) <$> pField <*>((cs <$>) <$> optionMaybe (string "::" *> many letter)) )
   <|> do
     s <- pStar
-    return ((s, Nothing), Nothing)
+    return ((UnqualifiedIdentifier s, Nothing), Nothing)
 
 pOperator :: Parser Operator
 pOperator = cs <$> (pOp <?> "operator (eq, gt, ...)")

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TupleSections        #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module PostgREST.QueryBuilder (
     addRelations
@@ -29,32 +29,34 @@ import qualified Hasql.Postgres          as P
 
 import qualified Data.Aeson              as JSON
 
-import           PostgREST.RangeQuery    (NonnegRange, rangeLimit, rangeOffset)
 import           Control.Error           (note, fromMaybe, mapMaybe)
 import           Control.Monad           (join)
 import           Data.List               (find)
 import           Data.Monoid             ((<>))
+import           Data.Maybe              (fromJust)
 import           Data.Text               (Text, intercalate, unwords, replace, isInfixOf, toLower, split)
 import qualified Data.Text as T          (map, takeWhile)
 import           Data.String.Conversions (cs)
-import qualified Data.HashMap.Strict     as H
-import           Control.Applicative     (empty, (<|>))
-import           Data.Tree               (Tree(..))
-import           PostgREST.Types
-import qualified Data.Map as M
-import           Text.Regex.TDFA         ((=~))
 import qualified Data.ByteString.Char8   as BS
-import           Data.Scientific         ( FPFormat (..)
-                                         , formatScientific
-                                         , isInteger
-                                         )
+import qualified Data.Map                as M
+import qualified Data.HashMap.Strict     as H
+import           Data.Tree               (Tree(..))
+import           Data.Scientific         (FPFormat (..), formatScientific, isInteger)
+import           Text.Regex.TDFA         ((=~))
+import           Control.Applicative     (empty, (<|>))
+
+import           PostgREST.RangeQuery    (NonnegRange, rangeLimit, rangeOffset)
+import           PostgREST.Types
+
 import           Prelude hiding          (unwords)
 
 type PStmt = H.Stmt P.Postgres
+
 instance Monoid PStmt where
   mappend (B.Stmt query params prep) (B.Stmt query' params' prep') =
     B.Stmt (query <> query') (params <> params') (prep && prep')
   mempty = B.Stmt "" empty True
+
 type StatementT = PStmt -> PStmt
 
 addRelations :: Schema -> [Relation] -> Maybe ApiRequest -> ApiRequest -> Either Text ApiRequest
@@ -83,7 +85,7 @@ addJoinConditions schema (Node (query, (n, r)) forest) =
       Node (qq, (n, r)) <$> updatedForest
       where
          q = addCond updatedQuery (getJoinConditions rel)
-         qq = q{from=tableName linkTable : from q}
+         qq = q{from=tableQi linkTable : from q}
     _ -> Left "unknown relation"
   where
     -- add parentTable and parentJoinConditions to the query
@@ -92,7 +94,7 @@ addJoinConditions schema (Node (query, (n, r)) forest) =
         parentJoinConditions = map (getJoinConditions . snd) parents
         parentTables = map fst parents
         parents = mapMaybe (getParents . rootLabel) forest
-        getParents (_, (tbl, Just rel@(Relation{relType=Parent}))) = Just (tbl, rel)
+        getParents (_, (_, Just rel@(Relation{relType=Parent,relTable=tbl}))) = Just (tableQi tbl, rel)
         getParents _ = Nothing
     updatedForest = mapM (addJoinConditions schema) forest
     addCond q con = q{where_=con ++ where_ q}
@@ -189,19 +191,14 @@ pgFmtLit x =
    else slashed
 
 requestToQuery :: Schema -> ApiRequest -> SqlQuery
-requestToQuery schema (Node (Select colSelects tbls conditions ord, (mainTbl, _)) forest) =
+requestToQuery schema (Node (Select colSelects tbls conditions ord, _) forest) =
   query
   where
-    -- TODO! the folloing helper functions are just to remove the "schema" part when the table is "source" which is the name
-    -- of our WITH query part
-    tblSchema tbl = if tbl == sourceSubqueryName then "" else schema
-    qi = QualifiedIdentifier (tblSchema mainTbl) mainTbl
-    toQi t = QualifiedIdentifier (tblSchema t) t
     query = unwords [
       ("WITH " <> intercalate ", " withs) `emptyOnNull` withs,
-      "SELECT ", intercalate ", " (map (pgFmtSelectItem qi) colSelects ++ selects),
-      "FROM ", intercalate ", " (map (fromQi . toQi) tbls),
-      ("WHERE " <> intercalate " AND " ( map (pgFmtCondition qi ) conditions )) `emptyOnNull` conditions,
+      "SELECT ", intercalate ", " (map pgFmtSelectItem colSelects ++ selects),
+      "FROM ", intercalate ", " (map fromQi tbls),
+      ("WHERE " <> intercalate " AND " (map pgFmtCondition conditions)) `emptyOnNull` conditions,
       orderF (fromMaybe [] ord)
       ]
     (withs, selects) = foldr getQueryParts ([],[]) forest
@@ -229,40 +226,44 @@ requestToQuery schema (Node (Select colSelects tbls conditions ord, (mainTbl, _)
     --getQueryParts is not total but requestToQuery is called only after addJoinConditions which ensures the only
     --posible relations are Child Parent Many
     getQueryParts (Node (_,(_,Nothing)) _) _ = undefined
+
 requestToQuery schema (Node (Insert _ flds vals, (mainTbl, _)) _) =
   query
   where
-    qi = QualifiedIdentifier schema mainTbl
+    qi = QualifiedIdentifier (Just schema) mainTbl Nothing
     query = unwords [
       "INSERT INTO ", fromQi qi,
-      " (" <> intercalate ", " (map (pgFmtIdent . fst) flds) <> ") ",
+      " (" <> intercalate ", " (map pgFmtIdent $ mapMaybe (qiColumn . fst) flds) <> ") ",
       "VALUES " <> intercalate ", "
         ( map (\v ->
             "(" <>
-            intercalate ", " ( map insertableValue v ) <>
+            intercalate ", " (map insertableValue v) <>
             ")"
           ) vals
         ),
       "RETURNING " <> fromQi qi <> ".*"
       ]
+
 requestToQuery schema (Node (Update _ setWith conditions, (mainTbl, _)) _) =
   query
   where
-    qi = QualifiedIdentifier schema mainTbl
+    qi = QualifiedIdentifier (Just schema) mainTbl Nothing
     query = unwords [
       "UPDATE ", fromQi qi,
-      " SET " <> intercalate ", " (map formatSet (M.toList setWith)) <> " ",
-      ("WHERE " <> intercalate " AND " ( map (pgFmtCondition qi ) conditions )) `emptyOnNull` conditions,
+      " SET " <> intercalate ", " (mapMaybe formatSet (M.toList setWith)) <> " ",
+      ("WHERE " <> intercalate " AND " (map pgFmtCondition conditions)) `emptyOnNull` conditions,
       "RETURNING " <> fromQi qi <> ".*"
       ]
-    formatSet ((c, jp), v) = pgFmtIdent c <> pgFmtJsonPath jp <> " = " <> insertableValue v
+    formatSet ((QualifiedIdentifier _ _ (Just c), jp), v) = Just $ pgFmtIdent c <> pgFmtJsonPath jp <> " = " <> insertableValue v
+    formatSet _ = Nothing
+
 requestToQuery schema (Node (Delete _ conditions, (mainTbl, _)) _) =
   query
   where
-    qi = QualifiedIdentifier schema mainTbl
+    qi = QualifiedIdentifier (Just schema) mainTbl Nothing
     query = unwords [
       "DELETE FROM ", fromQi qi,
-      ("WHERE " <> intercalate " AND " ( map (pgFmtCondition qi ) conditions )) `emptyOnNull` conditions,
+      ("WHERE " <> intercalate " AND " (map pgFmtCondition conditions)) `emptyOnNull` conditions,
       "RETURNING " <> fromQi qi <> ".*"
       ]
 
@@ -289,24 +290,21 @@ wrapQuery source selectColumns returnSelect range =
 
 -- private functions
 fromQi :: QualifiedIdentifier -> SqlFragment
-fromQi t = (if s == "" then "" else pgFmtIdent s <> ".") <> pgFmtIdent n
-  where
-    n = qiName t
-    s = qiSchema t
+fromQi (QualifiedIdentifier s t (Just "*")) = fromQi (QualifiedIdentifier s t Nothing) <> ".*"
+fromQi (QualifiedIdentifier s t c) = intercalate "." $ mapMaybe (pgFmtIdent <$>) [s,Just t,c]
+fromQi (UnqualifiedIdentifier _) = error "Identifier must be qualified"
 
 getJoinConditions :: Relation -> [Filter]
-getJoinConditions (Relation t cols ft fcs typ lt lc1 lc2) =
+getJoinConditions (Relation t cols ft fcols typ mlt lc1 lc2) =
   case typ of
-    Child  -> zipWith (toFilter tN ftN) cols fcs
-    Parent -> zipWith (toFilter tN ftN) cols fcs
-    Many   -> zipWith (toFilter tN ltN) cols (fromMaybe [] lc1) ++ zipWith (toFilter ftN ltN) fcs (fromMaybe [] lc2)
+    Child  -> zipWith (toFilter t ft) cols fcols
+    Parent -> zipWith (toFilter t ft) cols fcols
+    Many   -> zipWith (toFilter t lt) cols (fromMaybe [] lc1) ++ zipWith (toFilter ft lt) fcols (fromMaybe [] lc2)
   where
-    s = tableSchema t
-    tN = tableName t
-    ftN = tableName ft
-    ltN = fromMaybe "" (tableName <$> lt)
-    toFilter :: Text -> Text -> Column -> Column -> Filter
-    toFilter tb ftb c fc = Filter (colName c, Nothing) "=" (VForeignKey (QualifiedIdentifier s tb) (ForeignKey fc{colTable=(colTable fc){tableName=ftb}}))
+    lt = fromJust mlt -- This is ok because it is only used when the relation is of the `Many` type
+    toFilter tb ftb c fc = Filter (makeQi tb c, Nothing) "=" $ VForeignKey (makeQi ftb fc)
+    makeQi tb c = QualifiedIdentifier sch (tableName tb) (Just $ colName c)
+      where sch = if tableName tb == sourceSubqueryName then Nothing else Just (tableSchema tb)
 
 emptyOnNull :: Text -> [a] -> Text
 emptyOnNull val x = if null x then "" else val
@@ -333,38 +331,31 @@ whiteList val = fromMaybe
   (cs (pgFmtLit val) <> "::unknown ")
   (find ((==) . toLower $ val) ["null","true","false"])
 
-pgFmtColumn :: QualifiedIdentifier -> Text -> SqlFragment
-pgFmtColumn table "*" = fromQi table <> ".*"
-pgFmtColumn table c = fromQi table <> "." <> pgFmtIdent c
+pgFmtField :: Field -> SqlFragment
+pgFmtField (c, jp) = fromQi c <> pgFmtJsonPath jp
 
-pgFmtField :: QualifiedIdentifier -> Field -> SqlFragment
-pgFmtField table (c, jp) = pgFmtColumn table c <> pgFmtJsonPath jp
+pgFmtSelectItem :: SelectItem -> SqlFragment
+pgFmtSelectItem (f@(_, jp), Nothing) = pgFmtField f <> pgFmtAsJsonPath jp
+pgFmtSelectItem (f@(_, jp), Just cast) = "CAST (" <> pgFmtField f <> " AS " <> cast <> " )" <> pgFmtAsJsonPath jp
 
-pgFmtSelectItem :: QualifiedIdentifier -> SelectItem -> SqlFragment
-pgFmtSelectItem table (f@(_, jp), Nothing) = pgFmtField table f <> pgFmtAsJsonPath jp
-pgFmtSelectItem table (f@(_, jp), Just cast ) = "CAST (" <> pgFmtField table f <> " AS " <> cast <> " )" <> pgFmtAsJsonPath jp
-
-pgFmtCondition :: QualifiedIdentifier -> Filter -> SqlFragment
-pgFmtCondition table (Filter (col,jp) ops val) =
+pgFmtCondition :: Filter -> SqlFragment
+pgFmtCondition (Filter (col,jp) ops val) =
   notOp <> " " <> sqlCol  <> " " <> pgFmtOperator opCode <> " " <>
-    if opCode `elem` ["is","isnot"] then whiteList (getInner val) else sqlValue
+    if opCode `elem` ["is","isnot"] then whiteList innerVal else sqlValue
   where
     headPredicate:rest = split (=='.') ops
     hasNot caseTrue caseFalse = if headPredicate == "not" then caseTrue else caseFalse
     opCode      = hasNot (head rest) headPredicate
     notOp       = hasNot headPredicate ""
     sqlCol = case val of
-      VText _ -> pgFmtColumn table col <> pgFmtJsonPath jp
-      VForeignKey qi _ -> pgFmtColumn qi col
-    sqlValue = valToStr val
-    getInner v = case v of
+      VText _ -> fromQi col <> pgFmtJsonPath jp
+      VForeignKey _ -> fromQi col
+    innerVal = case val of
       VText s -> s
-      _      -> ""
-    valToStr v = case v of
-      VText s -> pgFmtValue opCode s
-      VForeignKey (QualifiedIdentifier s _) (ForeignKey Column{colTable=Table{tableName=ft}, colName=fc}) -> pgFmtColumn qi fc
-        where qi = QualifiedIdentifier (if ft == sourceSubqueryName then "" else s) ft
       _ -> ""
+    sqlValue = case val of
+      VText s -> pgFmtValue opCode s
+      VForeignKey qi -> fromQi qi
 
 pgFmtValue :: Text -> Text -> SqlFragment
 pgFmtValue opCode val =

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -25,24 +25,29 @@ data Table = Table {
 , tableInsertable :: Bool
 } deriving (Show, Ord)
 
+tableQi :: Table -> QualifiedIdentifier
+tableQi t = QualifiedIdentifier (Just $ tableSchema t) (tableName t) Nothing
+
 data ForeignKey = ForeignKey { fkCol :: Column } deriving (Show, Eq, Ord)
 
-data Column =
-    Column {
-      colTable     :: Table
-    , colName      :: Text
-    , colPosition  :: Int
-    , colNullable  :: Bool
-    , colType      :: Text
-    , colUpdatable :: Bool
-    , colMaxLen    :: Maybe Int
-    , colPrecision :: Maybe Int
-    , colDefault   :: Maybe Text
-    , colEnum      :: [Text]
-    , colFK        :: Maybe ForeignKey
-    }
-  | Star { colTable :: Table }
-  deriving (Show, Ord)
+data Column = Column {
+  colTable     :: Table
+, colName      :: Text
+, colPosition  :: Int
+, colNullable  :: Bool
+, colType      :: Text
+, colUpdatable :: Bool
+, colMaxLen    :: Maybe Int
+, colPrecision :: Maybe Int
+, colDefault   :: Maybe Text
+, colEnum      :: [Text]
+, colFK        :: Maybe ForeignKey
+} | Star {
+  colTable :: Table
+} deriving (Show, Ord)
+
+colQi :: Column -> QualifiedIdentifier
+colQi c = QualifiedIdentifier (Just $ (tableSchema . colTable) c) ((tableName . colTable) c) (Just $ colName c)
 
 type Synonym = (Column,Column)
 
@@ -57,12 +62,6 @@ data OrderTerm = OrderTerm {
 , otNullOrder :: Maybe BS.ByteString
 } deriving (Show, Eq)
 
-data QualifiedIdentifier = QualifiedIdentifier {
-  qiSchema :: Schema
-, qiName   :: TableName
-} deriving (Show, Eq)
-
-
 data RelationType = Child | Parent | Many deriving (Show, Eq)
 data Relation = Relation {
   relTable    :: Table
@@ -75,21 +74,47 @@ data Relation = Relation {
 , relLCols2   :: Maybe [Column]
 } deriving (Show, Eq)
 
+data QualifiedIdentifier = QualifiedIdentifier {
+  qiSchema :: Maybe Schema
+, qiTable  :: TableName
+, qiColumn :: Maybe Text
+} | UnqualifiedIdentifier {
+  qiName   :: Text
+} deriving (Show, Eq, Ord)
 
-type Operator = Text
-data FValue = VText Text | VForeignKey QualifiedIdentifier ForeignKey deriving (Show, Eq)
-type FieldName = Text
+type Path = [Text]
 type JsonPath = [Text]
-type Field = (FieldName, Maybe JsonPath)
+type Operator = Text
+data FValue = VText Text | VForeignKey QualifiedIdentifier deriving (Show, Eq)
+type Field = (QualifiedIdentifier, Maybe JsonPath)
 type Cast = Text
 type NodeName = Text
 type SelectItem = (Field, Maybe Cast)
-type Path = [Text]
-data Query = Select { select::[SelectItem], from::[Text], where_::[Filter], order::Maybe [OrderTerm] }
-           | Insert { into::Text, fields::[Field], values::[[Value]] }
-           | Delete { from::[Text], where_::[Filter] }
-           | Update { into::Text, set::Map Field Value, where_::[Filter] } deriving (Show, Eq)
-data Filter = Filter {field::Field, operator::Operator, value::FValue} deriving (Show, Eq)
+
+data Query = Select {
+  select :: [SelectItem]
+, from   :: [QualifiedIdentifier]
+, where_ :: [Filter]
+, order  :: Maybe [OrderTerm]
+} | Insert {
+  into   :: QualifiedIdentifier
+, fields :: [Field]
+, values :: [[Value]]
+} | Delete {
+  from   :: [QualifiedIdentifier]
+, where_ :: [Filter]
+} | Update {
+  into   :: QualifiedIdentifier
+, set    :: Map Field Value
+, where_ :: [Filter]
+} deriving (Show, Eq)
+
+data Filter = Filter {
+  field    :: Field
+, operator :: Operator
+, value    :: FValue
+} deriving (Show, Eq)
+
 type ApiNode = (Query, (NodeName, Maybe Relation))
 type ApiRequest = Tree ApiNode
 
@@ -126,8 +151,7 @@ instance ToJSON Table where
     , "insertable" .= tableInsertable v ]
 
 instance Eq Table where
-  Table{tableSchema=s1,tableName=n1} == Table{tableSchema=s2,tableName=n2} = s1 == s2 && n1 == n2
+  t1 == t2 = tableQi t1 == tableQi t2
 
 instance Eq Column where
-  Column{colTable=t1,colName=n1} == Column{colTable=t2,colName=n2} = t1 == t2 && n1 == n2
-  _ == _ = False
+  c1 == c2 = colQi c1 == colQi c2


### PR DESCRIPTION
Currently, when it comes to `QualifiedIdentifier` the code can get very confusing. Column names are stored in weird places, for there to be no schema the value must be set to `""`, `VForeignKey` held a `QualifiedIdentifier` for the `Field` type which contained it, and there was no way to distinguish between un-qualified values and qualified ones. The parser module does not have access to `DbStructure` so it can't add the schema and/or table name, therefore the new `qualifyRequest` function takes an unqualified identifier and qualifies it in one place vs. the dangerous assumptions being made in multiple places throughout the code base.