### PR TITLE
Add docker file with configurable env vars

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2014 Joe Nelson
+Modified work Copyright 2015 Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,10 +26,10 @@ ENV POSTGREST_CONNECTION_POOL_SIZE 10
 ENV POSTGREST_JWT_SECRET secret
 ENV POSTGREST_SCHEMA public
 
-# Connstring shorthand variable
-ENV CONNSTRING postgres://${POSTGREST_DB_USER}:${POSTGREST_DB_PASS}@${POSTGREST_DB_HOST}:${POSTGREST_DB_PORT}/${POSTGREST_DB_NAME}
+# POSTGREST_CONNSTRING can be set as well. If not set it defaults to a
+# connstring constructed from the user, password, host, port, and db name vars
 
-CMD postgrest ${CONNSTRING} \
+CMD postgrest ${POSTGREST_CONNSTRING:=postgres://${POSTGREST_DB_USER}:${POSTGREST_DB_PASS}@${POSTGREST_DB_HOST}:${POSTGREST_DB_PORT}/${POSTGREST_DB_NAME}} \
               --port 3000 \
               --anonymous ${POSTGREST_ANON_USER} \
               --schema ${POSTGREST_SCHEMA} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:8.2
+
+ARG POSTGREST_VERSION
+
+# Shorthands to make commands easier to read
+ENV POSTGREST_DOWNLOAD postgrest-${POSTGREST_VERSION}-ubuntu.tar.xz
+ENV POSTGREST_RELEASES_URL http://github.com/begriffs/postgrest/releases/download/v${POSTGREST_VERSION}
+
+RUN apt-get update \
+  && apt-get install -y xz-utils wget libpq-dev \
+  && wget ${POSTGREST_RELEASES_URL}/${POSTGREST_DOWNLOAD} \
+  && tar xf ${POSTGREST_DOWNLOAD} \
+  && mv postgrest /usr/local/bin/postgrest \
+  && rm -f ${POSTGREST_DOWNLOAD} \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Public env vars, can be passed in as params
+ENV POSTGREST_DB_HOST db
+ENV POSTGREST_DB_PORT 5432
+ENV POSTGREST_DB_USER postgres
+ENV POSTGREST_DB_NAME ${POSTGREST_DB_USER}
+ENV POSTGREST_ANON_USER ${POSTGREST_DB_USER}
+ENV POSTGREST_DB_PASS ${POSTGREST_DB_USER}
+ENV POSTGREST_CONNECTION_POOL_SIZE 10
+ENV POSTGREST_JWT_SECRET secret
+ENV POSTGREST_SCHEMA public
+
+# Connstring shorthand variable
+ENV CONNSTRING postgres://${POSTGREST_DB_USER}:${POSTGREST_DB_PASS}@${POSTGREST_DB_HOST}:${POSTGREST_DB_PORT}/${POSTGREST_DB_NAME}
+
+CMD postgrest ${CONNSTRING} \
+              --port 3000 \
+              --anonymous ${POSTGREST_ANON_USER} \
+              --schema ${POSTGREST_SCHEMA} \
+              --jwt-secret ${POSTGREST_JWT_SECRET}
+
+EXPOSE 3000


### PR DESCRIPTION
This pull request adds a simple dockerfile that can be configured to build an image for any PostgREST version not less than 0.3 (due to the change in how flags are passed to postgrest).  It uses a build arg (`ARG POSTGREST_VERSION`) which is only available since docker 1.9. Older docker versions can still run the built images however.

The dockerfile has different defaults than postgrest does, in order to line up with the defaults for the Postgres image. For instance, assuming this is used to build a `postgrest:0.3.0.1` image, the following docker-compose.yml links a postgrest container to a postgres database container:

```yaml
postgrest:
  image: postgrest:0.3.0.1
  links:
    - db:db
db:
  image: postgres
```

This works because the postgrest image has configurable `POSTGREST_DB_USER`, `POSTGREST_DB_PASSWORD`, `POSTGREST_DB_HOST`, `POSTGREST_DB_PORT` env vars that default to values that happen to directly connect to a postgres database running at host "db" (the host inserted by the link) on port `5432` (default postgres port) with username and password both `postgrest` (the official postgres docker image's defaults). You can connect to an arbitrary postgres database (including an amazon one) not in a docker container by changing those variables, with no need for `external_links`.

Future work is to set up a docker hub image repository and push images for each version to it, so that docker users won't need to build anything themselves.

This PR also adds Google Inc. to the license due to legal requirements of my employment. This does not change the underlying license terms in any way, and approval for this PR was given through an automated process - Google has no desire to manage or interfere with this project. I can also request copyright myself for this PR, but that's subject to weeks of review and bureaucratic overhead and may not be approved.