### PR TITLE
Issue http 405 for anything but POST on RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Reject non-POSTs to rpc endpoints - @begriffs
+
 ## [0.3.0.3] - 2016-01-08
 
 ### Fixed

--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,8 @@ dependencies:
     - "~/.stack"
     - ".stack-work"
   pre:
-    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442
-    - echo 'deb http://download.fpcomplete.com/ubuntu precise main'|sudo tee /etc/apt/sources.list.d/fpco.list
-    - sudo apt-get update && sudo apt-get install stack -y
+    - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.0.2/stack-1.0.2-linux-x86_64.tar.gz | tar zx -C /tmp
+    - sudo mv /tmp/stack-1.0.2-linux-x86_64/stack /usr/bin
     - createuser --superuser --no-password postgrest_test
     - createdb -O postgrest_test -U ubuntu postgrest_test
   override:

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -31,6 +31,7 @@ data Action = ActionCreate | ActionRead
             | ActionUnknown BS.ByteString deriving Eq
 -- | The target db object of a user action
 data Target = TargetIdent QualifiedIdentifier
+            | TargetProc  QualifiedIdentifier
             | TargetRoot
             | TargetUnknown [T.Text]
 -- | How to return the inserted data
@@ -90,7 +91,7 @@ userApiRequest schema req reqBody =
                  []            -> TargetRoot
                  [table]       -> TargetIdent
                                   $ QualifiedIdentifier schema table
-                 ["rpc", proc] -> TargetIdent
+                 ["rpc", proc] -> TargetProc
                                   $ QualifiedIdentifier schema proc
                  other         -> TargetUnknown other
       payload = case pickContentType (lookupHeader "content-type") of

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -155,7 +155,7 @@ app dbStructure conf reqBody req =
           filterCol _ _ _ =  False
       return $ responseLBS status200 [jsonH, allOrigins] $ cs body
 
-    (ActionInvoke, TargetIdent qi,
+    (ActionInvoke, TargetProc qi,
      Just (PayloadJSON (UniformObjects payload))) -> do
       exists <- H.query qi doesProcExist
       if exists
@@ -177,6 +177,8 @@ app dbStructure conf reqBody req =
       return $ responseLBS status200 [jsonH] $ cs body
 
     (ActionUnknown _, _, _) -> return notFound
+
+    (_, TargetProc _, _) -> return $ responseLBS status405 [] ""
 
     (_, TargetUnknown _, _) -> return notFound
 

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -386,6 +386,9 @@ spec struct c = around (withApp cfgDefault struct c) $ do
         post "/rpc/sayhello" [json| { "name": "world" } |] `shouldRespondWith`
           [json| [{"sayhello":"Hello, world"}] |]
 
+    it "currently supports POST only" $
+      get "/rpc/fake" `shouldRespondWith` 405 -- method not allowed
+
   describe "weird requests" $ do
     it "can query as normal" $ do
       get "/Escap3e;" `shouldRespondWith`

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -386,8 +386,22 @@ spec struct c = around (withApp cfgDefault struct c) $ do
         post "/rpc/sayhello" [json| { "name": "world" } |] `shouldRespondWith`
           [json| [{"sayhello":"Hello, world"}] |]
 
-    it "currently supports POST only" $
-      get "/rpc/fake" `shouldRespondWith` 405 -- method not allowed
+    context "unsupported verbs" $ do
+      it "DELETE fails" $
+        request methodDelete "/rpc/sayhello" [] ""
+          `shouldRespondWith` 405
+      it "PATCH fails" $
+        request methodPatch "/rpc/sayhello" [] ""
+          `shouldRespondWith` 405
+      it "OPTIONS fails" $
+        -- TODO: should return info about the function
+        request methodOptions "/rpc/sayhello" [] ""
+          `shouldRespondWith` 405
+      it "GET fails with 405 on unknown procs" $
+        -- TODO: should this be 404?
+        get "/rpc/fake" `shouldRespondWith` 405
+      it "GET with 405 on known procs" $
+        get "/rpc/sayhello" `shouldRespondWith` 405
 
   describe "weird requests" $ do
     it "can query as normal" $ do


### PR DESCRIPTION
Fixes #481

Eventually we will allow GET requests for non-volatile functions but not yet. Note that this will also issue a 405 for OPTIONS on an rpc endpoint. Implementing OPTIONS is another todo.