### PR TITLE
Regression test for read/write unicode table names

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -146,6 +146,7 @@ Test-Suite spec
                      , Feature.QueryLimitedSpec
                      , Feature.RangeSpec
                      , Feature.StructureSpec
+                     , Feature.UnicodeSpec
                      , Paths_postgrest
                      , PostgREST.App
                      , PostgREST.Auth

--- a/test/Feature/UnicodeSpec.hs
+++ b/test/Feature/UnicodeSpec.hs
@@ -1,0 +1,20 @@
+module Feature.UnicodeSpec where
+
+import Test.Hspec
+import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
+import Network.Wai (Application)
+import Control.Monad (void)
+
+spec :: SpecWith Application
+spec =
+  describe "Reading and writing to unicode schema and table names" $
+    it "Can read and write values" $ do
+      get "/%D9%85%D9%88%D8%A7%D8%B1%D8%AF"
+        `shouldRespondWith` "[]"
+
+      void $ post "/%D9%85%D9%88%D8%A7%D8%B1%D8%AF"
+        [json| { "هویت": 1 } |]
+
+      get "/%D9%85%D9%88%D8%A7%D8%B1%D8%AF"
+        `shouldRespondWith` [json| [{ "هویت": 1 }] |]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,6 +18,7 @@ import qualified Feature.QueryLimitedSpec
 import qualified Feature.QuerySpec
 import qualified Feature.RangeSpec
 import qualified Feature.StructureSpec
+import qualified Feature.UnicodeSpec
 
 main :: IO ()
 main = do
@@ -29,6 +30,7 @@ main = do
   let dbStructure = either (error.show) id result
       withApp = return $ postgrest testCfg dbStructure pool
       ltdApp  = return $ postgrest testLtdRowsCfg dbStructure pool
+      unicodeApp = return $ postgrest testUnicodeCfg dbStructure pool
 
   hspec $ do
     mapM_ (beforeAll_ resetDb . before withApp) specs
@@ -36,6 +38,10 @@ main = do
     -- this test runs with a different server flag
     beforeAll_ resetDb . before ltdApp $
       describe "Feature.QueryLimitedSpec" Feature.QueryLimitedSpec.spec
+
+    -- this test runs with a different schema
+    beforeAll_ resetDb . before unicodeApp $
+      describe "Feature.UnicodeSpec" Feature.UnicodeSpec.spec
 
  where
   specs = map (uncurry describe) [

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -21,6 +21,10 @@ testCfg :: AppConfig
 testCfg =
   AppConfig testDbConn "postgrest_test_anonymous" "test" 3000 (secret "safe") 10 Nothing True
 
+testUnicodeCfg :: AppConfig
+testUnicodeCfg =
+  AppConfig testDbConn "postgrest_test_anonymous" "تست" 3000 (secret "safe") 10 Nothing True
+
 testLtdRowsCfg :: AppConfig
 testLtdRowsCfg =
   AppConfig testDbConn "postgrest_test_anonymous" "test" 3000 (secret "safe") 10 (Just 3) True

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -2,10 +2,11 @@
 GRANT USAGE ON SCHEMA
       postgrest
     , test
+    , "تست"
 TO postgrest_test_anonymous;
 
 -- Schema test objects
-SET search_path = test, pg_catalog;
+SET search_path = test, "تست", pg_catalog;
 
 GRANT ALL ON TABLE
     items
@@ -36,6 +37,7 @@ GRANT ALL ON TABLE
     , "Escap3e;"
     , "ghostBusters"
     , "withUnique"
+    , "موارد"
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -34,6 +34,13 @@ CREATE SCHEMA test;
 
 
 --
+-- Name: تست; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA تست;
+
+
+--
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -160,6 +167,14 @@ CREATE FUNCTION always_true(test.items) RETURNS boolean
 CREATE FUNCTION anti_id(test.items) RETURNS bigint
     LANGUAGE sql STABLE
     AS $_$ SELECT $1.id * -1 $_$;
+
+
+
+SET search_path = تست, pg_catalog;
+
+CREATE TABLE موارد (
+    هویت bigint NOT NULL
+);
 
 
 SET search_path = test, pg_catalog;
@@ -984,7 +999,6 @@ ALTER TABLE ONLY users_tasks
 
 ALTER TABLE ONLY users_tasks
     ADD CONSTRAINT users_tasks_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
-
 
 --
 -- PostgreSQL database dump complete


### PR DESCRIPTION
Test (suggested by @ruslantalpa) to ensure that non-English table/schema names are accessible.

I verified that it fails when cherry-picked onto v0.3.1.0:
```
status mismatch:
  expected: 200
  but got:  404
body mismatch:
  expected: []
  but got:  {"hint":null,"details":null,"code":"42P01","message":"relation \"*3*.EH'1/\" does not exist"}
```