### PR TITLE
Fix Windows build issue 589

### DIFF
--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -11,7 +11,6 @@ import           PostgREST.Config                     (AppConfig (..),
 import           PostgREST.DbStructure
 
 import           Control.Monad
-import           Control.Monad.IO.Class               (liftIO)
 import           Data.Monoid                          ((<>))
 import           Data.String.Conversions              (cs)
 import qualified Hasql.Query                          as H
@@ -27,9 +26,9 @@ import           Web.JWT                              (secret)
 #ifndef mingw32_HOST_OS
 import           System.Posix.Signals
 import           Control.Concurrent                   (myThreadId)
-import           Data.IORef
 import           Control.Exception.Base               (throwTo, AsyncException(..))
 #endif
+import           Data.IORef
 
 isServerVersionSupported :: H.Session Bool
 isServerVersionSupported = do

--- a/src/PostgREST/Main.hs
+++ b/src/PostgREST/Main.hs
@@ -23,12 +23,13 @@ import           System.IO                            (BufferMode (..),
                                                        hSetBuffering, stderr,
                                                        stdin, stdout)
 import           Web.JWT                              (secret)
+import           Data.IORef
 #ifndef mingw32_HOST_OS
+import           Control.Monad.IO.Class               (liftIO)
 import           System.Posix.Signals
 import           Control.Concurrent                   (myThreadId)
 import           Control.Exception.Base               (throwTo, AsyncException(..))
 #endif
-import           Data.IORef
 
 isServerVersionSupported :: H.Session Bool
 isServerVersionSupported = do


### PR DESCRIPTION
A small change in Main.hs to fix the Windows build. I moved Data.IORef outside of the block of code covered by `ifndef mingw32_HOST_OS` and deleted line 14, `Control.Monad.IO.Class` because that generated a warning about the import being redundant and the warning was treated as an error.