### PR TITLE
Return proper 401/403 when access denied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Support column/node renaming `alias:column` - @ruslantalpa
 
 ### Fixed
+- Return 401 or 403 for access denied rather than 404 - @begriffs
 - Omit Content-Type header for empty body - @begriffs
 - Prevent role from being changed twice - @begriffs
 - Use read-only transaction for read requests - @ruslantalpa

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -13,6 +13,7 @@ very simple authentication system inside the PostgreSQL database.
 -}
 module PostgREST.Auth (
     claimsToSQL
+  , containsRole
   , jwtClaims
   , tokenJWT
   ) where
@@ -80,3 +81,10 @@ tokenJWT secret (Array arr) =
       jcs = parseMaybe parseJSON obj :: Maybe JWT.JWTClaimsSet in
   JWT.encodeSigned JWT.HS256 secret $ fromMaybe JWT.def jcs
 tokenJWT secret _ = tokenJWT secret emptyArray
+
+{-|
+  Whether a response from jwtClaims contains a role claim
+-}
+containsRole :: Either Text (M.HashMap Text Value) -> Bool
+containsRole (Left _) = False
+containsRole (Right claims) = M.member "role" claims

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -24,6 +24,7 @@ spec = do
         , {"schema":"test","name":"comments","insertable":true}
         , {"schema":"test","name":"complex_items","insertable":true}
         , {"schema":"test","name":"compound_pk","insertable":true}
+        , {"schema":"test","name":"empty_table","insertable":true}
         , {"schema":"test","name":"filtered_tasks","insertable":true}
         , {"schema":"test","name":"ghostBusters","insertable":true}
         , {"schema":"test","name":"has_count_column","insertable":false}

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -17,6 +17,7 @@ GRANT ALL ON TABLE
     , comments
     , complex_items
     , compound_pk
+    , empty_table
     , has_count_column
     , has_fk
     , insertable_view_with_join

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -459,6 +459,13 @@ CREATE TABLE empty_table (
 
 
 --
+-- Name: private_table; Type: TABLE; Schema: test; Owner: -
+--
+
+CREATE TABLE private_table ();
+
+
+--
 -- Name: has_count_column; Type: VIEW; Schema: test; Owner: -
 --
 


### PR DESCRIPTION
When PostgreSQL returns code `42501` for insufficient privilege we now return an access denied status code rather than a 404. If the request did not provide a JWT token with role claim then we return 401 Unauthorized with a `WWW-Authenticate` header. When the request does have a JWT with role then we return 403 Forbidden.

Fixes #584

As decided in the referenced issue we are changing the behavior unconditionally, no need for a special command-line flag.