### PR TITLE
jwtClaims should always return Left for invalid JWT

### DIFF
--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -30,10 +30,7 @@ runWithClaims :: AppConfig -> Either Text (M.HashMap Text Value) ->
 runWithClaims conf eClaims app req =
   case eClaims of
     Left e -> clientErr e
-    Right claims ->
-      if M.null claims && not (null $ iJWT req)
-        then clientErr "Invalid JWT"
-        else do
+    Right claims -> do
           -- role claim defaults to anon if not specified in jwt
           H.sql . mconcat . claimsToSQL $ M.union claims (M.singleton "role" anon)
           app req


### PR DESCRIPTION
It's a tiny refactor but I believe the code is better like this.
Before this PR `jwtClaims` was returning a Right value in some invalid JWT cases, so we had to double check in our `Middleware` using a clumsy `if`.
It makes more sense to always return a `Left` value in error cases.
The PR also improves readability as the case for empty JWTs is now handled separately. 