### PR TITLE
Adjust usage message to indicate required arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
+- Improved usage screen - @begriffs
 - Reject non-POSTs to rpc endpoints - @begriffs
 - Throw an error for OPTIONS on nonexistent tables - @calebmer
 

--- a/docs/install/server.md
+++ b/docs/install/server.md
@@ -65,7 +65,7 @@ If you want to run the test suite, stack can do that too: `stack test`.
 ### Running the Server
 
 ```bash
-postgrest postgres://user:pass@host:port/db [flags]
+postgrest postgres://user:pass@host:port/db -s public -a anon_user [other flags]
 ```
 
 The user in the connection string is the "authenticator role," i.e.
@@ -80,11 +80,11 @@ The possible flags are:
 <dd>The port on which the server will listen for HTTP requests.
     Defaults to 3000.</dd>
 
-<dt>-a, --anonymous</dt>
+<dt>-a, --anonymous (required)</dt>
 <dd>The database role used to execute commands for those requests
     which provide no JWT authorization.</dd>
 
-<dt>-s, --schema</dt>
+<dt>-s, --schema (required)</dt>
 <dd>The db schema which you want to expose as an API. For historical
     reasons it defaults to <code>1</code>, but you're more likely
     to want to choose a value of <code>public</code>.</dd>

--- a/docs/install/server.md
+++ b/docs/install/server.md
@@ -65,7 +65,7 @@ If you want to run the test suite, stack can do that too: `stack test`.
 ### Running the Server
 
 ```bash
-postgrest postgres://user:pass@host:port/db -s public -a anon_user [other flags]
+postgrest postgres://user:pass@host:port/db -a anon_user [other flags]
 ```
 
 The user in the connection string is the "authenticator role," i.e.
@@ -73,7 +73,7 @@ a role which is used temporarily to switch into other roles depending
 on the authentication request JWT. For simple API's you can use the
 same role for authenticator and anonymous.
 
-The possible flags are:
+The complete list of options:
 
 <dl>
 <dt>-p, --port</dt>
@@ -84,7 +84,7 @@ The possible flags are:
 <dd>The database role used to execute commands for those requests
     which provide no JWT authorization.</dd>
 
-<dt>-s, --schema (required)</dt>
+<dt>-s, --schema</dt>
 <dd>The db schema which you want to expose as an API. For historical
     reasons it defaults to <code>1</code>, but you're more likely
     to want to choose a value of <code>public</code>.</dd>

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -47,11 +47,11 @@ data AppConfig = AppConfig {
 
 argParser :: Parser AppConfig
 argParser = AppConfig
-  <$> argument str (help "database connection string" <> metavar "STRING")
+  <$> argument str (help "(REQUIRED) database connection string" <> metavar "DB_URL")
 
   <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
-  <*> strOption    (long "anonymous"  <> short 'a' <> help "postgres role to use for non-authenticated requests" <> metavar "ROLE")
-  <*> strOption    (long "schema"     <> short 's' <> help "schema to use for API routes" <> metavar "NAME" <> value "public" <> showDefault)
+  <*> strOption    (long "anonymous"  <> short 'a' <> help "(REQUIRED) postgres role to use for non-authenticated requests" <> metavar "ROLE")
+  <*> strOption    (long "schema"     <> short 's' <> help "(REQUIRED) schema to use for API routes" <> metavar "NAME" <> value "public" <> showDefault)
   <*> (secret . cs <$>
       strOption    (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET" <> value "secret" <> showDefault))
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -37,9 +37,9 @@ import           Prelude
 -- | Data type to store all command line options
 data AppConfig = AppConfig {
     configDatabase  :: String
-  , configPort      :: Int
   , configAnonRole  :: String
   , configSchema    :: String
+  , configPort      :: Int
   , configJwtSecret :: Secret
   , configPool      :: Int
   , configMaxRows   :: Maybe Integer
@@ -48,10 +48,9 @@ data AppConfig = AppConfig {
 argParser :: Parser AppConfig
 argParser = AppConfig
   <$> argument str (help "(REQUIRED) database connection string" <> metavar "DB_URL")
-
-  <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
   <*> strOption    (long "anonymous"  <> short 'a' <> help "(REQUIRED) postgres role to use for non-authenticated requests" <> metavar "ROLE")
-  <*> strOption    (long "schema"     <> short 's' <> help "(REQUIRED) schema to use for API routes" <> metavar "NAME" <> value "public" <> showDefault)
+  <*> strOption    (long "schema"     <> short 's' <> help "schema to use for API routes" <> metavar "NAME" <> value "public" <> showDefault)
+  <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
   <*> (secret . cs <$>
       strOption    (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET" <> value "secret" <> showDefault))
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -47,7 +47,7 @@ data AppConfig = AppConfig {
 
 argParser :: Parser AppConfig
 argParser = AppConfig
-  <$> argument str (help "(REQUIRED) database connection string" <> metavar "DB_URL")
+  <$> argument str (help "(REQUIRED) database connection string, e.g. postgres://user:pass@host:port/db" <> metavar "DB_URL")
   <*> strOption    (long "anonymous"  <> short 'a' <> help "(REQUIRED) postgres role to use for non-authenticated requests" <> metavar "ROLE")
   <*> strOption    (long "schema"     <> short 's' <> help "schema to use for API routes" <> metavar "NAME" <> value "public" <> showDefault)
   <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -30,7 +30,7 @@ dbString :: String
 dbString = "postgres://postgrest_test_authenticator@localhost:5432/postgrest_test"
 
 cfg :: String -> Maybe Integer -> AppConfig
-cfg conStr = AppConfig conStr 3000 "postgrest_test_anonymous" "test" (secret "safe") 10
+cfg conStr = AppConfig conStr "postgrest_test_anonymous" "test" 3000 (secret "safe") 10
 
 cfgDefault :: AppConfig
 cfgDefault = cfg dbString Nothing


### PR DESCRIPTION
Several people have been confused about which command line arguments are required to run postgrest. This pull request changes the usage message slightly to hopefully make it clear. The new message looks like this:

```
$ postgrest
Missing: DB_URL (-a|--anonymous ROLE)

Usage: postgrest DB_URL [-p|--port PORT] (-a|--anonymous ROLE)
                 [-s|--schema NAME] [-j|--jwt-secret SECRET] [-o|--pool COUNT]
                 [-m|--max-rows COUNT]
  PostgREST 0.3.0.3 / create a REST API to an existing Postgres database

Available options:
  -h,--help                Show this help text
  DB_URL                   (REQUIRED) database connection string
  -p,--port PORT           port number on which to run HTTP
                           server (default: 3000)
  -a,--anonymous ROLE      (REQUIRED) postgres role to use for non-authenticated
                           requests
  -s,--schema NAME         (REQUIRED) schema to use for API
                           routes (default: "public")
  -j,--jwt-secret SECRET   secret used to encrypt and decrypt JWT
                           tokens (default: "secret")
  -o,--pool COUNT          max connections in database pool (default: 10)
  -m,--max-rows COUNT      max rows in response (default: "infinity")
```

@StevanWhite do you think this makes it clear enough?