### PR TITLE
Detect db schema changes

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -47,6 +47,7 @@ executable postgrest
                      , string-conversions
                      , text
                      , time
+                     , transformers
                      , unordered-containers
                      , vector
                      , wai >= 3.0.1
@@ -96,6 +97,7 @@ library
                      , string-conversions
                      , text
                      , time
+                     , transformers
                      , unordered-containers
                      , vector
                      , wai
@@ -172,6 +174,7 @@ Test-Suite spec
                      , string-conversions
                      , text
                      , time
+                     , transformers
                      , unordered-containers
                      , vector
                      , wai

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -13,7 +13,7 @@ import           PostgREST.Error                      (errResponse, pgErrRespons
 import           PostgREST.Middleware
 import           PostgREST.QueryBuilder               (inTransaction, Isolation(..))
 
-import           Control.Concurrent                   (forkIO, threadDelay)
+import           Control.Concurrent                   (forkIO, myThreadId, threadDelay)
 import           Control.Concurrent.MVar              (newEmptyMVar, putMVar)
 import           Control.Monad                        (forever, unless, void)
 import           Data.Monoid                          ((<>))
@@ -36,7 +36,6 @@ import           Web.JWT                              (secret)
 
 #ifndef mingw32_HOST_OS
 import           System.Posix.Signals
-import           Control.Concurrent                   (myThreadId)
 import           Control.Exception.Base               (throwTo, AsyncException(..))
 #endif
 


### PR DESCRIPTION
While the correct approach to detecting schema changes is outlined in #475, I moved ahead on this PR to figure out how to make the code keep a changing schema inside an `MVar`. It currently polls for changes every five minutes.

While we wait for support for postgresql LISTEN in hasql to arrive in the next week I wanted to put this PR out for code review.