### PR TITLE
Limit embeded items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Accept posts from HTML forms - @begriffs
 - Ability to order embedded entities - @ruslantalpa
 - Ability to paginate using &limit and &offset parameters - @ruslantalpa
-- Ability to apply limits to embedded entities and enforce --max-rows on all levels - @ruslantalpa 
+- Ability to apply limits to embedded entities and enforce --max-rows on all levels - @ruslantalpa, @begriffs 
 
 ### Fixed
 - Return 401 or 403 for access denied rather than 404 - @begriffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Support column/node renaming `alias:column` - @ruslantalpa
 - Accept posts from HTML forms - @begriffs
 - Ability to order embedded entities - @ruslantalpa
+- Ability to paginate using &limit and &offset parameters - @ruslantalpa
+- Ability to apply limits to embedded entities and enforce --max-rows on all levels - @ruslantalpa 
 
 ### Fixed
 - Return 401 or 403 for access denied rather than 404 - @begriffs

--- a/docs/api/reading.md
+++ b/docs/api/reading.md
@@ -172,9 +172,9 @@ GET /people?order=age.nullsfirst
 GET /people?order=age.desc.nullslast
 ```
 
-To filter the embedded items, you need to specify the tree path for the order param like so. 
+To order the embedded items, you need to specify the tree path for the order param like so.
 ```HTTP
-GET /projects?select=id,name,tasks{id,name}&order=id.asc&tasks.order=name.ask
+GET /projects?select=id,name,tasks{id,name}&order=id.ask&tasks.order=name.ask
 ```
 
 
@@ -213,6 +213,15 @@ Range: 0-4
 
 You can also use open-ended ranges for an offset with no limit:
 `Range: 10-`.
+
+In addition to the `Range` header, you can use `&limit` and `&offset` parameters
+to achieve the same result.
+
+You can also set a limit (but not offset) for the embedded items like so
+```HTTP
+/posts?select=id,title,body,comments{id,email,body}&limit=10&comments.limit=3
+```
+The above request will return the first 10 posts and for each of the posts, 3 comments at most
 
 #### Suppressing Counts
 
@@ -309,6 +318,13 @@ GET /orders?id=eq.1&select=orderId:id, customer:customer_id{customerId:id, custo
   }
 ]
 ```
+
+If you want to apply filters to the embedded items, you can do that like so:
+```HTTP
+GET /clients?id=eq.42&select=id,name,projects{id,name,is_active}&projects.is_active=eq.true
+```
+The above request will return the client with id=42 and all the projects for that client that are still active
+
 
 <div class="admonition note">
     <p class="admonition-title">Design Consideration</p>

--- a/docs/api/reading.md
+++ b/docs/api/reading.md
@@ -174,7 +174,7 @@ GET /people?order=age.desc.nullslast
 
 To order the embedded items, you need to specify the tree path for the order param like so.
 ```HTTP
-GET /projects?select=id,name,tasks{id,name}&order=id.ask&tasks.order=name.ask
+GET /projects?select=id,name,tasks{id,name}&order=id.asc&tasks.order=name.asc
 ```
 
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -47,7 +47,7 @@ import           PostgREST.Config          (AppConfig (..))
 import           PostgREST.DbStructure
 import           PostgREST.Error           (errResponse, pgErrResponse)
 import           PostgREST.Parsers
-import           PostgREST.RangeQuery
+import           PostgREST.RangeQuery      (NonnegRange, allRange, rangeOffset, restrictRange)
 import           PostgREST.Middleware
 import           PostgREST.QueryBuilder ( callProc
                                         , addJoinConditions
@@ -221,7 +221,7 @@ app dbStructure conf apiRequest =
   allOrigins = ("Access-Control-Allow-Origin", "*") :: Header
   schema = cs $ configSchema conf
   shouldCount = iPreferCount apiRequest
-  topLevelRange = fromMaybe (rangeGeq 0) $ M.lookup "limit" $ iRange apiRequest
+  topLevelRange = fromMaybe allRange $ M.lookup "limit" $ iRange apiRequest
   readDbRequest = DbRead <$> buildReadRequest (configMaxRows conf) (dbRelations dbStructure) apiRequest
   mutateDbRequest = DbMutate <$> buildMutateRequest apiRequest
   selectQuery = requestToQuery schema <$> readDbRequest
@@ -379,7 +379,7 @@ addOrder :: (Path, [OrderTerm]) -> ReadRequest -> ReadRequest
 addOrder = addProperty addOrderToNode
 
 addRangeToNode :: NonnegRange -> ReadRequest -> ReadRequest
-addRangeToNode r (Node (q,i) f) = Node (q{range_=Just r}, i) f
+addRangeToNode r (Node (q,i) f) = Node (q{range_=r}, i) f
 
 addRange :: (Path, NonnegRange) -> ReadRequest -> ReadRequest
 addRange = addProperty addRangeToNode

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -11,15 +11,14 @@ import           Data.Tree
 import           PostgREST.QueryBuilder        (operators)
 import           PostgREST.Types
 import           Text.ParserCombinators.Parsec hiding (many, (<|>))
-import           PostgREST.RangeQuery      (NonnegRange)
-
+import           PostgREST.RangeQuery      (NonnegRange,allRange)
 
 pRequestSelect :: Text -> Parser ReadRequest
 pRequestSelect rootNodeName = do
   fieldTree <- pFieldForest
   return $ foldr treeEntry (Node (readQuery, (rootNodeName, Nothing, Nothing)) []) fieldTree
   where
-    readQuery = Select [] [rootNodeName] [] Nothing Nothing
+    readQuery = Select [] [rootNodeName] [] Nothing allRange
     treeEntry :: Tree SelectItem -> ReadRequest -> ReadRequest
     treeEntry (Node fld@((fn, _),_,alias) fldForest) (Node (q, i) rForest) =
       case fldForest of
@@ -27,7 +26,7 @@ pRequestSelect rootNodeName = do
         _  -> Node (q, i) newForest
           where
             newForest =
-              foldr treeEntry (Node (Select [] [fn] [] Nothing Nothing, (fn, Nothing, alias)) []) fldForest:rForest
+              foldr treeEntry (Node (Select [] [fn] [] Nothing allRange, (fn, Nothing, alias)) []) fldForest:rForest
 
 pRequestFilter :: (String, String) -> Either ParseError (Path, Filter)
 pRequestFilter (k, v) = (,) <$> path <*> (Filter <$> fld <*> op <*> val)

--- a/src/PostgREST/RangeQuery.hs
+++ b/src/PostgREST/RangeQuery.hs
@@ -4,13 +4,16 @@ module PostgREST.RangeQuery (
 , rangeLimit
 , rangeOffset
 , restrictRange
+, rangeGeq
 , NonnegRange
+, limitToRange
+, toRange
 ) where
 
 
 import           Control.Applicative
 import           Network.HTTP.Types.Header
-import           PostgREST.Types           ()
+import           Data.Monoid               ((<>))
 
 import qualified Data.ByteString.Char8     as BS
 import           Data.Ranged.Boundaries
@@ -38,12 +41,13 @@ rangeParse range = do
       rangeIntersection lower upper
     Nothing -> rangeGeq 0
 
-rangeRequested :: RequestHeaders -> NonnegRange
-rangeRequested = rangeParse . fromMaybe "" . lookup hRange
+rangeRequested :: RequestHeaders -> Maybe NonnegRange
+rangeRequested headers = rangeParse <$> lookup hRange headers
 
-restrictRange :: Maybe Integer -> NonnegRange -> NonnegRange
+restrictRange :: Maybe Integer -> Maybe NonnegRange -> Maybe NonnegRange
 restrictRange Nothing r = r
-restrictRange (Just limit) r =
+restrictRange (Just limit) Nothing = Just $ rangeIntersection (rangeGeq 0) (rangeLeq (limit - 1))
+restrictRange (Just limit) (Just r) = Just $
   rangeIntersection r $
     Range BoundaryBelowAll (BoundaryAbove $ rangeOffset r + limit - 1)
 
@@ -66,3 +70,17 @@ rangeGeq n =
 rangeLeq :: Integer -> NonnegRange
 rangeLeq n =
   Range BoundaryBelowAll (BoundaryAbove n)
+
+limitToRange :: BS.ByteString -> NonnegRange
+limitToRange l = rangeParse ("0-" <> cs (show (l' - 1)))
+  where l' = fromMaybe 0 (readMaybe $ cs l)::Integer
+
+toRange :: Maybe String -> Maybe String -> Maybe NonnegRange
+toRange Nothing Nothing = Nothing
+toRange Nothing (Just o) = Just $ rangeParse $ cs $ show o' <> "-"
+  where o' = fromMaybe 0 (readMaybe $ cs o)::Integer
+toRange (Just l) Nothing = Just $ limitToRange $ cs l
+toRange (Just l) (Just o) = Just $ rangeParse $ cs $ show o' <> "-" <> show (o' + l' - 1)
+  where
+    l' = fromMaybe 0 (readMaybe $ cs l)::Integer
+    o' = fromMaybe 0 (readMaybe $ cs o)::Integer

--- a/src/PostgREST/RangeQuery.hs
+++ b/src/PostgREST/RangeQuery.hs
@@ -5,15 +5,13 @@ module PostgREST.RangeQuery (
 , rangeOffset
 , restrictRange
 , rangeGeq
+, allRange
 , NonnegRange
-, limitToRange
-, toRange
 ) where
 
 
 import           Control.Applicative
 import           Network.HTTP.Types.Header
-import           Data.Monoid               ((<>))
 
 import qualified Data.ByteString.Char8     as BS
 import           Data.Ranged.Boundaries
@@ -37,19 +35,19 @@ rangeParse range = do
     Just parsedRange ->
       let [_, from, to] = readMaybe . cs <$> parsedRange
           lower         = fromMaybe emptyRange   (rangeGeq <$> from)
-          upper         = fromMaybe (rangeGeq 0) (rangeLeq <$> to) in
+          upper         = fromMaybe allRange (rangeLeq <$> to) in
       rangeIntersection lower upper
-    Nothing -> rangeGeq 0
+    Nothing -> allRange
 
-rangeRequested :: RequestHeaders -> Maybe NonnegRange
-rangeRequested headers = rangeParse <$> lookup hRange headers
+rangeRequested :: RequestHeaders -> NonnegRange
+rangeRequested headers = fromMaybe allRange $
+  rangeParse <$> lookup hRange headers
 
-restrictRange :: Maybe Integer -> Maybe NonnegRange -> Maybe NonnegRange
+restrictRange :: Maybe Integer -> NonnegRange -> NonnegRange
 restrictRange Nothing r = r
-restrictRange (Just limit) Nothing = Just $ rangeIntersection (rangeGeq 0) (rangeLeq (limit - 1))
-restrictRange (Just limit) (Just r) = Just $
-  rangeIntersection r $
-    Range BoundaryBelowAll (BoundaryAbove $ rangeOffset r + limit - 1)
+restrictRange (Just limit) r =
+   rangeIntersection r $
+     Range BoundaryBelowAll (BoundaryAbove $ rangeOffset r + limit - 1)
 
 rangeLimit :: NonnegRange -> Maybe Integer
 rangeLimit range =
@@ -67,20 +65,9 @@ rangeGeq :: Integer -> NonnegRange
 rangeGeq n =
   Range (BoundaryBelow n) BoundaryAboveAll
 
+allRange :: NonnegRange
+allRange = rangeGeq 0
+
 rangeLeq :: Integer -> NonnegRange
 rangeLeq n =
   Range BoundaryBelowAll (BoundaryAbove n)
-
-limitToRange :: BS.ByteString -> NonnegRange
-limitToRange l = rangeParse ("0-" <> cs (show (l' - 1)))
-  where l' = fromMaybe 0 (readMaybe $ cs l)::Integer
-
-toRange :: Maybe String -> Maybe String -> Maybe NonnegRange
-toRange Nothing Nothing = Nothing
-toRange Nothing (Just o) = Just $ rangeParse $ cs $ show o' <> "-"
-  where o' = fromMaybe 0 (readMaybe $ cs o)::Integer
-toRange (Just l) Nothing = Just $ limitToRange $ cs l
-toRange (Just l) (Just o) = Just $ rangeParse $ cs $ show o' <> "-" <> show (o' + l' - 1)
-  where
-    l' = fromMaybe 0 (readMaybe $ cs l)::Integer
-    o' = fromMaybe 0 (readMaybe $ cs o)::Integer

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -6,6 +6,7 @@ import           Data.Int             (Int32)
 import           Data.Text
 import           Data.Tree
 import qualified Data.Vector          as V
+import           PostgREST.RangeQuery (NonnegRange)
 
 data DbStructure = DbStructure {
   dbTables      :: [Table]
@@ -111,7 +112,7 @@ type Cast = Text
 type NodeName = Text
 type SelectItem = (Field, Maybe Cast, Maybe Alias)
 type Path = [Text]
-data ReadQuery = Select { select::[SelectItem], from::[TableName], flt_::[Filter], order::Maybe [OrderTerm] } deriving (Show, Eq)
+data ReadQuery = Select { select::[SelectItem], from::[TableName], flt_::[Filter], order::Maybe [OrderTerm], range_::Maybe NonnegRange } deriving (Show, Eq)
 data MutateQuery = Insert { in_::TableName, qPayload::Payload }
                  | Delete { in_::TableName, where_::[Filter] }
                  | Update { in_::TableName, qPayload::Payload, where_::[Filter] } deriving (Show, Eq)

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -112,7 +112,7 @@ type Cast = Text
 type NodeName = Text
 type SelectItem = (Field, Maybe Cast, Maybe Alias)
 type Path = [Text]
-data ReadQuery = Select { select::[SelectItem], from::[TableName], flt_::[Filter], order::Maybe [OrderTerm], range_::Maybe NonnegRange } deriving (Show, Eq)
+data ReadQuery = Select { select::[SelectItem], from::[TableName], flt_::[Filter], order::Maybe [OrderTerm], range_::NonnegRange } deriving (Show, Eq)
 data MutateQuery = Insert { in_::TableName, qPayload::Payload }
                  | Delete { in_::TableName, where_::[Filter] }
                  | Update { in_::TableName, qPayload::Payload, where_::[Filter] } deriving (Show, Eq)

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -5,7 +5,7 @@ import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 import Network.HTTP.Types
 import Network.Wai.Test (SResponse(simpleHeaders, simpleStatus))
-
+import Text.Heredoc
 import SpecHelper
 import Network.Wai (Application)
 
@@ -15,15 +15,23 @@ spec =
     it "restricts results" $
       get "/items"
         `shouldRespondWith` ResponseMatcher {
-          matchBody    = Just [json| [{"id":1},{"id":2},{"id":3}] |]
+          matchBody    = Just [json| [{"id":1},{"id":2}] |]
         , matchStatus  = 206
-        , matchHeaders = ["Content-Range" <:> "0-2/15"]
+        , matchHeaders = ["Content-Range" <:> "0-1/15"]
         }
 
     it "respects additional client limiting" $ do
       r <- request methodGet  "/items"
-                   (rangeHdrs $ ByteRangeFromTo 0 1) ""
+                   (rangeHdrs $ ByteRangeFromTo 0 0) ""
       liftIO $ do
         simpleHeaders r `shouldSatisfy`
-          matchHeader "Content-Range" "0-1/15"
+          matchHeader "Content-Range" "0-0/15"
         simpleStatus r `shouldBe` partialContent206
+
+    it "limit works on all levels" $
+      get "/users?select=id,tasks{id}&order=id.asc&tasks.order=id.asc"
+        `shouldRespondWith` ResponseMatcher {
+          matchBody    = Just [str|[{"id":1,"tasks":[{"id":1},{"id":2}]},{"id":2,"tasks":[{"id":5},{"id":6}]}]|]
+        , matchStatus  = 206
+        , matchHeaders = ["Content-Range" <:> "0-1/3"]
+        }

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -27,7 +27,7 @@ testUnicodeCfg =
 
 testLtdRowsCfg :: AppConfig
 testLtdRowsCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" "test" 3000 (secret "safe") 10 (Just 3) True
+  AppConfig testDbConn "postgrest_test_anonymous" "test" 3000 (secret "safe") 10 (Just 2) True
 
 setupDb :: IO ()
 setupDb = do


### PR DESCRIPTION
This PR allows limiting embedded items and also enforces globally `--max-rows` setting.
In addition, it's possible now to specify the top level limit/range by using `&limit` and `&offset` (but Range header overrides them).
Just like for ordering, you specify the limit using `tree.path.limit=10`, however `offset` can only be specified for the top level (it does not make sense for the embedded items)

The code still needs a lot of cleanup (mainly because i don't fully understand the Range datatype, i just "guest" how it works, so i "improvised" some functions to fit my needs) but it works as it should and the tests pass.

Mainly i would like help with cleaning up/simplifying things in `ApiRequest.hs` and `RangeQuery.hs`, the rest of the files i will cleanup.