### PR TITLE
Detect relations event when authenticator does not have rights to intermediate tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Miscalculation of time used for expiring tokens - @calebmer
 - Remove bcrypt dependency to fix Windows build - @begriffs
+- Detect relations event when authenticator does not have rights to intermediate tables - @ruslantalpa 
 
 ### Added
 - Allow order by computed columns - @diogob


### PR DESCRIPTION
This issue might also be a problem for functions like allPrimaryKeys, allColumns because they also use information_schema ... this needs investigation.

While debugging this i was confronted with the fact i could not clearly see where the problem is because the the old way of getting all the relations from the query was changed to getting the info in 2 stages.

I am planning on changing this in the future so that the query returns all the relations directly and eliminate the need  for the functions in this line
```
let rels' = (addManyToManyRelations . raiseRelations schema syns . addParentRelations . addSynonymousRelations syns) rels
 ```

so i am going to post the current query here to have it documented
```
    /*
    -- CTE to get the original columns reference in views
    -- it returns results in the folowing format

    -- "src_table_schema","src_table_name","src_column_name","syn_table_schema","syn_table_name","syn_column_name"
    -- "basic_auth","users","email","public","authors","email"
    */
    WITH syns AS (
        WITH synonyms AS (
          /*
          -- CTE to replace the view from information_schema because the information in it depended on the logged in role
          -- notice the commented line
          */
          WITH view_column_usage AS (
            SELECT DISTINCT
                   CAST(current_database() AS character varying) AS view_catalog,
                   CAST(nv.nspname AS character varying) AS view_schema,
                   CAST(v.relname AS character varying) AS view_name,
                   CAST(current_database() AS character varying) AS table_catalog,
                   CAST(nt.nspname AS character varying) AS table_schema,
                   CAST(t.relname AS character varying) AS table_name,
                   CAST(a.attname AS character varying) AS column_name
            FROM pg_namespace nv, pg_class v, pg_depend dv,
                 pg_depend dt, pg_class t, pg_namespace nt,
                 pg_attribute a
            WHERE nv.oid = v.relnamespace
                  AND v.relkind = 'v'
                  AND v.oid = dv.refobjid
                  AND dv.refclassid = 'pg_catalog.pg_class'::regclass
                  AND dv.classid = 'pg_catalog.pg_rewrite'::regclass
                  AND dv.deptype = 'i'
                  AND dv.objid = dt.objid
                  AND dv.refobjid <> dt.refobjid
                  AND dt.classid = 'pg_catalog.pg_rewrite'::regclass
                  AND dt.refclassid = 'pg_catalog.pg_class'::regclass
                  AND dt.refobjid = t.oid
                  AND t.relnamespace = nt.oid
                  AND t.relkind IN ('r', 'v', 'f')
                  AND t.oid = a.attrelid
                  AND dt.refobjsubid = a.attnum
                  /*--AND pg_has_role(t.relowner, 'USAGE')*/
          )
          SELECT
            vcu.table_schema AS src_table_schema,
            vcu.table_name AS src_table_name,
            vcu.column_name AS src_column_name,
            view.schemaname AS syn_table_schema,
            view.viewname AS syn_table_name,
            view.definition AS view_definition
          FROM
            pg_catalog.pg_views AS view,
            view_column_usage AS vcu
          WHERE
            view.schemaname = vcu.view_schema AND
            view.viewname = vcu.view_name AND
            view.schemaname NOT IN ('pg_catalog', 'information_schema')
            /*--AND (SELECT COUNT(*) FROM information_schema.view_table_usage WHERE view_schema = view.schemaname AND view_name = view.viewname) = 1*/
        )
        SELECT
          src_table_schema, src_table_name, src_column_name,
          syn_table_schema, syn_table_name,
          (regexp_matches(view_definition, CONCAT('\.(', src_column_name, ')(?=,|$)'), 'gn'))[1] AS syn_column_name
        FROM synonyms
        UNION (
          SELECT
            src_table_schema, src_table_name, src_column_name,
            syn_table_schema, syn_table_name,
            (regexp_matches(view_definition, CONCAT('\.', src_column_name, '\sAS\s("?)(.+?)\1(,|$)'), 'gn'))[2] AS syn_column_name /* " <- for syntax highlighting */
          FROM synonyms
        )
    ),
    
    /*
    -- CTE to get the relations between tables based on foreign keys
    -- the returned format is
    -- "table_schema","table_name","columns","foreign_table_schema","foreign_table_name","foreign_columns"
    -- "public","posts","{author}","basic_auth","users","{email}"
    */

    table_fk AS (
      SELECT ns1.nspname AS table_schema,
             tab.relname AS table_name,
             column_info.cols AS columns,
             ns2.nspname AS foreign_table_schema,
             other.relname AS foreign_table_name,
             column_info.refs AS foreign_columns
      FROM pg_constraint,
         LATERAL (SELECT array_agg(cols.attname) AS cols,
                         array_agg(cols.attnum)  AS nums,
                         array_agg(refs.attname) AS refs
                    FROM ( SELECT unnest(conkey) AS col, unnest(confkey) AS ref) k,
                         LATERAL (SELECT * FROM pg_attribute
                                   WHERE attrelid = conrelid AND attnum = col)
                              AS cols,
                         LATERAL (SELECT * FROM pg_attribute
                                   WHERE attrelid = confrelid AND attnum = ref)
                              AS refs)
              AS column_info,
         LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = connamespace) AS ns1,
         LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = conrelid) AS tab,
         LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = confrelid) AS other,
         LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = other.relnamespace) AS ns2
      WHERE confrelid != 0
      ORDER BY (conrelid, column_info.nums)
    )

    /*
    -- The main result is generated by concatinating data from table_fk CTE
    -- then appending data based on table_fk CTE where we "rename" some items based on data from syns CTE
    */
    
    SELECT * FROM table_fk
    UNION
    (
        SELECT
            table_fk.table_schema,
            table_fk.table_name,
            table_fk.columns,
            vcu.syn_table_schema AS foreign_table_schema,
            vcu.syn_table_name AS foreign_table_name,
            array_agg(vcu.syn_column_name::text) AS foreign_columns
        FROM syns AS vcu
        JOIN table_fk ON
            table_fk.foreign_table_schema = vcu.src_table_schema AND
            table_fk.foreign_table_name = vcu.src_table_name AND
            vcu.src_column_name = ANY (table_fk.foreign_columns)
        WHERE
          foreign_columns = table_fk.foreign_columns
        GROUP BY table_fk.table_schema, table_fk.table_name, vcu.syn_table_schema, vcu.syn_table_name, table_fk.columns
    )
    UNION
    (
        SELECT
            vcu.syn_table_schema AS table_schema,
            vcu.syn_table_name AS table_name,
            array_agg(vcu.syn_column_name::text) AS columns,
            table_fk.foreign_table_schema,
            table_fk.foreign_table_name,
            table_fk.foreign_columns
        FROM syns AS vcu
        JOIN table_fk ON
            table_fk.table_schema = vcu.src_table_schema AND
            table_fk.table_name = vcu.src_table_name AND
            vcu.src_column_name = ANY (table_fk.columns)
        WHERE
            columns = table_fk.columns
        GROUP BY vcu.syn_table_schema, vcu.syn_table_name, table_fk.foreign_table_schema, table_fk.foreign_table_name, table_fk.foreign_columns
    )

```