### PR TITLE
Switch to Stack on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,21 @@
-machine:
+dependencies:
+  cache_directories:
+    - "~/.stack"
   pre:
+    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442
+    - echo 'deb http://download.fpcomplete.com/ubuntu precise main'|sudo tee /etc/apt/sources.list.d/fpco.list
+    - sudo apt-get update && sudo apt-get install stack -y
     - createuser --superuser --no-password postgrest_test
     - createdb -O postgrest_test -U ubuntu postgrest_test
-  ghc:
-    version: 7.10.1
-dependencies:
   override:
-    - cabal update
-    - cabal sandbox init
-    - cabal install --upgrade-dependencies --constraint="template-haskell installed" --dependencies-only --enable-tests --reorder-goals
-    - cabal configure --enable-tests -f ci
+    - stack setup
+    - stack install hlint packdeps cabal-install
+
 test:
-  post:
-    - cabal exec hlint -- -X QuasiQuotes src/**/*.hs test/**/*.hs
-    - cabal exec packdeps postgrest.cabal || true
+  override:
+    - stack test
+    - git ls-files | grep '\.l\?hs$' | xargs stack exec -- hlint -X QuasiQuotes "$@"
+    - stack exec -- packdeps *.cabal || true
+    - stack exec -- cabal check
+    - stack haddock --coverage
+    - stack sdist

--- a/circle.yml
+++ b/circle.yml
@@ -17,5 +17,5 @@ test:
     - git ls-files | grep '\.l\?hs$' | xargs stack exec -- hlint -X QuasiQuotes "$@"
     - stack exec -- packdeps *.cabal || true
     - stack exec -- cabal check
-    - stack haddock --coverage
+    - stack haddock
     - stack sdist

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 dependencies:
   cache_directories:
     - "~/.stack"
+    - ".stack-work"
   pre:
     - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442
     - echo 'deb http://download.fpcomplete.com/ubuntu precise main'|sudo tee /etc/apt/sources.list.d/fpco.list
@@ -10,6 +11,7 @@ dependencies:
   override:
     - stack setup
     - stack install hlint packdeps cabal-install
+    - stack build --test --no-run-tests
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -17,5 +17,5 @@ test:
     - git ls-files | grep '\.l\?hs$' | xargs stack exec -- hlint -X QuasiQuotes "$@"
     - stack exec -- packdeps *.cabal || true
     - stack exec -- cabal check
-    - stack haddock
+    - stack haddock --no-haddock-deps
     - stack sdist

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -34,6 +34,7 @@ executable postgrest
                      , contravariant
                      , errors
                      , hasql >= 0.19.3.3 && < 0.20
+                     , http-types
                      , interpolatedstring-perl6
                      , jwt
                      , optparse-applicative >= 0.11 && < 0.13
@@ -46,7 +47,6 @@ executable postgrest
                      , string-conversions
                      , text
                      , time
-                     , transformers
                      , unordered-containers
                      , vector
                      , wai >= 3.0.1
@@ -54,8 +54,7 @@ executable postgrest
                      , wai-extra
                      , wai-middleware-static >= 0.6.0
                      , warp >= 3.1.0
-                     , HTTP, http-types
-                     , MissingH
+                     , HTTP
                      , Ranged-sets
   if !os(windows)
     build-depends:     unix >= 2.7 && < 3
@@ -104,7 +103,6 @@ library
                      , wai-extra
                      , wai-middleware-static
                      , HTTP
-                     , MissingH
                      , Ranged-sets
 
   Other-Modules:       Paths_postgrest
@@ -159,7 +157,6 @@ Test-Suite spec
                      , errors
                      , hasql
                      , heredoc
-                     , hlint
                      , hspec == 2.2.*
                      , hspec-wai
                      , hspec-wai-json
@@ -167,11 +164,9 @@ Test-Suite spec
                      , interpolatedstring-perl6
                      , jwt
                      , optparse-applicative
-                     , packdeps
                      , parsec
                      , process
                      , regex-tdfa
-                     , resource-pool
                      , safe
                      , scientific
                      , string-conversions
@@ -184,5 +179,4 @@ Test-Suite spec
                      , wai-extra
                      , wai-middleware-static
                      , HTTP
-                     , MissingH
                      , Ranged-sets

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -22,11 +22,6 @@ Flag CI
   Default:     False
 
 executable postgrest
-  if flag(ci)
-    ghc-options:       -Wall -W -Werror
-  else
-    ghc-options:       -Wall -W -O2
-
   main-is:             PostgREST/Main.hs
   default-extensions:  OverloadedStrings, ScopedTypeVariables, QuasiQuotes, LambdaCase
   default-language:    Haskell2010
@@ -80,11 +75,6 @@ executable postgrest
                      , PostgREST.Types
 
 library
-  if flag(ci)
-    ghc-options:       -Wall -W -Werror
-  else
-    ghc-options:       -Wall -W -O2
-
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, ScopedTypeVariables, QuasiQuotes
   build-depends:       aeson
@@ -136,10 +126,6 @@ Test-Suite spec
   Default-Language:    Haskell2010
   default-extensions:  OverloadedStrings, ScopedTypeVariables, QuasiQuotes, LambdaCase
   Hs-Source-Dirs:      test, src
-  if flag(ci)
-    ghc-options:       -Wall -W -Werror
-  else
-    ghc-options:       -Wall -W -O2
   Main-Is:             Main.hs
   Other-Modules:       Feature.AuthSpec
                      , Feature.CorsSpec

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -30,7 +30,7 @@ executable postgrest
   main-is:             PostgREST/Main.hs
   default-extensions:  OverloadedStrings, ScopedTypeVariables, QuasiQuotes, LambdaCase
   default-language:    Haskell2010
-  build-depends:       aeson >= 0.8
+  build-depends:       aeson >= 0.8 && < 0.10
                      , base >= 4.8 && < 5
                      , bytestring
                      , case-insensitive

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -85,7 +85,7 @@ app dbStructure conf reqBody req =
               then responseLBS status404 [] ""
               else responseLBS status200 [contentTypeH] (cs body)
             else do
-              let frm = toInteger $ rangeOffset range
+              let frm = rangeOffset range
                   to = frm + toInteger queryTotal - 1
                   contentRange = contentRangeH frm to (toInteger <$> tableTotal)
                   status = rangeStatus frm to (toInteger <$> tableTotal)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,11 @@
-flags: {}
-packages:
-- '.'
+resolver: lts-5.0
 extra-deps:
   - hasql-0.19.3.3
   - Ranged-sets-0.3.0
   - packdeps-0.4.2.1
-resolver: lts-5.0
+# Almost all warnings, plus minimal-imports for packunused
+ghc-options:
+  postgrest: -ddump-minimal-imports -Werror -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction -fwarn-auto-orphans -fwarn-missing-local-sigs -fwarn-missing-exported-sigs -fwarn-missing-import-lists -fwarn-identities
+
+packages:
+- '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,9 +3,8 @@ extra-deps:
   - hasql-0.19.3.3
   - Ranged-sets-0.3.0
   - packdeps-0.4.2.1
-# Almost all warnings, plus minimal-imports for packunused
 ghc-options:
-  postgrest: -ddump-minimal-imports -Werror -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction -fwarn-auto-orphans -fwarn-missing-local-sigs -fwarn-missing-exported-sigs -fwarn-missing-import-lists -fwarn-identities
+  postgrest: -Werror -Wall -fwarn-monomorphism-restriction -fwarn-missing-exported-sigs -fwarn-identities
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ extra-deps:
   - Ranged-sets-0.3.0
   - packdeps-0.4.2.1
 ghc-options:
-  postgrest: -Werror -Wall -fwarn-monomorphism-restriction -fwarn-missing-exported-sigs -fwarn-identities
+  postgrest: -O2 -Werror -Wall -fwarn-monomorphism-restriction -fwarn-missing-exported-sigs -fwarn-identities
 
 packages:
 - '.'

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -40,7 +40,7 @@ cfgLimitRows = cfg dbString . Just
 
 withApp :: AppConfig -> DbStructure -> H.Connection
         -> ActionWith Application -> IO ()
-withApp config dbStructure c perform = do
+withApp config dbStructure c perform =
   perform $ defaultMiddle $ \req resp -> do
     time <- getPOSIXTime
     body <- strictRequestBody req


### PR DESCRIPTION
The new config has a few benefits

* Builds like we do in development
* Removes helpers like hlint and packdeps from the cabal file and into the circle config
* Newer stack resolver
* More kinds of ghc warnings
* Added checks for
    * cabal file warnings
    * haddock coverage
    * problems creating hackage tarball