### PR TITLE
Fix failing test after test structure optimization

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -158,7 +158,6 @@ Test-Suite spec
                      , PostgREST.RangeQuery
                      , PostgREST.ApiRequest
                      , PostgREST.Types
-                     , Spec
                      , SpecHelper
                      , TestTypes
   Build-Depends:       aeson

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import Test.Hspec
 import SpecHelper
 
-import PostgREST.Types (DbStructure(..))
+--import PostgREST.Types (DbStructure(..))
 
 import qualified Feature.AuthSpec
 import qualified Feature.CorsSpec
@@ -23,16 +23,15 @@ main = do
 
   -- Not using hspec-discover because we want to precompute
   -- the db structure and pass it to specs for speed
-  mapM_ (hspec . ($ pool) . ($ dbStructure)) specs
+  hspec $ specs dbStructure pool
 
  where
-  specs = [
-      Feature.AuthSpec.spec
-    , Feature.CorsSpec.spec
-    , Feature.DeleteSpec.spec
-    , Feature.InsertSpec.spec
-    , Feature.QueryLimitedSpec.spec
-    , Feature.QuerySpec.spec
-    , Feature.RangeSpec.spec
-    , Feature.StructureSpec.spec
-    ]
+  specs dbStructure pool = do
+    describe "Feature.AuthSpec" $ Feature.AuthSpec.spec dbStructure pool
+    describe "Feature.CorsSpec" $ Feature.CorsSpec.spec dbStructure pool
+    describe "Feature.DeleteSpec" $ Feature.DeleteSpec.spec dbStructure pool
+    describe "Feature.InsertSpec" $ Feature.InsertSpec.spec dbStructure pool
+    describe "Feature.QueryLimitedSpec" $ Feature.QueryLimitedSpec.spec dbStructure pool
+    describe "Feature.QuerySpec" $ Feature.QuerySpec.spec dbStructure pool
+    describe "Feature.RangeSpec" $ Feature.RangeSpec.spec dbStructure pool
+    describe "Feature.StructureSpec" $ Feature.StructureSpec.spec dbStructure pool

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -56,7 +56,7 @@ specDbPool = H.acquirePool pgSettings testPoolOpts
 specDbStructure :: H.Pool P.Postgres -> IO DbStructure
 specDbStructure pool = do
   dbOrError <- H.session pool $ H.tx specTxSettings
-    $ getDbStructure "postgrest_test"
+    $ getDbStructure "test"
   either (fail . show) return dbOrError
 
 withApp :: AppConfig -> DbStructure -> H.Pool P.Postgres
@@ -116,4 +116,5 @@ clearTable table = do
   void . liftIO $ H.session pool $ H.tx Nothing $
     H.unitEx $ B.Stmt ("truncate table test." <> table <> " cascade") V.empty True
 
+specTxSettings :: Maybe (TxIsolationLevel, Maybe Bool)
 specTxSettings = Just (H.ReadCommitted, Just True)


### PR DESCRIPTION
The error was in specDbStructure
it's parameter is the name of the schema, you were calling it with the name of the db, strange how only this test was failing :)
I also changed the main, the previous version was running tests separately, now they are ran as a single one (the way it was before).

Please merge your branch into master and close my previous PR (since it's commit is included in this branch)