### PR TITLE
Add schema cache freshness warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,10 @@ your contributions.
   [enable logging all statements](http://www.microhowto.info/howto/log_all_queries_to_a_postgresql_server.html),
   then [find your logs](http://blog.endpoint.com/2014/11/dear-postgresql-where-are-my-logs.html).
 
+* If your database schema has changed while the PostgREST server is running,
+  send the server a `SIGHUP` signal or restart it to ensure the schema cache
+  is not stale. This sometimes fixes apparent bugs.
+
 ## Code
 
 ### Haskell Conventions


### PR DESCRIPTION
This adds a note to the CONTRIBUTING file about checking for schema cache freshness, since it has confused many people, including @wkrause13.

@rkoberg suggests we add an issue template; do we want to revisit #615?