### PR TITLE
Change default schema #389

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Detect relations event when authenticator does not have rights to intermediate tables - @ruslantalpa
 - Ensure db connections released on sigint - @begriffs
 - Fix #396 include records with missing parents - @ruslantalpa
+- Default schema, changed from `"1"` to `public` - @calebmer
 
 ### Added
 - Allow order by computed columns - @diogob

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -51,7 +51,7 @@ argParser = AppConfig
 
   <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
   <*> strOption    (long "anonymous"  <> short 'a' <> help "postgres role to use for non-authenticated requests" <> metavar "ROLE")
-  <*> strOption    (long "schema"     <> short 's' <> help "schema to use for API routes" <> metavar "NAME" <> value "1" <> showDefault)
+  <*> strOption    (long "schema"     <> short 's' <> help "schema to use for API routes" <> metavar "NAME" <> value "public" <> showDefault)
   <*> (secret . cs <$>
       strOption    (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET" <> value "secret" <> showDefault))
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)


### PR DESCRIPTION
This was the second issue. Closes #389 and ends the versioning legacy ☺️

Except for all the API devs that are smart and still version their schemas…