### PR TITLE
Adds Api module to handle HTTP parsing using servant

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -61,6 +61,8 @@ executable postgrest
                      , parsec
                      , errors
                      , bifunctors
+                     , servant
+                     , servant-server
   hs-source-dirs:      src
   other-modules:       Paths_postgrest
                      , PostgREST.App
@@ -73,6 +75,7 @@ executable postgrest
                      , PostgREST.QueryBuilder
                      , PostgREST.RangeQuery
                      , PostgREST.Types
+                     , PostgREST.Api
 
 library
   if flag(ci)
@@ -124,6 +127,8 @@ library
                      , wai-extra
                      , wai-middleware-static
                      , warp
+                     , servant
+                     , servant-server
 
   Other-Modules:       Paths_postgrest
   Exposed-Modules:     PostgREST.App
@@ -136,6 +141,7 @@ library
                      , PostgREST.QueryBuilder
                      , PostgREST.RangeQuery
                      , PostgREST.Types
+                     , PostgREST.Api
   hs-source-dirs:      src
 
 Test-Suite spec
@@ -202,3 +208,5 @@ Test-Suite spec
                      , parsec
                      , errors
                      , bifunctors
+                     , servant
+                     , servant-server

--- a/src/PostgREST/Api.hs
+++ b/src/PostgREST/Api.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds         #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module PostgREST.Api (runTestServer) where
+
+import           Data.Aeson
+import           Data.Monoid
+import           Data.Proxy
+import           Data.Text
+import           GHC.Generics
+import           Network.Wai
+import           Network.Wai.Handler.Warp
+
+import           Data.String.Conversions (cs)
+import qualified Data.ByteString as B
+import Data.ByteString (ByteString)
+
+import           Servant
+import Servant.Server
+
+-- * Example
+
+-- | A greet message data type
+newtype ResultSet = ResultSet { _msg :: Text }
+  deriving (Generic, Show)
+
+instance FromJSON ResultSet
+instance ToJSON ResultSet
+
+instance MimeRender PlainText ResultSet where
+    mimeRender _ = cs . show
+
+data QueryString
+
+instance HasServer api => HasServer (QueryString :> api) where
+  -- Type level extension
+  type ServerT (QueryString :> api) m =
+    [(ByteString, Maybe ByteString)] -> ServerT api m
+  -- Implementation
+  route Proxy subServer req =
+    route (Proxy :: Proxy api) (subServer (queryString req)) req
+
+-- API specification
+type Api =
+  -- GET /:relation?parameters returns a Resultset as JSON
+  Capture "relation" Text :> QueryString :> Header "Prefer" Text :> Get '[JSON, PlainText] ResultSet
+
+  -- POST /:relation with data in request body and returns Resultset as JSON
+  :<|> Capture "relation" Text :> ReqBody '[JSON] ResultSet :> Post '[JSON] ResultSet
+
+  -- POST /rpc/:procedure with data in request body and returns Resultset as JSON
+  :<|> "rpc" :> Capture "procedure" Text :> ReqBody '[JSON] ResultSet :> Post '[JSON] ResultSet
+
+  -- PATCH /:relation?parameters with data in request body and returns Resultset as JSON
+  :<|> Capture "relation" Text :> QueryString :> ReqBody '[JSON] ResultSet :> Patch '[JSON] ResultSet
+
+  -- DELETE /:relation?parameters returns a Resultset as JSON
+  :<|> Capture "relation" Text :> Delete '[JSON] ResultSet
+
+testApi :: Proxy Api
+testApi = Proxy
+
+-- Server-side handlers.
+--
+-- There's one handler per endpoint, which, just like in the type
+-- that represents the API, are glued together using :<|>.
+--
+-- Each handler runs in the 'ExceptT ServantErr IO' monad.
+server :: Server Api
+server = readData :<|> insertData :<|> callProc :<|> updateData :<|> removeData
+  where 
+    readData relation qs prefer = return . ResultSet $ "Reading data"
+    insertData relation rows = return . ResultSet $ "Inserting data"
+    callProc procedure parameters = return . ResultSet $ "Inserting data"
+    updateData relation parameters rows = return . ResultSet $ "Updating data"
+    removeData relation = return . ResultSet $ "Removing data"
+
+-- Turn the server into a WAI app. 'serve' is provided by servant,
+-- more precisely by the Servant.Server module.
+test :: Application
+test = serve testApi server
+
+-- Run the server.
+--
+-- 'run' comes from Network.Wai.Handler.Warp
+runTestServer :: Port -> IO ()
+runTestServer port = run port test

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 
+import           PostgREST.Api (runTestServer)
 import           PostgREST.App
 import           PostgREST.Config                     (AppConfig (..),
                                                        minimumPgVersion,
@@ -71,8 +72,11 @@ main = do
   dbOrError <- H.session pool $ H.tx txSettings $ getDbStructure (cs $ configSchema conf)
   dbStructure <- either hasqlError return dbOrError
 
+  runTestServer 8001
+  {-
   runSettings appSettings $ middle $ \ req respond -> do
     body <- strictRequestBody req
     resOrError <- liftIO $ H.session pool $ H.tx txSettings $
       runWithClaims conf (app dbStructure conf body) req
     either (respond . pgErrResponse) respond resOrError
+  -}


### PR DESCRIPTION
First, this PR is just to discuss the approach, so it's totally incomplete but I wanted to have a green light before spending any more time.

The idea is to isolate the Api design from it's implementation (as we've been discussing), with servant the whole Api shape gets nicely encapsulated in a Api type.

We can extend servant and add any combinators we like to extract info from the HTTP request. There is an example in which I extract the whole queryString to a list here:
```haskell
instance HasServer api => HasServer (QueryString :> api) where
```

More examples of how to extend servant are found here: http://haskell-servant.github.io/extending.html

Servant also solves the content type problem in a very elegant way, for we can provide different instances for our result data type and define in this instance how to serve it.
This can be seen here where I've defined an instance for PlainText:
```haskell
instance MimeRender PlainText ResultSet where
    mimeRender _ = cs . show
```
More can be read here:
http://haskell-servant.github.io/tutorial/server.html#using-content-types-with-your-data-types

Overall it seems a very thin layer, would not add a lot of overhead (although it's relies heavily on several GHC extensions) and would encapsulate a big chunk of our custom code that deals with HTTP.