### PR TITLE
Add --max-rows option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Allow order by computed columns - @diogob
+- Set max rows in response with --max-rows - @begriffs
 
 ## [0.3.0.1] - 2015-11-27
 

--- a/docs/install/server.md
+++ b/docs/install/server.md
@@ -92,6 +92,10 @@ The possible flags are:
 <dd>Max connections to use in db pool. Defaults to to 10, but you
     should find an optimal value for your db by running the SQL
     command <code>show max_connections;</code></dd>
+
+<dt>-m, --max-rows</dt>
+<dd>Max number of rows to return in a read request. The default is
+    no limit.</dd>
 </dl>
 
 <div class="admonition note">

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -45,6 +45,7 @@ executable postgrest
                      , parsec
                      , postgrest
                      , regex-tdfa
+                     , safe >= 0.3 && < 0.4
                      , scientific
                      , string-conversions
                      , text
@@ -98,6 +99,7 @@ library
                      , optparse-applicative
                      , parsec
                      , regex-tdfa
+                     , safe
                      , scientific
                      , string-conversions
                      , text
@@ -181,6 +183,7 @@ Test-Suite spec
                      , parsec
                      , process
                      , regex-tdfa
+                     , safe
                      , scientific
                      , string-conversions
                      , text

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -20,7 +20,7 @@ import           PostgREST.RangeQuery    (NonnegRange, rangeRequested)
 import           PostgREST.Types         (QualifiedIdentifier (..),
                                           Schema, Payload(..),
                                           UniformObjects(..))
-import           Data.Ranged.Ranges      (singletonRange)                                          
+import           Data.Ranged.Ranges      (singletonRange)
 
 type RequestBody = BL.ByteString
 
@@ -51,7 +51,7 @@ data ApiRequest = ApiRequest {
   -- | Set to Nothing for unknown HTTP verbs
     iAction :: Action
   -- | Set to Nothing for malformed range
-  , iRange  :: Maybe NonnegRange
+  , iRange  :: NonnegRange
   -- | Set to Nothing for strangely nested urls
   , iTarget :: Target
   -- | The content type the client most desires (or JSON if undecided)
@@ -115,7 +115,7 @@ userApiRequest schema req reqBody =
 
   ApiRequest {
     iAction = action
-  , iRange  = if singular then Just (singletonRange 0) else rangeRequested hdrs
+  , iRange  = if singular then singletonRange 0 else rangeRequested hdrs
   , iTarget = target
   , iAccepts = pickContentType $ lookupHeader "accept"
   , iPayload = relevantPayload

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -30,6 +30,7 @@ import           Network.Wai
 import           Network.Wai.Middleware.Cors (CorsResourcePolicy (..))
 import           Options.Applicative
 import           Paths_postgrest             (version)
+import           Safe                        (readMay)
 import           Web.JWT                     (Secret, secret)
 import           Prelude
 
@@ -41,6 +42,7 @@ data AppConfig = AppConfig {
   , configSchema    :: String
   , configJwtSecret :: Secret
   , configPool      :: Int
+  , configMaxRows   :: Maybe Int
   }
 
 argParser :: Parser AppConfig
@@ -53,6 +55,7 @@ argParser = AppConfig
   <*> (secret . cs <$>
       strOption    (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET" <> value "secret" <> showDefault))
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)
+  <*> (readMay <$> strOption  (long "max-rows"   <> short 'm' <> help "max rows in response" <> metavar "COUNT" <> value "infinity" <> showDefault))
 
 defaultCorsPolicy :: CorsResourcePolicy
 defaultCorsPolicy =  CorsResourcePolicy Nothing

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -12,7 +12,7 @@ import SpecHelper
 spec :: Spec
 spec = beforeAll
   (clearTable "postgrest.auth") . afterAll_ (clearTable "postgrest.auth")
-  $ around withApp
+  $ around (withApp cfgDefault)
   $ describe "authorization" $ do
 
   it "hides tables that anonymous does not own" $

--- a/test/Feature/CorsSpec.hs
+++ b/test/Feature/CorsSpec.hs
@@ -12,7 +12,7 @@ import Network.HTTP.Types
 -- }}}
 
 spec :: Spec
-spec = around withApp $ describe "CORS" $ do
+spec = around (withApp cfgDefault) $ describe "CORS" $ do
     let preflightHeaders = [
           ("Accept", "*/*"),
           ("Origin", "http://example.com"),

--- a/test/Feature/DeleteSpec.hs
+++ b/test/Feature/DeleteSpec.hs
@@ -8,7 +8,7 @@ import Network.HTTP.Types
 
 spec :: Spec
 spec = beforeAll (clearTable "items" >> createItems 15) . afterAll_ (clearTable "items")
-  . around withApp $
+  . around (withApp cfgDefault) $
   describe "Deleting" $ do
     context "existing record" $ do
       it "succeeds with 204 and deletion count" $

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -17,7 +17,7 @@ import Control.Monad (replicateM_)
 import TestTypes(IncPK(..), CompoundPK(..))
 
 spec :: Spec
-spec = afterAll_ resetDb $ around withApp $ do
+spec = afterAll_ resetDb $ around (withApp cfgDefault) $ do
   describe "Posting new record" $ do
     after_ (clearTable "menagerie") . context "disparate csv types" $ do
       it "accepts disparate json types" $ do

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -12,8 +12,7 @@ spec :: Spec
 spec =
   beforeAll (clearTable "items" >> createItems 15)
    . afterAll_ (clearTable "items")
-   . around (withApp $ cfgLimitRows 3) $ do
-
+   . around (withApp $ cfgLimitRows 3) $
   describe "Requesting many items with server limits enabled" $ do
     it "restricts results" $
       get "/items"

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -1,0 +1,32 @@
+module Feature.QueryLimitedSpec where
+
+import Test.Hspec hiding (pendingWith)
+import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
+import Network.HTTP.Types
+import Network.Wai.Test (SResponse(simpleHeaders, simpleStatus))
+
+import SpecHelper
+
+spec :: Spec
+spec =
+  beforeAll (clearTable "items" >> createItems 15)
+   . afterAll_ (clearTable "items")
+   . around (withApp $ cfgLimitRows 3) $ do
+
+  describe "Requesting many items with server limits enabled" $ do
+    it "restricts results" $
+      get "/items"
+        `shouldRespondWith` ResponseMatcher {
+          matchBody    = Just [json| [{"id":1},{"id":2},{"id":3}] |]
+        , matchStatus  = 206
+        , matchHeaders = ["Content-Range" <:> "0-2/15"]
+        }
+
+    it "respects additional client limiting" $ do
+      r <- request methodGet  "/items"
+                   (rangeHdrs $ ByteRangeFromTo 0 1) ""
+      liftIO $ do
+        simpleHeaders r `shouldSatisfy`
+          matchHeader "Content-Range" "0-1/15"
+        simpleStatus r `shouldBe` partialContent206

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -22,7 +22,7 @@ spec =
        createLikableStrings >>
        createJsonData)
    . afterAll_ (clearTable "items" >> clearTable "complex_items" >> clearTable "no_pk" >> clearTable "simple_pk")
-   . around withApp $ do
+   . around (withApp cfgDefault) $ do
 
   describe "Querying a table with a column called count" $
     it "should not confuse count column with pg_catalog.count aggregate" $

--- a/test/Feature/RangeSpec.hs
+++ b/test/Feature/RangeSpec.hs
@@ -10,7 +10,7 @@ import SpecHelper
 
 spec :: Spec
 spec = beforeAll (clearTable "items" >> createItems 15) . afterAll_ (clearTable "items")
-  . around withApp $
+  . around (withApp cfgDefault) $
   describe "GET /items" $ do
 
     context "without range headers" $ do

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -9,7 +9,7 @@ import SpecHelper
 import Network.HTTP.Types
 
 spec :: Spec
-spec = around withApp $ do
+spec = around (withApp cfgDefault) $ do
   describe "GET /" $ do
     it "lists views in schema" $
       request methodGet "/" [] ""

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -42,7 +42,7 @@ isLeft (Left _ ) = True
 isLeft _ = False
 
 cfg :: AppConfig
-cfg = AppConfig dbString 3000 "postgrest_anonymous" "test" (secret "safe") 10
+cfg = AppConfig dbString 3000 "postgrest_anonymous" "test" (secret "safe") 10 Nothing
 
 testPoolOpts :: PoolSettings
 testPoolOpts = fromMaybe (error "bad settings") $ H.poolSettings 1 30

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -41,8 +41,13 @@ isLeft :: Either a b -> Bool
 isLeft (Left _ ) = True
 isLeft _ = False
 
-cfg :: AppConfig
-cfg = AppConfig dbString 3000 "postgrest_anonymous" "test" (secret "safe") 10 Nothing
+cfgDefault :: AppConfig
+cfgDefault = AppConfig dbString 3000 "postgrest_anonymous" "test" (secret "safe") 10 Nothing
+
+cfgLimitRows :: Int -> AppConfig
+cfgLimitRows limit =
+  AppConfig dbString 3000 "postgrest_anonymous" "test"
+    (secret "safe") 10 (Just limit)
 
 testPoolOpts :: PoolSettings
 testPoolOpts = fromMaybe (error "bad settings") $ H.poolSettings 1 30
@@ -50,20 +55,20 @@ testPoolOpts = fromMaybe (error "bad settings") $ H.poolSettings 1 30
 pgSettings :: P.Settings
 pgSettings = P.StringSettings $ cs dbString
 
-withApp :: ActionWith Application -> IO ()
-withApp perform = do
+withApp :: AppConfig -> ActionWith Application -> IO ()
+withApp config perform = do
   pool :: H.Pool P.Postgres
     <- H.acquirePool pgSettings testPoolOpts
 
   let txSettings = Just (H.ReadCommitted, Just True)
-  dbOrError <- H.session pool $ H.tx txSettings $ getDbStructure (cs $ configSchema cfg)
+  dbOrError <- H.session pool $ H.tx txSettings $ getDbStructure (cs $ configSchema config)
   db <- either (fail . show) return dbOrError
 
   perform $ middle $ \req resp -> do
     time <- getPOSIXTime
     body <- strictRequestBody req
     result <- liftIO $ H.session pool $ H.tx txSettings
-      $ runWithClaims cfg time (app db cfg body) req
+      $ runWithClaims config time (app db config body) req
     either (resp . pgErrResponse) resp result
 
   where middle = defaultMiddle


### PR DESCRIPTION
Add command line option to limit the number of rows ever returned by any read request. This does not apply to inserting rows with `Prefer: return=representation`. All those kind of rows would be returned possibly in excess of the read row limit.

Also `rangeParse` now always returns a range, no more Maybe. Where it would have returned maybe before it now returns the unbounded range starting from 0. This simplifies other parts of the code.