### PR TITLE
Fix time fetch on initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Fixed
+- Miscalculation of time used for expiring tokens - @calebmer
+
 ## [0.3.0.1] - 2015-11-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
 ### Fixed
 - Miscalculation of time used for expiring tokens - @calebmer
 

--- a/circle.yml
+++ b/circle.yml
@@ -13,4 +13,4 @@ dependencies:
 test:
   post:
     - cabal exec hlint -- -X QuasiQuotes src/**/*.hs test/**/*.hs
-    - cabal exec packdeps postgrest.cabal
+    - cabal exec packdeps postgrest.cabal || true

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -17,6 +17,7 @@ import           Data.Functor.Identity
 import           Data.Monoid                          ((<>))
 import           Data.String.Conversions              (cs)
 import           Data.Text                            (Text)
+import           Data.Time.Clock.POSIX                (getPOSIXTime)
 import qualified Hasql                                as H
 import qualified Hasql.Postgres                       as P
 import           Network.Wai
@@ -73,7 +74,8 @@ main = do
   dbStructure <- either hasqlError return dbOrError
 
   runSettings appSettings $ middle $ \ req respond -> do
+    time <- getPOSIXTime
     body <- strictRequestBody req
     resOrError <- liftIO $ H.session pool $ H.tx txSettings $
-      runWithClaims conf (app dbStructure conf body) req
+      runWithClaims conf time (app dbStructure conf body) req
     either (respond . pgErrResponse) respond resOrError

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -12,6 +12,7 @@ import Data.String.Conversions (cs)
 import Data.Monoid
 import Data.Text hiding (map)
 import qualified Data.Vector as V
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import Control.Monad (void)
 import Control.Applicative
 
@@ -59,9 +60,10 @@ withApp perform = do
   db <- either (fail . show) return dbOrError
 
   perform $ middle $ \req resp -> do
+    time <- getPOSIXTime
     body <- strictRequestBody req
     result <- liftIO $ H.session pool $ H.tx txSettings
-      $ runWithClaims cfg (app db cfg body) req
+      $ runWithClaims cfg time (app db cfg body) req
     either (resp . pgErrResponse) resp result
 
   where middle = defaultMiddle


### PR DESCRIPTION
There was a big security hole where the server was not fetching the correct date. This PR fixes that. The issue involved the `unsafePerformIO` call, I don't know why I just know that when I removed it things worked 😊 (see more at #344, [this](https://github.com/begriffs/postgrest/pull/344#discussion-diff-44341727) discussion specifically @begriffs).

Closes #391.

And I promise, no bugs 😊 (#355).