### PR TITLE
Fix typo-d flag in the installation docs.

### DIFF
--- a/docs/install/server.md
+++ b/docs/install/server.md
@@ -95,7 +95,7 @@ The complete list of options:
     <code>secret</code> but do not use the default in production!
     Load-balanced PostgREST servers should share the same secret.</dd>
 
-<dt>-p, --pool</dt>
+<dt>-o, --pool</dt>
 <dd>Max connections to use in db pool. Defaults to to 10, but you
     should find an optimal value for your db by running the SQL
     command <code>show max_connections;</code></dd>


### PR DESCRIPTION
Just fixing a typo in the docs where it lists -p twice instead of -p and -o