### PR TITLE
Fix #399 insert records in tables with no SELECT privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `pgFmtIdent` always quotes #388 - @calebmer
 - Default schema, changed from `"1"` to `public` - @calebmer
 - #414 revert to separate count query
+- Fix #399, allow inserting in tables with no select privileges using "Prefer: representation=minimal" - @ruslantalpa
 
 ### Added
 - Allow order by computed columns - @diogob

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -93,6 +93,15 @@ spec struct pool = beforeAll_ resetDb $ around (withApp cfgDefault struct pool) 
             simpleHeaders p `shouldSatisfy` matchHeader hLocation "/no_pk\\?a=eq.bar&b=eq.baz"
             simpleStatus p `shouldBe` created201
 
+        it "can insert in tables with no select privileges" $ do
+          p <- request methodPost "/insertonly"
+                       [("Prefer", "return=minimal")]
+                       [json| { "v":"some value" } |]
+          liftIO $ do
+            simpleBody p `shouldBe` ""
+            simpleStatus p `shouldBe` created201
+
+
         it "can post nulls" $ do
           p <- request methodPost "/no_pk"
                        [("Prefer", "return=representation")]

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -28,6 +28,7 @@ spec struct pool = around (withApp cfgDefault struct pool) $ do
         , {"schema":"test","name":"has_count_column","insertable":false}
         , {"schema":"test","name":"has_fk","insertable":true}
         , {"schema":"test","name":"insertable_view_with_join","insertable":true}
+        , {"schema":"test","name":"insertonly","insertable":true}
         , {"schema":"test","name":"items","insertable":true}
         , {"schema":"test","name":"json","insertable":true}
         , {"schema":"test","name":"materialized_view","insertable":false}

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -34,6 +34,8 @@ GRANT ALL ON TABLE
     , users_tasks
 TO postgrest_test_anonymous;
 
+GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;
+
 GRANT USAGE ON SEQUENCE
       auto_incrementing_pk_id_seq
     , items_id_seq

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -501,6 +501,15 @@ CREATE TABLE nullable_integer (
 
 
 --
+-- Name: insertonly; Type: TABLE; Schema: test; Owner: -
+--
+
+CREATE TABLE insertonly (
+    v text NOT NULL
+);
+
+
+--
 -- Name: projects; Type: TABLE; Schema: test; Owner: -
 --
 


### PR DESCRIPTION
This PR adds the possibility of insterting records in tables with no SELECT privileges if you supply the header
```
Prefer: return=none
```
I don't really like the idea of an extra header but i don't see a way around this. Also this "feature" made the code a bit dirtier, especially the "createWriteStatement"

Let's discuss the issue like so:
Is the extra header the right way to go?
   yes -> can the code that implements it be nicer?
   no -> how do we put an "IF" around the "RETURNING *" in SQL ?