### PR TITLE
fix #453 by sending the request to the db (instead of using the cached data)

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -178,7 +178,7 @@ app dbStructure conf reqBody req =
         else return notFound
 
     (ActionRead, TargetRoot, Nothing) -> do
-      body <- encode <$> accessibleTables (filter ((== cs schema) . tableSchema) (dbTables dbStructure))
+      body <- encode <$> accessibleTables (cs schema)
       return $ responseLBS status200 [jsonH] $ cs body
 
     (ActionUnknown _, _, _) -> return notFound

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -71,25 +71,33 @@ doesProcReturnJWT = doesProc [H.stmt|
       AND    pg_catalog.pg_get_function_result(p.oid) like '%jwt_claims'
     |]
 
-accessibleTables :: [Table] -> H.Tx P.Postgres s [Table]
-accessibleTables allTabs = do
-  accessible <- H.listEx $ [H.stmt|
-      SELECT
-        n.nspname AS table_schema,
-        c.relname AS table_name
-      FROM pg_class c
-      JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE
-        c.relkind IN ('v','r','m') AND
-        n.nspname NOT IN ('pg_catalog', 'information_schema') AND (
-          pg_has_role(c.relowner, 'USAGE'::text) OR
-          has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'::text) OR
-          has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES'::text)
+accessibleTables :: Schema -> H.Tx P.Postgres s [Table]
+accessibleTables schema = do
+  rows <- H.listEx $
+    [H.stmt|
+      select
+        n.nspname as table_schema,
+        relname as table_name,
+        c.relkind = 'r' or (c.relkind IN ('v', 'f')) and (pg_relation_is_updatable(c.oid::regclass, false) & 8) = 8
+        or (exists (
+           select 1
+           from pg_trigger
+           where pg_trigger.tgrelid = c.oid and (pg_trigger.tgtype::integer & 69) = 69)
+        ) as insertable
+      from
+        pg_class c
+        join pg_namespace n on n.oid = c.relnamespace
+      where
+        c.relkind in ('v', 'r', 'm')
+        and n.nspname = ?
+        and (
+          pg_has_role(c.relowner, 'USAGE'::text)
+          or has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'::text)
+          or has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES'::text)
         )
-      ORDER BY table_schema, table_name
-    |]
-  let isAccessible table = isJust $ find (\(s,n) -> tableSchema table == s && tableName table == n) accessible
-  return $ filter isAccessible allTabs
+      order by relname
+    |] schema
+  return $ map tableFromRow rows
 
 synonymousColumns :: [(Column,Column)] -> [Column] -> [[Column]]
 synonymousColumns allSyns cols = synCols'


### PR DESCRIPTION
So the history of this is as follows:
In the beginning the / request used to go to the db (like in this pr).
The we started caching the db structure (along the info of who has access to what) and serving the response using that.
Then during discussions about how to model "users/auth" we figured that when someone wants to use 1 user = 1 role, this way of doing things (caching who has access to what) so we started to migrate back and at the same time there was some dbstructure refactoring and things got mixed up.

PS: @begriffs before merging this, can you test in 3.0.3 my suspicion that this bug only appears when the "grant" command is executed during the time postgrest is running and the bug presents itself but when you restart postgrest, it works again. If that is correct then the docs should say somewhere that on each db structure change, postgrest needs to be restarted

