### PR TITLE
Add Github issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Context
+<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
+
+## Possible Fix
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this bug affected you? What were you trying to accomplish? -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* PostgREST version:
+* PostgreSQL version:
+* Operating System and version:
+* Link to your project:


### PR DESCRIPTION
When people open a new issue they will see these questions. Should help automate getting useful information. Any suggestions for improvements? I got it from https://www.talater.com/open-source-templates/#/page/98 and modified it slightly