### PR TITLE
ordering with DESC & NULLS LAST together

### DIFF
--- a/docs/api/reading.md
+++ b/docs/api/reading.md
@@ -169,6 +169,7 @@ If you care where nulls are sorted, add `nullsfirst` or `nullslast`:
 
 ```HTTP
 GET /people?order=age.nullsfirst
+GET /people?order=age.desc.nullslast
 ```
 
 You can also use [computed


### PR DESCRIPTION
One more sample query which is probably one of most useful ones in real life (by default, DESC ordering leads to NULLS FIRST option, this is not so clear for beginners), showing how to combine ordering direction and NULLS *** for the same column.