### PR TITLE
Replace lens dependency for microlens

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -40,8 +40,8 @@ executable postgrest
                      , http-types
                      , interpolatedstring-perl6
                      , jwt
-                     , lens >=3.8 && < 5.0
-                     , lens-aeson >= 1.0.0.0 && < 1.1.0.0
+                     , microlens >= 0.4.2 && < 0.5
+                     , microlens-aeson >= 2.1.1 && < 2.2
                      , mtl
                      , optparse-applicative >= 0.11 && < 0.13
                      , parsec
@@ -84,8 +84,8 @@ library
                      , http-types
                      , interpolatedstring-perl6
                      , jwt
-                     , lens
-                     , lens-aeson
+                     , microlens
+                     , microlens-aeson
                      , mtl
                      , optparse-applicative
                      , parsec
@@ -158,8 +158,8 @@ Test-Suite spec
                      , http-types
                      , interpolatedstring-perl6
                      , jwt
-                     , lens
-                     , lens-aeson
+                     , microlens
+                     , microlens-aeson
                      , monad-control
                      , mtl
                      , optparse-applicative

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -18,9 +18,9 @@ module PostgREST.Auth (
   , tokenJWT
   ) where
 
-import           Control.Lens
+import           Lens.Micro
+import           Lens.Micro.Aeson
 import           Data.Aeson              (Value (..), parseJSON, toJSON)
-import           Data.Aeson.Lens
 import           Data.Aeson.Types        (parseMaybe, emptyObject, emptyArray)
 import qualified Data.ByteString         as BS
 import qualified Data.Vector             as V


### PR DESCRIPTION
We don't need the whole Lens library. The difference in compilation time is minimal though, but if you guys don't think it's worth changing I totally understand.
Compiling from scratch with lens:
<img width="225" alt="screen shot 2016-05-21 at 2 26 06 pm" src="https://cloud.githubusercontent.com/assets/20662/15450103/97eddc72-1f60-11e6-895f-30fdcd99b944.png">

Compiling from scratch with microlens:
<img width="227" alt="screen shot 2016-05-21 at 2 04 31 pm" src="https://cloud.githubusercontent.com/assets/20662/15450104/a15dc7c2-1f60-11e6-87f7-a478fb8356f3.png">
