### PR TITLE
Test and fixes for #407 #403 #107

### DIFF
--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -211,6 +211,11 @@ spec = around (withApp cfgDefault) $ do
       get "/users_tasks?user_id=eq.2&task_id=eq.6&select=*, comments{content}" `shouldRespondWith`
         "[{\"user_id\":2,\"task_id\":6,\"comments\":[{\"content\":\"Needs to be delivered ASAP\"}]}]"
 
+    it "detect relations in views from exposed schema that are based on tables in private schema and have columns renames" $
+      get "/articles?id=eq.1&select=id,articleStars{users{*}}" `shouldRespondWith`
+        [str|[{"id":1,"articlestars":[{"users":{"id":1,"name":"Angela Martin"}},{"users":{"id":2,"name":"Michael Scott"}},{"users":{"id":3,"name":"Dwight Schrute"}}]}]|]
+
+
   describe "Plurality singular" $ do
     it "will select an existing object" $
       request methodGet "/items?id=eq.5" [("Prefer","plurality=singular")] ""

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -208,16 +208,14 @@ spec = around (withApp cfgDefault) $ do
       }
       |]
 
-    it "includes foreign key data" $ do
-      pendingWith "have to resolve issue #107"
-
+    it "includes foreign key data" $
       request methodOptions "/has_fk" [] ""
         `shouldRespondWith` [json|
       {
         "pkey": ["id"],
         "columns":[
           {
-            "default": "nextval('\"1\".has_fk_id_seq'::regclass)",
+            "default": "nextval('test.has_fk_id_seq'::regclass)",
             "precision": 64,
             "updatable": true,
             "schema": "test",
@@ -239,7 +237,7 @@ spec = around (withApp cfgDefault) $ do
             "nullable": true,
             "position": 2,
             "enum": [],
-            "references": {"table": "auto_incrementing_pk", "column": "id"}
+            "references": {"schema":"test", "table": "auto_incrementing_pk", "column": "id"}
           }, {
             "default": null,
             "precision": null,
@@ -251,14 +249,13 @@ spec = around (withApp cfgDefault) $ do
             "nullable": true,
             "position": 3,
             "enum": [],
-            "references": {"table": "simple_pk", "column": "k"}
+            "references": {"schema":"test", "table": "simple_pk", "column": "k"}
           }
         ]
       }
       |]
 
-    it "includes all information on views for renamed columns, and raises relations to correct schema" $ do
-      pendingWith "have to resolve issue #107"
+    it "includes all information on views for renamed columns, and raises relations to correct schema" $
       request methodOptions "/articleStars" [] ""
         `shouldRespondWith` [json|
           {


### PR DESCRIPTION
This PR adds tests for a weak authenticator #407, and ads a check for detecting relations #403
A good side effect is it fixes also an old issue #107 (test passing, it can be closed).

One thing i noticed is that test got a lot slower from 20s to 90s.
The only major thing that changed is that we rely on CTE instead of information_schema and the new queries take about 500ms to execute. Since the queries in the dbstructure are executed only once in the beginning i don't think it will impact runtime performance however i think that these queries are somehow rerun at each test. 
Can anyone spot why this is happening and maybe fix it in a separate PR?  