### PR TITLE
Add request limit and offset query parameters

### DIFF
--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -117,14 +117,14 @@ userApiRequest schema req reqBody =
 
   ApiRequest {
     iAction = action
-  , iRange  = if singular then singletonRange 0 else rangeRequested hdrs
+  , iRange  = if singular then singletonRange 0 else rangeRequested hdrs qParams
   , iTarget = target
   , iAccepts = pickContentType $ lookupHeader "accept"
   , iPayload = relevantPayload
   , iPreferRepresentation = representation
   , iPreferSingular = singular
   , iPreferCount = not $ hasPrefer "count=none"
-  , iFilters = [ (k, fromJust v) | (k,v) <- qParams, k `notElem` ["select", "order"], isJust v ]
+  , iFilters = [ (k, fromJust v) | (k,v) <- qParams, k `notElem` ["select", "order", "page", "limit", "offset"], isJust v ]
   , iSelect = if method == "DELETE"
               then "*"
               else fromMaybe "*" $ fromMaybe (Just "*") $ lookup "select" qParams


### PR DESCRIPTION
Once I saw the way PostgREST handled pagination, I was ready to leave the traditional `limit` and `page` query parameters behind. However, @davidthewatson (when talking about something else entirely) brought up the [HATEOAS](http://pilhuhn.blogspot.com/2013/02/best-practice-for-paging-in-restful-apis.html) argument for query parameters to control pagination. In addition, there is currently no mechanism for paginating embedded collections.

This PR aims to solve these two problems:

1. HATEOAS pagination.
2. Collection embedding limiting.

The way this PR accomplishes this is by adding three query parameters: `limit`, `offset`, and `page` (if `offset` is not defined and `page` is, `limit * page = offset`). This PR also allows these parameters to be qualified, for example `posts.limit=4` to limit embedded collections. These parameters do not replace the range headers, but rather supplement. Extending the existing mechanisms.

I was going to wait until I had finished the collection limiting before submitting this PR, however @begriffs in gitter alluded to a large rewrite as he upgraded to the newest Hasql. Therefore I really don't want to go too deep into this PR before that upgrade has been merged. For now the only new features are the global request headers.

Also, I haven't currently implemented `Link` headers for pagination because I'm not exactly sure how they would work. I'm thinking they would only be included if a `page` query parameter was specified.