### PR TITLE
Name custom types and domains on OPTIONS requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Output names of used-defined types (instead of 'USER-DEFINED') - @martingms
+
 ### Fixed
 
 ## [0.3.2.0] - 2016-06-10

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -285,18 +285,8 @@ allColumns tabs =
                         ELSE 'YES'::text
                     END::information_schema.yes_or_no AS is_nullable,
                     CASE
-                        WHEN t.typtype = 'd'::"char" THEN
-                        CASE
-                            WHEN bt.typelem <> 0::oid AND bt.typlen = (-1) THEN 'ARRAY'::text
-                            WHEN nbt.nspname = 'pg_catalog'::name THEN format_type(t.typbasetype, NULL::integer)
-                            ELSE 'USER-DEFINED'::text
-                        END
-                        ELSE
-                        CASE
-                            WHEN t.typelem <> 0::oid AND t.typlen = (-1) THEN 'ARRAY'::text
-                            WHEN nt.nspname = 'pg_catalog'::name THEN format_type(a.atttypid, NULL::integer)
-                            ELSE 'USER-DEFINED'::text
-                        END
+                        WHEN bt.typelem <> 0::oid AND bt.typlen = (-1) THEN 'ARRAY'::text
+                        ELSE format_type(a.atttypid, a.atttypmod)
                     END::information_schema.character_data AS data_type,
                 information_schema._pg_char_max_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_maximum_length,
                 information_schema._pg_char_octet_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_octet_length,

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -285,8 +285,18 @@ allColumns tabs =
                         ELSE 'YES'::text
                     END::information_schema.yes_or_no AS is_nullable,
                     CASE
-                        WHEN bt.typelem <> 0::oid AND bt.typlen = (-1) THEN 'ARRAY'::text
-                        ELSE format_type(a.atttypid, a.atttypmod)
+                        WHEN t.typtype = 'd'::"char" THEN
+                        CASE
+                            WHEN bt.typelem <> 0::oid AND bt.typlen = (-1) THEN 'ARRAY'::text
+                            WHEN nbt.nspname = 'pg_catalog'::name THEN format_type(t.typbasetype, NULL::integer)
+                            ELSE format_type(a.atttypid, a.atttypmod)
+                        END
+                        ELSE
+                        CASE
+                            WHEN t.typelem <> 0::oid AND t.typlen = (-1) THEN 'ARRAY'::text
+                            WHEN nt.nspname = 'pg_catalog'::name THEN format_type(a.atttypid, NULL::integer)
+                            ELSE format_type(a.atttypid, a.atttypmod)
+                        END
                     END::information_schema.character_data AS data_type,
                 information_schema._pg_char_max_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_maximum_length,
                 information_schema._pg_char_octet_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_octet_length,

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -310,7 +310,7 @@ spec = do
             "updatable": true,
             "schema": "test",
             "name": "simple_fk",
-            "type": "character varying(255)",
+            "type": "character varying",
             "maxLen": 255,
             "nullable": true,
             "position": 3,

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -204,7 +204,7 @@ spec = do
             "updatable": true,
             "schema": "test",
             "name": "enum",
-            "type": "USER-DEFINED",
+            "type": "test.enum_menagerie_type",
             "maxLen": null,
             "enum": [
               "foo",
@@ -310,7 +310,7 @@ spec = do
             "updatable": true,
             "schema": "test",
             "name": "simple_fk",
-            "type": "character varying",
+            "type": "character varying(255)",
             "maxLen": 255,
             "nullable": true,
             "position": 3,


### PR DESCRIPTION
I use quite a lot of custom types in my schema, and would like to get the actual typenames when doing an OPTIONS request on a table. Right now, postgrest returns 'USER-DEFINED' if it is a custom type, and the base type if it is a domain. I had a look at the code and patched it to allow my usecase. I couldn't think of any reason to treat domains differently than other types in this context, or if outputting user-defined types in general is a bad idea?