### PR TITLE
App: Remove erroneous import of Data.Monoid

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -29,7 +29,6 @@ import           Network.Wai.Middleware.RequestLogger (logStdout)
 
 import           Data.Aeson
 import           Data.Aeson.Types (emptyArray)
-import           Data.Monoid
 import           Data.Time.Clock.POSIX     (getPOSIXTime)
 import qualified Data.Vector               as V
 import qualified Hasql.Transaction         as H


### PR DESCRIPTION
This broke the build on GHC 8 with df6cbc4afa5b025f31c27a0d32c2d0253dd50eb3.