### PR TITLE
`pgFmtIdent` always quotes #388

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Detect relations event when authenticator does not have rights to intermediate tables - @ruslantalpa
 - Ensure db connections released on sigint - @begriffs
 - Fix #396 include records with missing parents - @ruslantalpa
+- `pgFmtIdent` always quotes #388 - @calebmer
 
 ### Added
 - Allow order by computed columns - @diogob

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -46,8 +46,6 @@ import           Data.Tree               (Tree(..))
 import qualified Data.Vector as V
 import           PostgREST.Types
 import qualified Data.Map as M
-import           Text.Regex.TDFA         ((=~))
-import qualified Data.ByteString.Char8   as BS
 import           Data.Scientific         ( FPFormat (..)
                                          , formatScientific
                                          , isInteger
@@ -166,12 +164,7 @@ operators = [
   ]
 
 pgFmtIdent :: SqlFragment -> SqlFragment
-pgFmtIdent x =
- let escaped = replace "\"" "\"\"" (trimNullChars $ cs x) in
- if (cs escaped :: BS.ByteString) =~ danger
-   then "\"" <> escaped <> "\""
-   else escaped
- where danger = "^$|^[^a-z_]|[^a-z_0-9]" :: BS.ByteString
+pgFmtIdent x = "\"" <> replace "\"" "\"\"" (trimNullChars $ cs x) <> "\""
 
 pgFmtLit :: SqlFragment -> SqlFragment
 pgFmtLit x =


### PR DESCRIPTION
While I was knocking around the PostgREST codebase I wanted to knock out some of the easy issues. There were two I found. It might be nice to have a tag to denote these issues, anyway this should close #388. From what I know quoting everything shouldn't be a problem, maybe @diogob should weigh in?