### PR TITLE
Release db connections on sigint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Miscalculation of time used for expiring tokens - @calebmer
 - Remove bcrypt dependency to fix Windows build - @begriffs
 - Detect relations event when authenticator does not have rights to intermediate tables - @ruslantalpa 
+- Ensure db connections released on sigint - @begriffs
 
 ### Added
 - Allow order by computed columns - @diogob

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -61,6 +61,7 @@ executable postgrest
                      , HTTP, http-types
                      , MissingH
                      , Ranged-sets
+                     , unix >= 2.7 && < 3
 
   hs-source-dirs:      src
   other-modules:       Paths_postgrest

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -74,7 +74,6 @@ main = do
 
   tid <- myThreadId
   void $ installHandler keyboardSignal (Catch $ do
-      putStrLn "\nReleasing connection pool..."
       H.releasePool pool
       throwTo tid UserInterrupt
     ) Nothing

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -6,9 +6,9 @@ import           PostgREST.Config                     (AppConfig (..),
                                                        minimumPgVersion,
                                                        prettyVersion,
                                                        readOptions)
-import           PostgREST.Error                      (pgErrResponse, PgError)
-import           PostgREST.Middleware
 import           PostgREST.DbStructure
+import           PostgREST.Error                      (PgError, pgErrResponse)
+import           PostgREST.Middleware
 
 import           Control.Concurrent                   (myThreadId)
 import           Control.Exception.Base               (throwTo, AsyncException(..))

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -10,7 +10,9 @@ import           PostgREST.Error                      (pgErrResponse, PgError)
 import           PostgREST.Middleware
 import           PostgREST.DbStructure
 
-import           Control.Monad                        (unless)
+import           Control.Concurrent                   (myThreadId)
+import           Control.Exception.Base               (throwTo, AsyncException(..))
+import           Control.Monad                        (unless, void)
 import           Control.Monad.IO.Class               (liftIO)
 import           Data.Aeson                           (encode)
 import           Data.Functor.Identity
@@ -26,6 +28,7 @@ import           Network.Wai.Middleware.RequestLogger (logStdout)
 import           System.IO                            (BufferMode (..),
                                                        hSetBuffering, stderr,
                                                        stdin, stdout)
+import           System.Posix.Signals
 import           Web.JWT                              (secret)
 
 isServerVersionSupported :: H.Session P.Postgres IO Bool
@@ -68,6 +71,13 @@ main = do
           "Cannot run in this PostgreSQL version, PostgREST needs at least "
           <> show minimumPgVersion)
     ) supportedOrError
+
+  tid <- myThreadId
+  void $ installHandler keyboardSignal (Catch $ do
+      putStrLn "\nReleasing connection pool..."
+      H.releasePool pool
+      throwTo tid UserInterrupt
+    ) Nothing
 
   let txSettings = Just (H.ReadCommitted, Just True)
   dbOrError <- H.session pool $ H.tx txSettings $ getDbStructure (cs $ configSchema conf)


### PR DESCRIPTION
When I interrupt the program with ctrl-c I see it print out the message, "Releasing connection pool...". Other than that I'm not sure if it changes the behavior of the program. To manually test I run this command in another terminal:

```bash
watch "psql -d postgrest_test -c 'SELECT sum(numbackends) FROM pg_stat_database;'" 
```

When PostgREST is not running the count is 1 because of psql itself. Once the server starts the count goes to 2. When I ctrl-c the server it goes back down to 1. The decreasing to 1 happens with or without the code in this pull request though.

@monemihir can you check if this pull request helps? I'm not sure how else to test it.