### PR TITLE
adding uuid-ossp extension into documentation

### DIFF
--- a/docs/examples/users.md
+++ b/docs/examples/users.md
@@ -28,10 +28,11 @@ value.
 ### Storing Users and Passwords
 
 We create a database schema especially for auth information. We'll
-also need the postgres extension
-[pgcrypto](http://www.postgresql.org/docs/current/static/pgcrypto.html).
+also need the postgres extensions
+[pgcrypto](http://www.postgresql.org/docs/current/static/pgcrypto.html) and [uuid-oosp](http://www.postgresql.org/docs/current/static/uuid-ossp.html).
 
 ```sql
+create extension if not exists "uuid-ossp";
 create extension if not exists pgcrypto;
 
 -- We put things inside the basic_auth schema to hide


### PR DESCRIPTION
 I got "function uuid_generate_v4() does not exist" error for `/rpc/signup` and for direct inserting into `basic_auth.users` (using pgsql 9.5):
```
insert into basic_auth.users VALUES  ('michal@example.com','123','author',true);
```
and had to do
```
CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
create extension if not exists pgcrypto;
```
(the second line is taken from the documentation)