### PR TITLE
Rpc refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Ability to generate an OpenAPI spec - @mainx07, @hudayou, @ruslantalpa, @begriffs
 - Ability to set addresses to listen on - @hudayou
-
+- Filtering, shaping and embedding with &select for the /rpc path - @ruslantalpa
 - Output names of used-defined types (instead of 'USER-DEFINED') - @martingms
 
 ### Fixed

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -186,22 +186,18 @@ app dbStructure conf apiRequest =
 
     (ActionInvoke, TargetProc qi,
      Just (PayloadJSON (UniformObjects payload))) -> do
-      exists <- H.query qi doesProcExist
-      if exists
-        then do
-          let p = V.head payload
-              jwtSecret = configJwtSecret conf
-          respondToRange $ do
-            row <- H.query () (callProc qi p topLevelRange shouldCount)
-            returnJWT <- H.query qi doesProcReturnJWT
-            let (tableTotal, queryTotal, body) = fromMaybe (Just 0, 0, emptyArray) row
-                (status, contentRange) = rangeHeader queryTotal tableTotal
-              in
-              return $ responseLBS status [jsonH, contentRange]
-                      (if returnJWT
-                      then "{\"token\":\"" <> cs (tokenJWT jwtSecret body) <> "\"}"
-                      else cs $ encode body)
-        else return notFound
+        let p = V.head payload
+            jwtSecret = configJwtSecret conf
+        respondToRange $ do
+          row <- H.query () (callProc qi p topLevelRange shouldCount)
+          returnJWT <- H.query qi doesProcReturnJWT
+          let (tableTotal, queryTotal, body) = fromMaybe (Just 0, 0, emptyArray) row
+              (status, contentRange) = rangeHeader queryTotal tableTotal
+            in
+            return $ responseLBS status [jsonH, contentRange]
+                    (if returnJWT
+                    then "{\"token\":\"" <> cs (tokenJWT jwtSecret body) <> "\"}"
+                    else cs $ encode body)
 
     (ActionRead, TargetRoot, Nothing) -> do
       let encodeApi ti = encodeOpenAPI ti host port

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -188,9 +188,10 @@ app dbStructure conf apiRequest =
      Just (PayloadJSON (UniformObjects payload))) -> do
         let p = V.head payload
             jwtSecret = configJwtSecret conf
+            returnJWT = qiName qi `elem` dbProcsReturningJWT dbStructure
         respondToRange $ do
           row <- H.query () (callProc qi p topLevelRange shouldCount)
-          returnJWT <- H.query qi doesProcReturnJWT
+          --returnJWT <- H.query qi doesProcReturnJWT
           let (tableTotal, queryTotal, body) = fromMaybe (Just 0, 0, emptyArray) row
               (status, contentRange) = rangeHeader queryTotal tableTotal
             in

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -14,7 +14,7 @@ import           Data.List                 (find, delete)
 import           Data.Maybe                (fromMaybe, fromJust, mapMaybe)
 import           Data.Ranged.Ranges        (emptyRange)
 import           Data.String.Conversions   (cs)
-import           Data.Text                 (Text, replace, strip)
+import           Data.Text                 (Text, replace, strip, isInfixOf, dropWhile, drop)
 import           Data.Tree
 
 import qualified Hasql.Pool                as P
@@ -62,7 +62,7 @@ import           PostgREST.QueryBuilder ( callProc
 import           PostgREST.Types
 import           PostgREST.OpenAPI
 
-import           Prelude
+import           Prelude                hiding (dropWhile, drop)
 
 
 postgrest :: AppConfig -> IORef DbStructure -> P.Pool -> Application
@@ -189,17 +189,17 @@ app dbStructure conf apiRequest =
         let p = V.head payload
             singular = iPreferSingular apiRequest
             jwtSecret = configJwtSecret conf
-            returnJWT = qiName qi `elem` dbProcsReturningJWT dbStructure
+            returnType = lookup (qiName qi) $ dbProcs dbStructure
+            returnsJWT = fromMaybe False $ isInfixOf "jwt_claims" <$> returnType
         case readSqlParts of
           Left e -> return $ responseLBS status400 [jsonH] $ cs e
           Right (q,cq) -> respondToRange $ do
             row <- H.query () (callProc qi p q cq topLevelRange shouldCount singular)
-            --returnJWT <- H.query qi doesProcReturnJWT
             let (tableTotal, queryTotal, body) = fromMaybe (Just 0, 0, emptyArray) row
                 (status, contentRange) = rangeHeader queryTotal tableTotal
               in
               return $ responseLBS status [jsonH, contentRange]
-                      (if returnJWT
+                      (if returnsJWT
                       then "{\"token\":\"" <> cs (tokenJWT jwtSecret body) <> "\"}"
                       else cs $ encode body)
 
@@ -241,7 +241,7 @@ app dbStructure conf apiRequest =
   schema = cs $ configSchema conf
   shouldCount = iPreferCount apiRequest
   topLevelRange = fromMaybe allRange $ M.lookup "limit" $ iRange apiRequest
-  readDbRequest = DbRead <$> buildReadRequest (configMaxRows conf) (dbRelations dbStructure) apiRequest
+  readDbRequest = DbRead <$> buildReadRequest (configMaxRows conf) (dbRelations dbStructure) (dbProcs dbStructure) apiRequest
   mutateDbRequest = DbMutate <$> buildMutateRequest apiRequest
   selectQuery = requestToQuery schema False <$> readDbRequest
   countQuery = requestToCountQuery schema <$> readDbRequest
@@ -341,8 +341,8 @@ treeRestrictRange maxRows_ request = pure $ nodeRestrictRange maxRows_ `fmap` re
     nodeRestrictRange :: Maybe Integer -> ReadNode -> ReadNode
     nodeRestrictRange m (q@Select {range_=r}, i) = (q{range_=restrictRange m r }, i)
 
-buildReadRequest :: Maybe Integer -> [Relation] -> ApiRequest -> Either Text ReadRequest
-buildReadRequest maxRows allRels apiRequest  =
+buildReadRequest :: Maybe Integer -> [Relation] -> [(Text, Text)] -> ApiRequest -> Either Text ReadRequest
+buildReadRequest maxRows allRels allProcs apiRequest  =
   treeRestrictRange maxRows =<<
   augumentRequestWithJoin schema relations =<<
   first formatParserError readRequest
@@ -351,7 +351,13 @@ buildReadRequest maxRows allRels apiRequest  =
       let target = iTarget apiRequest in
       case target of
         (TargetIdent (QualifiedIdentifier s t) ) -> Just (s, t)
-        (TargetProc  (QualifiedIdentifier s p) ) -> Just (s, p)
+        (TargetProc  (QualifiedIdentifier s p) ) -> Just (s, t)
+          where
+            returnType = fromMaybe "" $ lookup p allProcs
+            -- we are looking for results looking like "SETOF schema.tablename" and want to extract tablename
+            t = if "SETOF " `isInfixOf` returnType
+              then drop 1 $ dropWhile (/= '.') returnType
+              else p
 
         _ -> Nothing
 
@@ -372,6 +378,7 @@ buildReadRequest maxRows allRels apiRequest  =
       ActionCreate -> fakeSourceRelations ++ allRels
       ActionUpdate -> fakeSourceRelations ++ allRels
       ActionDelete -> fakeSourceRelations ++ allRels
+      ActionInvoke -> fakeSourceRelations ++ allRels
       _       -> allRels
       where fakeSourceRelations = mapMaybe (toSourceRelation rootTableName) allRels -- see comment in toSourceRelation
 

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -6,7 +6,6 @@
 module PostgREST.DbStructure (
   getDbStructure
 , accessibleTables
-, doesProcExist
 , doesProcReturnJWT
 ) where
 
@@ -103,19 +102,6 @@ decodeSynonyms cols =
     <$> HD.value HD.text <*> HD.value HD.text
     <*> HD.value HD.text <*> HD.value HD.text
     <*> HD.value HD.text <*> HD.value HD.text
-
-doesProcExist :: H.Query QualifiedIdentifier Bool
-doesProcExist =
-  H.statement sql encodeQi (HD.singleRow (HD.value HD.bool)) True
- where
-  sql = [q| SELECT EXISTS (
-      SELECT 1
-      FROM   pg_catalog.pg_namespace n
-      JOIN   pg_catalog.pg_proc p
-      ON     pronamespace = n.oid
-      WHERE  nspname = $1
-      AND    proname = $2
-    ) |]
 
 doesProcReturnJWT :: H.Query QualifiedIdentifier Bool
 doesProcReturnJWT =

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -212,15 +212,13 @@ callProc qi params selectQuery countQuery _ countTotal isSingle =
             SELECT
               {countResultF} AS total_result_set,
               pg_catalog.count(t) AS page_total,
-              case when pg_catalog.count(1) > 1
-            		then {bodyF}
-            	    else (
-            	    	select case when ((array_agg(row_to_json(t)))[1]->{_procName}) is not null
-            		    	then ((array_agg(row_to_json(t)))[1]->{_procName})::character varying
-            		    	else {bodyF}
-            		    end
-            	    )
-            	end as body
+              case 
+                when pg_catalog.count(1) > 1 then 
+                  {bodyF}
+                else
+                  coalesce(((array_agg(row_to_json(t)))[1]->{_procName})::character varying, {bodyF})
+
+              end as body
             FROM ({selectQuery}) t;
           |]
           -- FROM (select * from {sourceCTEName} {limitF range}) t;

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -13,6 +13,7 @@ data DbStructure = DbStructure {
 , dbColumns     :: [Column]
 , dbRelations   :: [Relation]
 , dbPrimaryKeys :: [PrimaryKey]
+, dbProcsReturningJWT :: [Text]
 } deriving (Show, Eq)
 
 type Schema = Text

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -13,7 +13,7 @@ data DbStructure = DbStructure {
 , dbColumns     :: [Column]
 , dbRelations   :: [Relation]
 , dbPrimaryKeys :: [PrimaryKey]
-, dbProcsReturningJWT :: [Text]
+, dbProcs       :: [(Text,Text)]
 } deriving (Show, Eq)
 
 type Schema = Text

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -477,6 +477,11 @@ spec = do
         request methodPost "/rpc/sayhello"
           (acceptHdrs "application/json") "sdfsdf"
             `shouldRespondWith` 400
+      -- it used to be 404 and it makes sense but in another part we decided that it's good to return
+      -- PostgreSQL errors (and have the proxy handle them) and this saves us an aditional query on each rpc request
+      it "responds with 400 on an unexisting proc" $
+        post "/rpc/fake" [json| {} |] `shouldRespondWith` 400
+
 
     context "unsupported verbs" $ do
       it "DELETE fails" $

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -454,6 +454,38 @@ spec = do
         post "/rpc/getitemrange" [json| { "min": 2, "max": 4 } |] `shouldRespondWith`
           [json| [ {"id": 3}, {"id":4} ] |]
 
+    context "shaping the response returned by a proc" $ do
+      it "returns a project" $
+        post "/rpc/getproject" [json| { "id": 1} |] `shouldRespondWith`
+          [json|[{"id":1,"name":"Windows 7","client_id":1}]|]
+
+      it "can filter proc results" $
+        post "/rpc/getallprojects?id=gt.1&id=lt.5&select=id" [json| {} |] `shouldRespondWith`
+          [json|[{"id":2},{"id":3},{"id":4}]|]
+
+      it "can limit proc results" $
+        post "/rpc/getallprojects?id=gt.1&id=lt.5&select=id?limit=2&offset=1" [json| {} |]
+          `shouldRespondWith` ResponseMatcher {
+               matchBody    = Just [json|[{"id":3},{"id":4}]|]
+             , matchStatus = 206
+             , matchHeaders = ["Content-Range" <:> "1-2/3"]
+             }
+
+
+
+      it "prefer singular" $
+        request methodPost "/rpc/getproject"
+          [("Prefer","plurality=singular")] [json| { "id": 1} |] `shouldRespondWith`
+          [json|{"id":1,"name":"Windows 7","client_id":1}|]
+
+      it "select works on the first level" $
+        post "/rpc/getproject?select=id,name" [json| { "id": 1} |] `shouldRespondWith`
+          [json|[{"id":1,"name":"Windows 7"}]|]
+
+      it "can embed foreign entities to the items returned by a proc" $
+        post "/rpc/getproject?select=id,name,client{id},tasks{id}" [json| { "id": 1} |] `shouldRespondWith`
+          [json|[{"id":1,"name":"Windows 7","client":{"id":2},"tasks":[{"id":1}]}]|]
+
     context "a proc that returns an empty rowset" $
       it "returns empty json array" $
         post "/rpc/test_empty_rowset" [json| {} |] `shouldRespondWith`
@@ -462,11 +494,11 @@ spec = do
     context "a proc that returns plain text" $ do
       it "returns proper json" $
         post "/rpc/sayhello" [json| { "name": "world" } |] `shouldRespondWith`
-          [json| [{"sayhello":"Hello, world"}] |]
+          [json|"Hello, world"|]
 
       it "can handle unicode" $
         post "/rpc/sayhello" [json| { "name": "￥" } |] `shouldRespondWith`
-          [json| [{"sayhello":"Hello, ￥"}] |]
+          [json|"Hello, ￥"|]
 
     context "improper input" $ do
       it "rejects unknown content type even if payload is good" $
@@ -502,9 +534,9 @@ spec = do
 
     it "executes the proc exactly once per request" $ do
       post "/rpc/callcounter" [json| {} |] `shouldRespondWith`
-        [json| [{"callcounter":1}] |]
+        [json|1|]
       post "/rpc/callcounter" [json| {} |] `shouldRespondWith`
-        [json| [{"callcounter":2}] |]
+        [json|2|]
 
   describe "weird requests" $ do
     it "can query as normal" $ do

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -484,7 +484,7 @@ spec = do
 
       it "can embed foreign entities to the items returned by a proc" $
         post "/rpc/getproject?select=id,name,client{id},tasks{id}" [json| { "id": 1} |] `shouldRespondWith`
-          [json|[{"id":1,"name":"Windows 7","client":{"id":2},"tasks":[{"id":1}]}]|]
+          [json|[{"id":1,"name":"Windows 7","client":{"id":1},"tasks":[{"id":1},{"id":2}]}]|]
 
     context "a proc that returns an empty rowset" $
       it "returns empty json array" $

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1021,6 +1021,18 @@ create table orders (
 	shipping_address_id  int references addresses(id)
 );
 
+CREATE FUNCTION getproject(id int) RETURNS SETOF projects
+    LANGUAGE sql
+    AS $_$
+    SELECT * FROM test.projects WHERE id = $1;
+$_$;
+
+CREATE FUNCTION getallprojects() RETURNS SETOF projects
+    LANGUAGE sql
+    AS $_$
+    SELECT * FROM test.projects;
+$_$;
+
 --
 -- PostgreSQL database dump complete
 --


### PR DESCRIPTION
This PR introduces a breaking change, for functions that return scalar types, the output will be directly that value, it used to be wrapped in `[{functionname:...}]`.
This particular change, coupled with the fact that before running the PRC we know the output type, we can generate different queries (for example binary output). These issues are addressed #600 #599.

The other (more interesting) features are the fact that RPC path now joins the elites :) (GET/POST/PATH/DELETE) and supports filtering and shaping/embedding with &select

Enjoy