### PR TITLE
Ability to rename columns/nodes in the output and support "-" in column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Reload database schema on SIGHUP - @begriffs
+- Support "-" in column names - @ruslantalpa
 
 ### Fixed
+- Set transaction mode to READ when possible to support connecting to read replicas - @ruslantalpa
 
 - Omit Content-Type header for empty body - @begriffs
 - Prevent role from being changed twice - @begriffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
-
 - Reload database schema on SIGHUP - @begriffs
 - Support "-" in column names - @ruslantalpa
+- Support column/node renaming `alias:column` - @ruslantalpa
 
 ### Fixed
-- Set transaction mode to READ when possible to support connecting to read replicas - @ruslantalpa
-
 - Omit Content-Type header for empty body - @begriffs
 - Prevent role from being changed twice - @begriffs
 - Use read-only transaction for read requests - @ruslantalpa

--- a/docs/api/reading.md
+++ b/docs/api/reading.md
@@ -258,7 +258,8 @@ but the the select query is recursive. You could for instance specify
 GET /foo?select=x, y, bar{z, w, baz{*}}
 ```
 
-You can select not only using table names, but also column names!
+You can select not only using table names, but also foreign key column names!
+This is especially needed when you have a table with two foreign keys pointing to the same table, for example billing_address_id and shipping_address_id.
 To embed the same foreign key row from our client example earlier
 you could do the following:
 
@@ -270,8 +271,7 @@ In the response there will be a `client_id` object containing all
 the data for that row.
 
 However, a `client_id` object doesn't make a lot of sense, so you
-could do one of two things. Create a view which renames `client_id`
-to just `client` (this is the hard way), or just try `client{*}`
+could do one of two things. Tell PostgREST that you want the key renamed by using the `alias` feature like so `client:client_id{*}`, or just try `client{*}`
 in the select parameter! PostgREST supports smart ducktype checking
 for common foreign key names, so if your column name ends with
 `_id`, `_fk`, or any variation of the two (including camelcase)
@@ -284,6 +284,25 @@ GET /projects?id=eq.1&select=id, name, client{*}
 ```
 
 Would embed in the `client` key the row referenced with `client_id`.
+
+The `alias` feature works for embedded entities and also for regular columns. This is useful in situations where for example you use different naming conventions in the database and frontend. 
+
+The following request will produce the output below:
+```HTTP
+GET /orders?id=eq.1&select=orderId:id, customer:customer_id{customerId:id, customerName:name}
+```
+
+```json
+[
+  {
+    "orderId": 1,
+    "customer": {
+      "customerId": 1,
+      "customerName": "John Smith"
+    }
+  }
+]
+```
 
 <div class="admonition note">
     <p class="admonition-title">Design Consideration</p>

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -7,10 +7,12 @@ module PostgREST.App (
 ) where
 
 import           Control.Applicative
+import           Control.Arrow             ((***))
+import           Control.Monad             (join)
 import           Data.Bifunctor            (first)
-import           Data.IORef                (IORef, readIORef)
-import           Data.List                 (find, delete)
+import           Data.List                 (find, sortBy, delete)
 import           Data.Maybe                (isJust, fromMaybe, fromJust, mapMaybe)
+import           Data.Ord                  (comparing)
 import           Data.Ranged.Ranges        (emptyRange)
 import           Data.String.Conversions   (cs)
 import           Data.Text                 (Text, replace, strip)
@@ -22,8 +24,10 @@ import qualified Hasql.Transaction         as HT
 import           Text.Parsec.Error
 import           Text.ParserCombinators.Parsec (parse)
 
+import           Network.HTTP.Base         (urlEncodeVars)
 import           Network.HTTP.Types.Header
 import           Network.HTTP.Types.Status
+import           Network.HTTP.Types.URI    (parseSimpleQuery)
 import           Network.Wai
 import           Network.Wai.Middleware.RequestLogger (logStdout)
 
@@ -60,31 +64,29 @@ import           PostgREST.Types
 import           Prelude
 
 
-postgrest :: AppConfig -> IORef DbStructure -> P.Pool -> Application
-postgrest conf refDbStructure pool =
-  let middle = (if configQuiet conf then id else logStdout) . defaultMiddle in
-
-  middle $ \ req respond -> do
-    time <- getPOSIXTime
-    body <- strictRequestBody req
-    dbStructure <- readIORef refDbStructure
-
-    let schema = cs $ configSchema conf
-        apiRequest = userApiRequest schema req body
-        handleReq = runWithClaims conf time (app dbStructure conf) apiRequest
-        txMode = transactionMode $ iAction apiRequest
-
-    resp <- either pgErrResponse id <$> P.use pool
-      (HT.run handleReq HT.ReadCommitted txMode)
-    respond resp
-
 transactionMode :: Action -> H.Mode
 transactionMode ActionRead = HT.Read
 transactionMode ActionInfo = HT.Read
 transactionMode _ = HT.Write
 
-app :: DbStructure -> AppConfig -> ApiRequest -> H.Transaction Response
-app dbStructure conf apiRequest =
+postgrest :: AppConfig -> DbStructure -> P.Pool -> Application
+postgrest conf dbStructure pool =
+  let middle = (if configQuiet conf then id else logStdout) . defaultMiddle in
+
+  middle $ \ req respond -> do
+    time <- getPOSIXTime
+    body <- strictRequestBody req
+
+    let schema = cs $ configSchema conf
+        apiRequest = userApiRequest schema req body
+        handleReq = runWithClaims conf time (app dbStructure conf apiRequest) req
+
+    resp <- either pgErrResponse id <$> P.use pool
+      (HT.run handleReq HT.ReadCommitted (transactionMode $ iAction apiRequest))
+    respond resp
+
+app :: DbStructure -> AppConfig -> ApiRequest -> Request -> H.Transaction Response
+app dbStructure conf apiRequest req =
   let
       -- TODO: blow up for Left values (there is a middleware that checks the headers)
       contentType = either (const ApplicationJSON) id (iAccepts apiRequest)
@@ -108,7 +110,11 @@ app dbStructure conf apiRequest =
               else responseLBS status200 [contentTypeH] (cs body)
             else do
               let (status, contentRange) = rangeHeader queryTotal tableTotal
-                  canonical = iCanonicalQS apiRequest
+                  canonical = urlEncodeVars -- should this be moved to the dbStructure (location)?
+                    . sortBy (comparing fst)
+                    . map (join (***) cs)
+                    . parseSimpleQuery
+                    $ rawQueryString req
               return $ responseLBS status
                 [contentTypeH, contentRange,
                   ("Content-Location",
@@ -127,14 +133,12 @@ app dbStructure conf apiRequest =
           let stm = createWriteStatement qi sq mq isSingle (iPreferRepresentation apiRequest) pKeys (contentType == TextCSV) payload
           row <- H.query uniform stm
           let (_, _, location, body) = extractQueryResult row
-
-          return $ if iPreferRepresentation apiRequest == Full
-            then responseLBS status201 [
-                  contentTypeH,
-                  (hLocation, "/" <> cs table <> "?" <> cs location)
-                ] (cs body)
-            else responseLBS status201
-              [(hLocation, "/" <> cs table <> "?" <> cs location)] ""
+          return $ responseLBS status201
+            [
+              contentTypeH,
+              (hLocation, "/" <> cs table <> "?" <> cs location)
+            ]
+            $ if iPreferRepresentation apiRequest == Full then cs body else ""
 
     (ActionUpdate, TargetIdent qi, Just payload@(PayloadJSON uniform)) ->
       case mutateSqlParts of
@@ -147,9 +151,8 @@ app dbStructure conf apiRequest =
               s = case () of _ | queryTotal == 0 -> status404
                                | iPreferRepresentation apiRequest == Full -> status200
                                | otherwise -> status204
-          return $ if iPreferRepresentation apiRequest == Full
-            then responseLBS s [contentTypeH, r] (cs body)
-            else responseLBS s [r] ""
+          return $ responseLBS s [contentTypeH, r]
+            $ if iPreferRepresentation apiRequest == Full then cs body else ""
 
     (ActionDelete, TargetIdent qi, Nothing) ->
       case mutateSqlParts of
@@ -333,11 +336,16 @@ addFilter (path, flt) (Node rn forest) =
   where
     targetNodeName:remainingPath = path
     (targetNode,restForest) = splitForest targetNodeName forest
+    splitForest :: NodeName -> Forest ReadNode -> (Maybe ReadRequest, Forest ReadNode)
     splitForest name forst =
       case maybeNode of
         Nothing -> (Nothing,forest)
         Just node -> (Just node, delete node forest)
-      where maybeNode = find ((name==).fst.snd.rootLabel) forst
+      where
+        maybeNode :: Maybe ReadRequest
+        maybeNode = find fnd forst
+          where
+            fnd :: ReadRequest -> Bool
 
 -- in a relation where one of the tables mathces "TableName"
 -- replace the name to that table with pg_source

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -106,16 +106,17 @@ data FValue = VText Text | VForeignKey QualifiedIdentifier ForeignKey deriving (
 type FieldName = Text
 type JsonPath = [Text]
 type Field = (FieldName, Maybe JsonPath)
+type Alias = Text
 type Cast = Text
 type NodeName = Text
-type SelectItem = (Field, Maybe Cast)
+type SelectItem = (Field, Maybe Cast, Maybe Alias)
 type Path = [Text]
 data ReadQuery = Select { select::[SelectItem], from::[TableName], flt_::[Filter], order::Maybe [OrderTerm] } deriving (Show, Eq)
 data MutateQuery = Insert { in_::TableName, qPayload::Payload }
                  | Delete { in_::TableName, where_::[Filter] }
                  | Update { in_::TableName, qPayload::Payload, where_::[Filter] } deriving (Show, Eq)
 data Filter = Filter {field::Field, operator::Operator, value::FValue} deriving (Show, Eq)
-type ReadNode = (ReadQuery, (NodeName, Maybe Relation))
+type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias))
 type ReadRequest = Tree ReadNode
 type MutateRequest = MutateQuery
 data DbRequest = DbRead ReadRequest | DbMutate MutateRequest

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -143,7 +143,11 @@ spec = do
 
     it "selectStar works in absense of parameter" $
       get "/complex_items?id=eq.3" `shouldRespondWith`
-        [str|[{"id":3,"name":"Three","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3]}]|]
+        [str|[{"id":3,"name":"Three","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3],"field-with_sep":1}]|]
+
+    it "dash `-` in column names is accepted" $
+      get "/complex_items?id=eq.3&select=id,field-with_sep" `shouldRespondWith`
+        [str|[{"id":3,"field-with_sep":1}]|]  
 
     it "one simple column" $
       get "/complex_items?select=id" `shouldRespondWith`

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -432,7 +432,8 @@ CREATE TABLE complex_items (
     id bigint NOT NULL,
     name text,
     settings pg_catalog.json,
-    arr_data integer[]
+    arr_data integer[],
+		"field-with_sep" integer default 1 not null
 );
 
 


### PR DESCRIPTION
With this PR now you can do this
`/projects?id=eq.1&select=myId:id, name, project_client:client_id{*}, project_tasks:tasks{id, name}`

to get this type of output
```
{
   "myId":1,
   "name":"Windows 7",
   "project_client":{
      "id":1,
      "name":"Microsoft"
   },
   "project_tasks":[
      {
         "id":1,
         "name":"Design w7"
      },
      {
         "id":2,
         "name":"Code w7"
      }
   ]
}
```

This can also close #310