### PR TITLE
Fix #396 include records with missing parents and return [] instead of  null for missing children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Miscalculation of time used for expiring tokens - @calebmer
 - Remove bcrypt dependency to fix Windows build - @begriffs
-- Detect relations event when authenticator does not have rights to intermediate tables - @ruslantalpa 
+- Detect relations event when authenticator does not have rights to intermediate tables - @ruslantalpa
 - Ensure db connections released on sigint - @begriffs
+- Fix #396 include records with missing parents - @ruslantalpa
 
 ### Added
 - Allow order by computed columns - @diogob

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -45,10 +45,10 @@ spec = beforeAll_ resetDb $ around (withApp cfgDefault) $ do
 
       it "includes related data after insert" $
         request methodPost "/projects?select=id,name,clients{id,name}" [("Prefer", "return=representation")]
-          [str|{"id":5,"name":"New Project","client_id":2}|] `shouldRespondWith` ResponseMatcher {
-            matchBody    = Just [str|{"id":5,"name":"New Project","clients":{"id":2,"name":"Apple"}}|]
+          [str|{"id":6,"name":"New Project","client_id":2}|] `shouldRespondWith` ResponseMatcher {
+            matchBody    = Just [str|{"id":6,"name":"New Project","clients":{"id":2,"name":"Apple"}}|]
           , matchStatus  = 201
-          , matchHeaders = ["Content-Type" <:> "application/json", "Location" <:> "/projects?id=eq.5"]
+          , matchHeaders = ["Content-Type" <:> "application/json", "Location" <:> "/projects?id=eq.6"]
           }
 
 

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -195,13 +195,21 @@ spec = around (withApp cfgDefault) $ do
       get "/projects?id=eq.1&select=id, name, clients{id}" `shouldRespondWith`
         "[{\"id\":1,\"name\":\"Windows 7\",\"clients\":{\"id\":1}}]"
 
+    it "rows with missing parents are included" $
+      get "/projects?id=in.1,5&select=id,clients{id}" `shouldRespondWith`
+        "[{\"id\":1,\"clients\":{\"id\":1}},{\"id\":5,\"clients\":null}]"
+
+    it "rows with no children return [] instead of null" $
+      get "/projects?id=in.5&select=id,tasks{id}" `shouldRespondWith`
+        [str|[{"id":5,"tasks":[]}]|]
+
     it "requesting children 2 levels" $
       get "/clients?id=eq.1&select=id,projects{id,tasks{id}}" `shouldRespondWith`
         "[{\"id\":1,\"projects\":[{\"id\":1,\"tasks\":[{\"id\":1},{\"id\":2}]},{\"id\":2,\"tasks\":[{\"id\":3},{\"id\":4}]}]}]"
 
     it "requesting many<->many relation" $
       get "/tasks?select=id,users{id}" `shouldRespondWith`
-        "[{\"id\":1,\"users\":[{\"id\":1},{\"id\":3}]},{\"id\":2,\"users\":[{\"id\":1}]},{\"id\":3,\"users\":[{\"id\":1}]},{\"id\":4,\"users\":[{\"id\":1}]},{\"id\":5,\"users\":[{\"id\":2},{\"id\":3}]},{\"id\":6,\"users\":[{\"id\":2}]},{\"id\":7,\"users\":[{\"id\":2}]},{\"id\":8,\"users\":null}]"
+        "[{\"id\":1,\"users\":[{\"id\":1},{\"id\":3}]},{\"id\":2,\"users\":[{\"id\":1}]},{\"id\":3,\"users\":[{\"id\":1}]},{\"id\":4,\"users\":[{\"id\":1}]},{\"id\":5,\"users\":[{\"id\":2},{\"id\":3}]},{\"id\":6,\"users\":[{\"id\":2}]},{\"id\":7,\"users\":[{\"id\":2}]},{\"id\":8,\"users\":[]}]"
 
     it "requesting parents and children on views" $
       get "/projects_view?id=eq.1&select=id, name, clients{*}, tasks{id, name}" `shouldRespondWith`

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -99,6 +99,7 @@ INSERT INTO projects VALUES (1, 'Windows 7', 1);
 INSERT INTO projects VALUES (2, 'Windows 10', 1);
 INSERT INTO projects VALUES (3, 'IOS', 2);
 INSERT INTO projects VALUES (4, 'OSX', 2);
+INSERT INTO projects VALUES (5, 'Orphan', NULL);
 
 
 --
@@ -263,4 +264,3 @@ INSERT INTO users_projects VALUES (3, 3);
 --
 -- PostgreSQL database dump complete
 --
-

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -890,4 +890,3 @@ ALTER TABLE ONLY users_tasks
 --
 -- PostgreSQL database dump complete
 --
-


### PR DESCRIPTION
Include records with missing parents and remove CTE related to parent relations.
Return [] instead of null for records that do not have children.