### PR TITLE
Set login permission for authenticator role

### DIFF
--- a/docs/admin/security.md
+++ b/docs/admin/security.md
@@ -60,7 +60,7 @@ for anonymous users, one for authors, and another for the authenticator,
 you would set it up like this
 
 ```sql
-CREATE ROLE authenticator NOINHERIT;
+CREATE ROLE authenticator NOINHERIT LOGIN;
 CREATE ROLE anon;
 CREATE ROLE author;
 


### PR DESCRIPTION
This was confusing when I got started with the docs. Above in the docs you're using `foo` as the authenticator role. Later, you're giving the example of using the `authenticator` role for this purpose. When using CREATE ROLE, the role will not have the LOGIN permission and starting the server with `postgrest postgres://authenticator@localhost:5432/mydb --anonymous anon` will result in `FATAL: role "authenticator" is not permitted to log in`. The docs should either use CREATE USER (like you door set LOGIN when using CREATE ROLE, as I understand it.