### PR TITLE
Document python requests jwt

### DIFF
--- a/docs/examples/python-requests-jwt.md
+++ b/docs/examples/python-requests-jwt.md
@@ -1,0 +1,37 @@
+## Accessing PostgREST API using Python Requests and Requests-JWT
+
+The following HTTP client example should work on Python 3.x. If you're using python < 3.x you may need to change the print functions to statements or use:
+
+    from __future__ import print_function
+
+This code relies on setting up the PostgreSQL auth functions and grants correctly first. Follow these instructions:
+
+http://postgrest.com/examples/users/
+
+After completing the configuration, be sure to create a user with email, password, role, and verified flag. We'll use that user to login in the code below.
+
+Install the required libraries
+
+    pip install requests
+    pip install Requests-jwt
+
+Then, from a python interpreter or script:
+
+    import requests
+    import requests_jwt
+    import json
+
+    # email and password auth through postgrest
+    resp = requests.post('http://localhost:3000/rpc/login', json={"email": "you@yours.com", "pass": "dog"})
+    if resp.status_code != 200:
+        raise Exception()
+
+    # JWT auth using the token above
+    token = json.loads(resp.text)['token']
+    auth = requests_jwt.JWTAuth(token)
+    r = requests.get('http://localhost:3000/weight', auth=auth)
+    if r.status_code != 200:
+        raise Exception()
+        
+    for each in r.json():
+        print(each)  

--- a/docs/examples/python-requests-jwt.md
+++ b/docs/examples/python-requests-jwt.md
@@ -1,9 +1,5 @@
 ## Accessing PostgREST API using Python Requests and Requests-JWT
 
-The following HTTP client example should work on Python 3.x. If you're using python < 3.x you may need to change the print functions to statements or use:
-
-    from __future__ import print_function
-
 This code relies on setting up the PostgreSQL auth functions and grants correctly first. Follow these instructions:
 
 http://postgrest.com/examples/users/
@@ -13,7 +9,7 @@ After completing the configuration, be sure to create a user with email, passwor
 Install the required libraries
 
     pip install requests
-    pip install Requests-jwt
+    pip install requests-jwt
 
 Then, from a python interpreter or script:
 
@@ -32,6 +28,11 @@ Then, from a python interpreter or script:
     r = requests.get('http://localhost:3000/weight', auth=auth)
     if r.status_code != 200:
         raise Exception()
-        
+
     for each in r.json():
-        print(each)  
+        # do as you wish with each row
+        print(each)
+
+The preceding HTTP client example should work on Python 3.x. If you're using python < 3.x you may need to change the print functions to statements or use:
+
+    from __future__ import print_function

--- a/docs/examples/python-requests-jwt.md
+++ b/docs/examples/python-requests-jwt.md
@@ -25,13 +25,18 @@ Then, from a python interpreter or script:
     # JWT auth using the token above
     token = json.loads(resp.text)['token']
     auth = requests_jwt.JWTAuth(token)
-    r = requests.get('http://localhost:3000/weight', auth=auth)
     if r.status_code != 200:
         raise Exception()
 
-    for each in r.json():
-        # do as you wish with each row
-        print(each)
+    # Handle pagination using the Range header
+    for i in range(0, upper_bound, 20):
+        this_range  = '{0}-{1}'.format(i, i+20 if i+20 < upper_bound else upper_bound)
+        headers = {"Range": "{}".format(this_range)}
+        r = requests.get('http://localhost:3000/posts', auth=auth, headers=headers)
+        if r.status_code != 200:
+            raise Exception()
+        page = r.json()
+        # put page into pagination control or the like
 
 The preceding HTTP client example should work on Python 3.x. If you're using python < 3.x you may need to change the print functions to statements or use:
 

--- a/docs/examples/python-requests-jwt.md
+++ b/docs/examples/python-requests-jwt.md
@@ -28,6 +28,12 @@ Then, from a python interpreter or script:
     if r.status_code != 200:
         raise Exception()
 
+    # Make a request to get the range header
+    r = requests.get('http://localhost:3000/posts', auth=auth)
+
+    # Extract the size of the resultset from the Content-Range
+    upper_bound = int(r.headers['Content-Range'].split('/')[1])
+
     # Handle pagination using the Range header
     for i in range(0, upper_bound, 20):
         this_range  = '{0}-{1}'.format(i, i+20 if i+20 < upper_bound else upper_bound)

--- a/docs/install/ecosystem.md
+++ b/docs/install/ecosystem.md
@@ -5,6 +5,8 @@
 * [mithril.postgrest](https://github.com/catarse/mithril.postgrest) - Mithril plugin to create and authenticate requests
 * [lewisjared/postgrest-request](https://github.com/lewisjared/postgrest-request) - node interface to postgrest instances
 * [JarvusInnovations/jarvus-postgrest-apikit](https://github.com/JarvusInnovations/jarvus-postgrest-apikit) - Sencha framework package for binding models/stores/proxies to PostgREST tables
+*
+[davidthewatson/postgrest_python_requests_client](https://github.com/davidthewatson/postgrest_python_requests_client) - python client featuring JWT auth and pagination of result sets
 
 ### Extensions
 

--- a/docs/install/ecosystem.md
+++ b/docs/install/ecosystem.md
@@ -5,8 +5,7 @@
 * [mithril.postgrest](https://github.com/catarse/mithril.postgrest) - Mithril plugin to create and authenticate requests
 * [lewisjared/postgrest-request](https://github.com/lewisjared/postgrest-request) - node interface to postgrest instances
 * [JarvusInnovations/jarvus-postgrest-apikit](https://github.com/JarvusInnovations/jarvus-postgrest-apikit) - Sencha framework package for binding models/stores/proxies to PostgREST tables
-*
-[davidthewatson/postgrest_python_requests_client](https://github.com/davidthewatson/postgrest_python_requests_client) - python client featuring JWT auth and pagination of result sets
+* [davidthewatson/postgrest_python_requests_client](https://github.com/davidthewatson/postgrest_python_requests_client) - python client featuring JWT auth and pagination of result sets
 
 ### Extensions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,3 +25,4 @@ pages:
   - User Management: examples/users.md
   - External Authentication: examples/external_auth.md
   - Multi-Tenant Blog: examples/blog.md
+  - Python Client:  examples/python-requests-jwt.md


### PR DESCRIPTION
As discussed with @begriffs, this example documents:

* logging into a PostgREST API using python-requests
* obtain token from response
* use token auth with requests-jwt
* use Range header for pagination of results