### PR TITLE
Set role only once, and set it before other GUC vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Prevent role from being changed twice - @begriffs
+
 ## [0.3.1.1] - 2016-03-28
 
 ### Fixed

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -42,11 +42,10 @@ import qualified Web.JWT                 as JWT
 -}
 claimsToSQL :: M.HashMap Text Value -> [BS.ByteString]
 claimsToSQL = map setVar . M.toList
-  where
-    setVar ("role", String val) = setRole val
-    setVar (k, val) = "set local " <> cs (pgFmtIdent $ "postgrest.claims." <> k)
-                      <> " = " <> cs (valueToVariable val) <> ";"
-    valueToVariable = pgFmtLit . unquoted
+ where
+  setVar (k, val) = "set local " <> cs (pgFmtIdent $ "postgrest.claims." <> k)
+                    <> " = " <> cs (valueToVariable val) <> ";"
+  valueToVariable = pgFmtLit . unquoted
 
 {-|
   Receives the JWT secret (from config) and a JWT and
@@ -71,8 +70,8 @@ jwtClaims secret input time =
   value2map _          = M.empty
 
 {-| Receives the name of a role and returns a SET ROLE statement -}
-setRole :: Text -> BS.ByteString
-setRole r = "set local role " <> cs (pgFmtLit r) <> ";"
+setRole :: Value -> BS.ByteString
+setRole r = "set local role " <> (cs . pgFmtLit $ unquoted r) <> ";"
 
 
 {-|


### PR DESCRIPTION
I verified in the sql logs that this fixes the order of `set local` statements. From the outside there is no change of behavior so I don't know what regression test I could add.