### PR TITLE
Add step to install libpq-dev when building from source on Ubuntu

### DIFF
--- a/docs/install/server.md
+++ b/docs/install/server.md
@@ -46,6 +46,10 @@ wget -q -O- https://s3.amazonaws.com/download.fpcomplete.com/ubuntu/fpco.key | s
 echo 'deb http://download.fpcomplete.com/ubuntu/trusty stable main'|sudo tee /etc/apt/sources.list.d/fpco.list
 sudo apt-get update && sudo apt-get install stack -y
 ```
+* Install libpq-dev
+```
+sudo apt-get install -y libpq-dev
+```
 * Build & install in one step
 
 ```bash


### PR DESCRIPTION
This is a dependency of postgresql-libpq-0.9.1.1, which results in
a failure when missing during stack build.

Closes #463.