### PR TITLE
Cookies, custom function, session authenication, relation bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to set addresses to listen on - @hudayou
 - Filtering, shaping and embedding with &select for the /rpc path - @ruslantalpa
 - Output names of used-defined types (instead of 'USER-DEFINED') - @martingms
+- Request cookies available as claims under postgrest.claims.cookie.cookie_name - @ruslantalpa
+- RPC functions that return session_claims type can send 'Set-Cookie' header - @ruslantalpa
+- new --function command line parameter, the name of the function to run after all the claims are set and before the main query - @ruslantalpa
 
 ### Fixed
 - Do not apply limit to parent items - @ruslantalpa
+- Fix bug in relation detection when selecting parents two levels up by using the name of the FK - @ruslantalpa
 
 ### Changed
 - Use HTTP 400 for raise\_exception - @begriffs

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -71,6 +71,7 @@ executable postgrest
                      , HTTP
                      , Ranged-sets
                      , protolude >= 0.1.5 && < 0.2.0
+                     , cookie
   if !os(windows)
     build-depends:     unix >= 2.7 && < 3
 
@@ -116,6 +117,7 @@ library
                      , insert-ordered-containers >= 0.1.0.1
                      , swagger2 >= 2.1
                      , protolude >= 0.1.5 && < 0.2.0
+                     , cookie
                      , network-uri >= 2.6.1.0
 
   Other-Modules:       Paths_postgrest
@@ -150,6 +152,7 @@ Test-Suite spec
                      , Feature.RangeSpec
                      , Feature.StructureSpec
                      , Feature.UnicodeSpec
+                     , Feature.SwitchingFnSpec
                      , SpecHelper
                      , TestTypes
   Build-Depends:       aeson
@@ -202,3 +205,4 @@ Test-Suite spec
                      , network-uri
                      , HTTP
                      , Ranged-sets
+                     , cookie

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -29,6 +29,7 @@ import           PostgREST.Types           (QualifiedIdentifier (..),
                                             Schema, Payload(..),
                                             UniformObjects(..))
 import           Data.Ranged.Ranges        (singletonRange, rangeIntersection)
+import           Web.Cookie                (parseCookiesText)
 
 type RequestBody = BL.ByteString
 
@@ -87,6 +88,8 @@ data ApiRequest = ApiRequest {
   , iCanonicalQS :: String
   -- | JSON Web Token
   , iJWT :: T.Text
+  -- | Request Cookies
+  , iCookies :: Maybe [(T.Text, T.Text)]
   }
 
 -- | Examines HTTP request and translates it into user intent.
@@ -163,6 +166,7 @@ userApiRequest schema req reqBody =
      . parseSimpleQuery
      $ rawQueryString req
   , iJWT = tokenStr
+  , iCookies = parseCookiesText <$> lookupHeader "Cookie"
   }
 
  where

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -45,6 +45,7 @@ data AppConfig = AppConfig {
   , configJwtSecret :: Secret
   , configPool      :: Int
   , configMaxRows   :: Maybe Integer
+  , configSqlFn     :: Maybe String
   , configQuiet     :: Bool
   }
 
@@ -59,7 +60,9 @@ argParser = AppConfig
   <*> (secret . cs <$>
       strOption    (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET" <> value "secret" <> showDefault))
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)
-  <*> (readMay <$> strOption  (long "max-rows"   <> short 'm' <> help "max rows in response" <> metavar "COUNT" <> value "infinity" <> showDefault))
+  <*> (readMay <$>
+      strOption    (long "max-rows"   <> short 'm' <> help "max rows in response" <> metavar "COUNT" <> value "infinity" <> showDefault))
+  <*> (optional.strOption) (long "function" <> short 'f' <> help "name of the function to call before each request (after the claims are set)" <> metavar "FUNCTION_NAME")
   <*> pure False
 
 defaultCorsPolicy :: CorsResourcePolicy

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -225,6 +225,14 @@ spec = do
       get "/projects?id=eq.1&select=myId:id, name, project_client:client_id{*}, project_tasks:tasks{id, name}" `shouldRespondWith`
         [str|[{"myId":1,"name":"Windows 7","project_client":{"id":1,"name":"Microsoft"},"project_tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]
 
+    it "requesting parents two levels up while using FK to specify the link" $
+      get "/tasks?id=eq.1&select=id,name,project:project_id{id,name,client:client_id{id,name}}" `shouldRespondWith`
+        [str|[{"id":1,"name":"Design w7","project":{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}}]|]
+
+    it "requesting parents two levels up while using FK to specify the link (with rename)" $
+      get "/tasks?id=eq.1&select=id,name,project:project_id{id,name,client:client_id{id,name}}" `shouldRespondWith`
+        [str|[{"id":1,"name":"Design w7","project":{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}}]|]
+
 
     it "requesting parents and filtering parent columns" $
       get "/projects?id=eq.1&select=id, name, clients{id}" `shouldRespondWith`

--- a/test/Feature/SwitchingFnSpec.hs
+++ b/test/Feature/SwitchingFnSpec.hs
@@ -1,0 +1,62 @@
+module Feature.SwitchingFnSpec where
+
+
+import Test.Hspec
+import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
+import Network.HTTP.Types
+import Text.Heredoc
+import SpecHelper
+import Network.Wai (Application)
+
+spec :: SpecWith Application
+spec =
+  describe "switching function works on id=1" $ do
+      it "switches to postgrest_test_author on id=1" $
+        let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MX0.mI2HNoOum6xM3sc4oHLxU4yLv-_WV5W1kqBfY_wEvLw" in
+        request methodPost "/rpc/get_current_user" [auth]
+          [json| {} |]
+           `shouldRespondWith` ResponseMatcher {
+              matchBody    = Just [str|"postgrest_test_author"|]
+            , matchStatus = 200
+            , matchHeaders = []
+            }
+
+      it "switches to postgrest_test_default_role on id=2" $
+        let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Mn0.W7jLsG-zswM91AJkCvZeIMHrnz7_6ceY2jnscVl3Yhk" in
+        request methodPost "/rpc/get_current_user" [auth]
+          [json| {} |]
+           `shouldRespondWith` ResponseMatcher {
+              matchBody    = Just [str|"postgrest_test_default_role"|]
+            , matchStatus = 200
+            , matchHeaders = []
+            }
+
+      it "switches to postgrest_test_anonymous on id=3" $
+        let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6M30.15Gy8PezQhJIaHYDJVLa-Gmz9T3sJnW66EKAYIsXc7c" in
+        request methodPost "/rpc/get_current_user" [auth]
+          [json| {} |]
+           `shouldRespondWith` ResponseMatcher {
+              matchBody    = Just [str|"postgrest_test_anonymous"|]
+            , matchStatus = 200
+            , matchHeaders = []
+            }
+
+      it "switches to postgrest_test_anonymous on no auth header" $
+        request methodPost "/rpc/get_current_user" []
+          [json| {} |]
+           `shouldRespondWith` ResponseMatcher {
+              matchBody    = Just [str|"postgrest_test_anonymous"|]
+            , matchStatus = 200
+            , matchHeaders = []
+            }
+
+      it "raises error on id=4" $
+        let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NH0.t_F7ULztyoyZYI1BkXa2AprkFZ6usbPF3LBwR6oT3po" in
+        request methodPost "/rpc/get_current_user" [auth]
+          [json| {} |]
+           `shouldRespondWith` ResponseMatcher {
+              matchBody    = Just [str|{"hint":"Please contact administrator","details":null,"code":"P0001","message":"Disabled ID --> 4"}|]
+            , matchStatus = 400
+            , matchHeaders = []
+            }

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -20,6 +20,7 @@ import qualified Feature.QuerySpec
 import qualified Feature.RangeSpec
 import qualified Feature.StructureSpec
 import qualified Feature.UnicodeSpec
+import qualified Feature.SwitchingFnSpec
 import qualified Feature.ProxySpec
 
 main :: IO ()
@@ -33,6 +34,7 @@ main = do
   let withApp = return $ postgrest testCfg refDbStructure pool
       ltdApp  = return $ postgrest testLtdRowsCfg refDbStructure pool
       unicodeApp = return $ postgrest testUnicodeCfg refDbStructure pool
+      switchingFnApp = return $ postgrest testSwitchingFnCfg refDbStructure pool
       proxyApp = return $ postgrest testProxyCfg refDbStructure pool
 
   hspec $ do
@@ -45,6 +47,10 @@ main = do
     -- this test runs with a different schema
     beforeAll_ resetDb . before unicodeApp $
       describe "Feature.UnicodeSpec" Feature.UnicodeSpec.spec
+
+    -- this test runs with a different schema
+    beforeAll_ resetDb . before switchingFnApp $
+      describe "Feature.UnicodeSpec" Feature.SwitchingFnSpec.spec
 
     -- this test runs with a proxy
     beforeAll_ resetDb . before proxyApp $

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -50,19 +50,24 @@ testDbConn = "postgres://postgrest_test_authenticator@localhost:5432/postgrest_t
 
 testCfg :: AppConfig
 testCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (secret "safe") 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (secret "safe") 10 Nothing Nothing True
 
 testUnicodeCfg :: AppConfig
 testUnicodeCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "تست" "localhost" 3000 (secret "safe") 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "تست" "localhost" 3000 (secret "safe") 10 Nothing Nothing True
 
 testLtdRowsCfg :: AppConfig
 testLtdRowsCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (secret "safe") 10 (Just 2) True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (secret "safe") 10 (Just 2) Nothing True
+
+testSwitchingFnCfg :: AppConfig
+testSwitchingFnCfg =
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (secret "safe") 10 Nothing (Just "switch_role") True
 
 testProxyCfg :: AppConfig
 testProxyCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" (Just "https://postgrest.com/openapi.json") "test" "localhost" 3000 (secret "safe") 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" (Just "https://postgrest.com/openapi.json") "test" "localhost" 3000 (secret "safe") 10 Nothing Nothing True
+
 
 setupDb :: IO ()
 setupDb = do

--- a/test/fixtures/database.sql
+++ b/test/fixtures/database.sql
@@ -2,3 +2,4 @@ DROP DATABASE IF EXISTS postgrest_test;
 DROP ROLE IF EXISTS postgrest_test;
 CREATE USER postgrest_test createdb createrole;
 CREATE DATABASE postgrest_test OWNER postgrest_test;
+alter database postgrest_test set postgrest.claims.id to '';


### PR DESCRIPTION
* Request cookies available as claims under postgrest.claims.cookie.cookie_name
* RPC functions that return session_claims type can send 'Set-Cookie' header
* new --function command line parameter, the name of the function to run after all the claims are set and before the main query
* Fix bug in relation detection when selecting parents two levels up by using the name of the FK

All things above allow *common* session authentication method
and a gift (which is not 100% complete/correct, figure it out) :)
```sql
create type session_claims AS (
  name text,
  value text,
  "path" text,
  expires integer,
  max_age integer,
  domain text,
  http_only boolean,
  secure boolean
);

create function
login(email text, password text) returns api.session_claims
volatile security definer
language plpgsql
as $$
declare
	usr data.users;
	eml text;
	pass text;
	sess data.sessions;
begin
	eml := email;
	pass := password;

    select * into usr
    from data.users as u
    where u.email = eml and u.password = pass;
    if not found then
    	raise exception 'invalid email/password';
    else
    	insert into data.sessions (user_id, company_id)
    	values (usr.id, usr.company_id)
    	returning * into sess;
    	return (
		    'SESSIONID'::text, -- cookie_name
		    sess.session_id::text, -- cookie_value
		    null::text, -- path
		    null::integer, -- expires
		    3600::integer, -- max_age
		    null::text, -- domain
		    null::boolean, -- http_only
		    null::boolean -- secure
		);
    end if;
end
$$;



set search_path to public;

create or replace function get_user_id(sess_id text) returns int as $$
	select user_id from data.sessions where session_id=sess_id::uuid;
$$ language sql stable security definer;

create or replace function get_user(usr_id int) returns record as $$
	select id as user_id, company_id, user_type::text as user_role from data.users where id=usr_id;
$$ language sql stable security definer;


create or replace function check_session_id() returns void as $$
declare
	sess_id text;
	usr_id int;
	usr record;
begin
	sess_id = nullif(current_setting('postgrest.claims.cookie.SESSIONID'),'');
	if sess_id <> '' then
		select get_user_id(sess_id) into usr_id;
    	if found then
			select * from get_user(usr_id) as (user_id int, company_id int, user_role text) into usr;
			if found then
				execute 'set local postgrest.claims.user_id = ' || quote_literal(usr.user_id);
				execute 'set local postgrest.claims.company_id = ' || quote_literal(usr.company_id);
				execute 'set local role to ' || quote_ident(usr.user_role);
			end if;
		end if;
	end if;
end; $$ language plpgsql volatile;
```