### PR TITLE
Set transaction mode to READ on GET requests, fixes #547

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
+- Set transaction mode to READ when possible to support connecting to read replicas - @ruslantalpa
 
 ## [0.3.1.1] - 2016-03-28
 


### PR DESCRIPTION
Quick fix to allow connecting to read replicas.
In the future, functions like app, runWithClaims (anything that runs in the transaction) might need a bit of refactoring and have a common type (continuation passing style) like this, in order to allow composition if needed

ApiRequest -> (ApiRequest -> H.Transaction Response) -> H.Transaction Response
For now i don't think it's worth the effort