### PR TITLE
Reduces pool resource locking

### DIFF
--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -97,8 +97,9 @@ main = do
     body <- strictRequestBody req
     let handleReq = H.run $ inTransaction ReadCommitted
           (runWithClaims conf time (app dbStructure conf body) req)
-    withResource pool $ \case
-      Left err -> respond $ errResponse HT.status500 (cs . show $ err)
+    res <- withResource pool $ \case
+      Left err -> return $ errResponse HT.status500 (cs . show $ err)
       Right c -> do
         resOrError <- handleReq c
-        either (respond . pgErrResponse) respond resOrError
+        either (return . pgErrResponse) return resOrError
+    respond res

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -101,5 +101,5 @@ main = do
       Left err -> return $ errResponse HT.status500 (cs . show $ err)
       Right c -> do
         resOrError <- handleReq c
-        either (return . pgErrResponse) return resOrError
+        return $ either pgErrResponse id resOrError
     respond res


### PR DESCRIPTION
This PR was based on a conversation I had with @ruslantalpa in the gitter and on some ad-hoc tests using ```threadDelay```.

I'm still not sure if I should include some kind of test or benchmark to validate this change.

The change is very simple though, I return the results from withResource function before applying the respond continuation. This ensures that the pool resource is freed as soon as the database operation is complete