### PR TITLE
Use `CMD exec` in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
+- Terminate gracefully on SIGTERM - @recmo
 
 ## [0.3.1.0] - 2016-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
-- Terminate gracefully on SIGTERM - @recmo
+* Terminate gracefully on SIGTERM (for use in Docker) - @recmo
 
 ## [0.3.1.0] - 2016-02-28
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN wget http://github.com/begriffs/postgrest/releases/download/v${POSTGREST_VER
     mv postgrest /usr/local/bin/postgrest && \
     rm postgrest-${POSTGREST_VERSION}-ubuntu.tar.xz
 
-CMD postgrest postgres://${PG_ENV_POSTGRES_USER}:${PG_ENV_POSTGRES_PASSWORD}@${PG_PORT_5432_TCP_ADDR}:${PG_PORT_5432_TCP_PORT}/${PG_ENV_POSTGRES_DB} \
+CMD exec postgrest postgres://${PG_ENV_POSTGRES_USER}:${PG_ENV_POSTGRES_PASSWORD}@${PG_PORT_5432_TCP_ADDR}:${PG_PORT_5432_TCP_PORT}/${PG_ENV_POSTGRES_DB} \
               --port 3000 \
               --schema ${POSTGREST_SCHEMA} \
               --anonymous ${POSTGREST_ANONYMOUS} \

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -60,10 +60,11 @@ main = do
 
 #ifndef mingw32_HOST_OS
   tid <- myThreadId
-  void $ installHandler keyboardSignal (Catch $ do
-      P.release pool
-      throwTo tid UserInterrupt
-    ) Nothing
+  forM_ [sigINT, sigTERM] $ \sig ->
+    void $ installHandler sig (Catch $ do
+        P.release pool
+        throwTo tid UserInterrupt
+      ) Nothing
 #endif
 
   result <- P.use pool $ do


### PR DESCRIPTION
Without exec the `postgrest` process is not run with PID 1 (it
is a child process of the shell that starts it). This means
signals send to the docker (like `docker stop` or ^C) will
not be handled correctly.

This commit adds `exec` to resolve this problem, as per the
recommendation in the Dockerfile documentation:

<https://docs.docker.com/engine/reference/builder/#shell-form-entrypoint-example>
