### PR TITLE
Rename endpoint for consistent endpoint names

### DIFF
--- a/docs/examples/external_auth.md
+++ b/docs/examples/external_auth.md
@@ -175,7 +175,7 @@ WHERE
 Now whenever you are authenticated in your Rails application you can use some Javascript
  code to get the token and use it:
 ```javascript
-$.getJSON('/api_json').done(function(data){
+$.getJSON('/api_token').done(function(data){
     $.ajax('/orders', {'Authorization': 'Bearer ' + data.token}).done(function(data){
         console.log('Visible Orders: ', data);
     })


### PR DESCRIPTION
In line 126 the endpoint url is api_token. Therefore it should be the same in line 178.