### PR TITLE
Accept JWT secrets that have crazy binary values

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -39,7 +39,7 @@ executable postgrest
                      , hasql-transaction >= 0.4.3 && < 0.5
                      , http-types
                      , interpolatedstring-perl6
-                     , jwt
+                     , jwt >= 0.7.1 && < 8
                      , lens >=3.8 && < 5.0
                      , lens-aeson >= 1.0.0.0 && < 1.1.0.0
                      , mtl

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -32,7 +32,7 @@ import           Options.Applicative
 import           Paths_postgrest             (version)
 import           Prelude
 import           Safe                        (readMay)
-import           Web.JWT                     (Secret, secret)
+import           Web.JWT                     (Secret, binarySecret)
 
 -- | Data type to store all command line options
 data AppConfig = AppConfig {
@@ -52,7 +52,7 @@ argParser = AppConfig
   <*> strOption    (long "anonymous"  <> short 'a' <> help "(REQUIRED) postgres role to use for non-authenticated requests" <> metavar "ROLE")
   <*> strOption    (long "schema"     <> short 's' <> help "schema to use for API routes" <> metavar "NAME" <> value "public" <> showDefault)
   <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
-  <*> (secret . cs <$>
+  <*> (binarySecret . cs <$>
       strOption    (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET" <> value "secret" <> showDefault))
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)
   <*> (readMay <$> strOption  (long "max-rows"   <> short 'm' <> help "max rows in response" <> metavar "COUNT" <> value "infinity" <> showDefault))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,11 @@
-resolver: lts-5.5
+resolver: lts-5.15
 extra-deps:
   - Ranged-sets-0.3.0
   - bytestring-tree-builder-0.2.5
   - hasql-0.19.9
   - hasql-pool-0.4
   - hasql-transaction-0.4.3
+  - jwt-0.7.1
   - packdeps-0.4.2.1
   - postgresql-error-codes-1
   - postgresql-binary-0.8.1


### PR DESCRIPTION
This PR converts the secret right to ByteString rather than to Text so that sequences of binary values which are invalid unicode are allowed. For instance the output of `openssl rand 8`.

This does not yet have a regression test.

Fixes #495.