### PR TITLE
Newdeps

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -34,9 +34,9 @@ executable postgrest
                      , containers
                      , contravariant
                      , errors
-                     , hasql >= 0.19.9 && < 0.20
-                     , hasql-pool >= 0.4 && < 0.5
-                     , hasql-transaction >= 0.4.3 && < 0.5
+                     , hasql == 0.19.12
+                     , hasql-pool == 0.4.1
+                     , hasql-transaction == 0.4.4.1
                      , http-types
                      , interpolatedstring-perl6
                      , jwt

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,13 @@
-resolver: lts-5.5
+resolver: lts-5.17
 extra-deps:
   - Ranged-sets-0.3.0
-  - bytestring-tree-builder-0.2.5
-  - hasql-0.19.9
-  - hasql-pool-0.4
-  - hasql-transaction-0.4.3
+  - bytestring-tree-builder-0.2.6
+  - hasql-0.19.12
+  - hasql-pool-0.4.1
+  - hasql-transaction-0.4.4.1
   - packdeps-0.4.2.1
   - postgresql-error-codes-1
-  - postgresql-binary-0.8.1
+  - postgresql-binary-0.9
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-monomorphism-restriction -fwarn-missing-exported-sigs -fwarn-identities
 


### PR DESCRIPTION
Upgrade the deps so @league is able to refactor sql array decoding.

One thing I did here is pin the hasql dependencies to exact versions so that `packdeps` can warn us in CI when newer versions come out on hackage. Will this be a problem for other programs which may want to use postgrest as a library, or will it (hopefully) affect only building the postgrest binary?