### PR TITLE
Remove unnecessary string conversions

### DIFF
--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -61,9 +61,7 @@ pTreePath :: Parser (Path,Field)
 pTreePath = do
   p <- pFieldName `sepBy1` pDelimiter
   jp <- optionMaybe pJsonPath
-  let pp = map cs p
-      jpp = map cs <$> jp
-  return (init pp, (last pp, jpp))
+  return (init p, (last p, jp))
 
 pFieldForest :: Parser [Tree SelectItem]
 pFieldForest = pFieldTree `sepBy1` lexeme (char ',')


### PR DESCRIPTION
While I was working in another refactor when I came across this code that can be simplified right away.
As it turns out it maps a `[Text]` to another `[Text]` and a `Maybe Text` to another `Maybe Text` without changing the value.