### PR TITLE
Use schema search path to enable real versioning

### DIFF
--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -45,29 +45,27 @@ getDbStructure schema = do
     }
 
 doesProc :: forall c s. B.CxValue c Int =>
-            (Text -> Text -> B.Stmt c) -> QualifiedIdentifier -> H.Tx c s Bool
-doesProc stmt qi = do
-  row :: Maybe (Identity Int) <- H.maybeEx $ stmt (qiSchema qi) (qiName qi)
+            (Text -> B.Stmt c) -> Text -> H.Tx c s Bool
+doesProc stmt proc = do
+  row :: Maybe (Identity Int) <- H.maybeEx $ stmt proc
   return $ isJust row
 
-doesProcExist :: QualifiedIdentifier -> H.Tx P.Postgres s Bool
+doesProcExist :: Text -> H.Tx P.Postgres s Bool
 doesProcExist = doesProc [H.stmt|
       SELECT 1
       FROM   pg_catalog.pg_namespace n
       JOIN   pg_catalog.pg_proc p
       ON     pronamespace = n.oid
-      WHERE  nspname = ?
-      AND    proname = ?
+      WHERE  proname = ?
     |]
 
-doesProcReturnJWT :: QualifiedIdentifier -> H.Tx P.Postgres s Bool
+doesProcReturnJWT :: Text -> H.Tx P.Postgres s Bool
 doesProcReturnJWT = doesProc [H.stmt|
       SELECT 1
       FROM   pg_catalog.pg_namespace n
       JOIN   pg_catalog.pg_proc p
       ON     pronamespace = n.oid
-      WHERE  nspname = ?
-      AND    proname = ?
+      WHERE  proname = ?
       AND    pg_catalog.pg_get_function_result(p.oid) like '%jwt_claims'
     |]
 

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -67,11 +67,6 @@ data OrderTerm = OrderTerm {
 , otNullOrder :: Maybe OrderNulls
 } deriving (Show, Eq)
 
-data QualifiedIdentifier = QualifiedIdentifier {
-  qiSchema :: Schema
-, qiName   :: TableName
-} deriving (Show, Eq)
-
 
 data RelationType = Child | Parent | Many deriving (Show, Eq)
 data Relation = Relation {
@@ -98,7 +93,7 @@ data Payload = PayloadJSON UniformObjects
              deriving (Show, Eq)
 
 type Operator = Text
-data FValue = VText Text | VForeignKey QualifiedIdentifier ForeignKey deriving (Show, Eq)
+data FValue = VText Text | VForeignKey TableName ForeignKey deriving (Show, Eq)
 type FieldName = Text
 type JsonPath = [Text]
 type Field = (FieldName, Maybe JsonPath)

--- a/test/Feature/VersionSpec.hs
+++ b/test/Feature/VersionSpec.hs
@@ -1,0 +1,25 @@
+module Feature.VersionSpec where
+
+-- {{{ Imports
+import Test.Hspec
+import Test.Hspec.Wai
+
+import Hasql as H
+import Hasql.Postgres as P
+
+import SpecHelper
+import PostgREST.Types (DbStructure(..))
+-- }}}
+
+spec :: DbStructure -> H.Pool P.Postgres -> Spec
+spec struct pool = around (withApp cfgTestV2Schema struct pool)
+  $ describe "versioning" $ do
+
+  it "hides tables not in v1 or v2 schemas" $
+    get "/private_schema_view" `shouldRespondWith` 404
+
+  it "can see a new view in v2" $
+    get "/new_v2" `shouldRespondWith` 200
+
+  it "can continue to see a route in v1" $
+    get "/items" `shouldRespondWith` 200

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,17 +13,21 @@ import qualified Feature.QueryLimitedSpec
 import qualified Feature.QuerySpec
 import qualified Feature.RangeSpec
 import qualified Feature.StructureSpec
+import qualified Feature.VersionSpec
 
 main :: IO ()
 main = do
   setupDb
 
   pool <- specDbPool
-  dbStructure <- specDbStructure pool
+  dbStructure <- specDbStructure pool "test"
+  dbStructureV2 <- specDbStructure pool "test_v2"
 
   -- Not using hspec-discover because we want to precompute
   -- the db structure and pass it to specs for speed
-  hspec $ specs dbStructure pool
+  hspec $ do
+    specs dbStructure pool
+    v2specs dbStructureV2 pool
 
  where
   specs dbStructure pool = do
@@ -35,3 +39,6 @@ main = do
     describe "Feature.QuerySpec" $ Feature.QuerySpec.spec dbStructure pool
     describe "Feature.RangeSpec" $ Feature.RangeSpec.spec dbStructure pool
     describe "Feature.StructureSpec" $ Feature.StructureSpec.spec dbStructure pool
+
+  v2specs dbStructure pool =
+    describe "Feature.VersionSpec" $ Feature.VersionSpec.spec dbStructure pool

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -35,14 +35,17 @@ import PostgREST.Types
 dbString :: String
 dbString = "postgres://postgrest_test_authenticator@localhost:5432/postgrest_test"
 
-cfg :: String -> Maybe Int -> AppConfig
-cfg conStr = AppConfig conStr 3000 "postgrest_test_anonymous" "test" (secret "safe") 10
+cfg :: String -> String -> Maybe Int -> AppConfig
+cfg conStr schema = AppConfig conStr 3000 "postgrest_test_anonymous" schema (secret "safe") 10
 
 cfgDefault :: AppConfig
-cfgDefault = cfg dbString Nothing
+cfgDefault = cfg dbString "test" Nothing
 
 cfgLimitRows :: Int -> AppConfig
-cfgLimitRows = cfg dbString . Just
+cfgLimitRows = cfg dbString "test" . Just
+
+cfgTestV2Schema :: AppConfig
+cfgTestV2Schema = cfg dbString "test_v2" Nothing
 
 testPoolOpts :: PoolSettings
 testPoolOpts = fromMaybe (error "bad settings") $ H.poolSettings 1 30
@@ -53,10 +56,10 @@ pgSettings = P.StringSettings $ cs dbString
 specDbPool :: IO (H.Pool P.Postgres)
 specDbPool = H.acquirePool pgSettings testPoolOpts
 
-specDbStructure :: H.Pool P.Postgres -> IO DbStructure
-specDbStructure pool = do
+specDbStructure :: H.Pool P.Postgres -> Schema -> IO DbStructure
+specDbStructure pool schema = do
   dbOrError <- H.session pool $ H.tx specTxSettings
-    $ getDbStructure "test"
+    $ getDbStructure schema
   either (fail . show) return dbOrError
 
 withApp :: AppConfig -> DbStructure -> H.Pool P.Postgres

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -2,6 +2,7 @@
 GRANT USAGE ON SCHEMA
       postgrest
     , test
+    , test_v2
 TO postgrest_test_anonymous;
 
 -- Schema test objects
@@ -32,6 +33,7 @@ GRANT ALL ON TABLE
     , users
     , users_projects
     , users_tasks
+    , test_v2.new_v2
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -34,6 +34,12 @@ CREATE SCHEMA test;
 
 
 --
+-- Name: test_v2; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA test_v2;
+
+--
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -253,6 +259,14 @@ CREATE TABLE articles (
     body text,
     owner name NOT NULL
 );
+
+
+--
+-- Name: private_schema_view; Type: VIEW; Schema: private; Owner: -
+--
+
+CREATE VIEW private_schema_view AS
+  SELECT 'Private';
 
 
 SET search_path = test, pg_catalog;
@@ -894,6 +908,16 @@ ALTER TABLE ONLY users_tasks
 
 ALTER TABLE ONLY users_tasks
     ADD CONSTRAINT users_tasks_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
+
+
+SET search_path = test_v2, pg_catalog;
+
+--
+-- Name: new_v2; Type: TABLE; Schema: test_v2; Owner: -
+--
+
+CREATE VIEW new_v2 AS
+  SELECT 'New for v2';
 
 
 --

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -45,10 +45,10 @@ CREATE SCHEMA test_v2;
 
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
-SET search_path = public, pg_catalog;
+SET search_path = test, pg_catalog;
 
 --
--- Name: jwt_claims; Type: TYPE; Schema: public; Owner: -
+-- Name: jwt_claims; Type: TYPE; Schema: test; Owner: -
 --
 
 CREATE TYPE jwt_claims AS (
@@ -131,10 +131,10 @@ CREATE TABLE items (
 );
 
 
-SET search_path = public, pg_catalog;
+SET search_path = test, pg_catalog;
 
 --
--- Name: always_true(test.items); Type: FUNCTION; Schema: public; Owner: -
+-- Name: always_true(test.items); Type: FUNCTION; Schema: test; Owner: -
 --
 
 CREATE FUNCTION always_true(test.items) RETURNS boolean
@@ -143,7 +143,7 @@ CREATE FUNCTION always_true(test.items) RETURNS boolean
 
 
 --
--- Name: anti_id(test.items); Type: FUNCTION; Schema: public; Owner: -
+-- Name: anti_id(test.items); Type: FUNCTION; Schema: test; Owner: -
 --
 
 CREATE FUNCTION anti_id(test.items) RETURNS bigint
@@ -182,7 +182,7 @@ $$;
 -- Name: login(text, text); Type: FUNCTION; Schema: test; Owner: -
 --
 
-CREATE FUNCTION login(id text, pass text) RETURNS public.jwt_claims
+CREATE FUNCTION login(id text, pass text) RETURNS test.jwt_claims
     LANGUAGE sql SECURITY DEFINER
     AS $$
 SELECT rolname::text, id::text FROM postgrest.auth WHERE id = id AND pass = pass;


### PR DESCRIPTION
I discovered a problem with how we are currently implementing versioning. Because we specify a fixed schema on every request it prevents a search path from working. For instance

```sql
create schema one;
create schema two;
create view one.hi as select 'hi';
SET search_path TO two,one;
select * from hi;
 ?column?
----------
 hi
(1 row)

select * from two.hi;
ERROR:  relation "two.hi" does not exist
```

This pull request removes all mention of schemas and adds new middleware `setSchemaSearchPath` to set the search path based on the command line parameter `--schema`. This parameter is now interpreted as a comma separated list like `--schema v2,v1`.

These changes make the new tests in `VersionSpec` pass, but I took things too far removing the considerations of schema from the structure building functions. Other old tests are failing.