### PR TITLE
#414 revert to separate count query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix #396 include records with missing parents - @ruslantalpa
 - `pgFmtIdent` always quotes #388 - @calebmer
 - Default schema, changed from `"1"` to `public` - @calebmer
+- #414 revert to separate count query
 
 ### Added
 - Allow order by computed columns - @diogob


### PR DESCRIPTION
For now i went with keeping the "pg_source" CTE and inlining the count query.
Besides counting, it's also used when dealing with CSV.
It's not the final version of the code (i want to remove the wrapQuery... functions, at this point i think they are in the way, it made sense when it was only one) but i wanted to PR this so that @diogob can check the performance of the generated query. @diogob please also look at the performance when the requested response needs to be in CSV format
If the query is good, then i will clean up a bit and do another commit here.