### PR TITLE
Remove unix dependency for tests

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -180,7 +180,6 @@ Test-Suite spec
                      , transformers
                      , transformers-base
                      , unordered-containers
-                     , unix
                      , vector
                      , wai
                      , wai-cors


### PR DESCRIPTION
Allows `stack test` to build and pass on Windows.