### PR TITLE
Use comma rather than semicolon to split header values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Use HTTP 400 for raise\_exception - @begriffs
 - Remove non-OpenAPI schema description - @begriffs
+- Use comma rather than semicolon to separate Prefer header values - @begriffs
 
 ## [0.3.2.0] - 2016-06-10
 

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -176,7 +176,7 @@ userApiRequest schema req reqBody =
   hasPrefer val   = any (\(h,v) -> h == "Prefer" && val `elem` split v) hdrs
     where
         split :: BS.ByteString -> [Text]
-        split = map T.strip . T.split (==';') . toS
+        split = map T.strip . T.split (==',') . toS
   singular        = hasPrefer "plurality=singular"
   representation
     | hasPrefer "return=representation" = Full

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -164,7 +164,7 @@ makeGetParams cs =
 
 makePostParams :: Text -> [Param]
 makePostParams tn =
-  [ makePreferParam ["return=representation", "return=representation;plurality=singular",
+  [ makePreferParam ["return=representation", "return=representation,plurality=singular",
                      "return=minimal", "return=none"]
   , (mempty :: Param)
     & name        .~ "body"

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -403,7 +403,7 @@ spec = do
         _ <- post "/addresses" [json| { id: 97, address: "A Street" } |]
         p <- request methodPatch
           "/addresses?id=eq.97"
-          [("Prefer", "return=representation;plurality=singular")]
+          [("Prefer", "return=representation,plurality=singular")]
           [json| { address: "B Street" } |]
         liftIO $ simpleBody p `shouldBe` [str|{"id":97,"address":"B Street"}|]
       it "raises an error when attempting to update multiple entities with plurality=singular" $ do
@@ -411,19 +411,19 @@ spec = do
         _ <- post "/addresses" [json| { id: 99, address: "yyy" } |]
         p <- request methodPatch
           "/addresses?id=gt.0"
-          [("Prefer", "return=representation;plurality=singular")]
+          [("Prefer", "return=representation,plurality=singular")]
           [json| { address: "zzz" } |]
         liftIO $ simpleStatus p `shouldBe` status400
       it "can provide a singular representation when creating one entity" $ do
         p <- request methodPost
           "/addresses"
-          [("Prefer", "return=representation;plurality=singular")]
+          [("Prefer", "return=representation,plurality=singular")]
           [json| [ { id: 100, address: "xxx" } ] |]
         liftIO $ simpleBody p `shouldBe` [str|{"id":100,"address":"xxx"}|]
       it "raises an error when attempting to create multiple entities with plurality=singular" $ do
         p <- request methodPost
           "/addresses"
-          [("Prefer", "return=representation;plurality=singular")]
+          [("Prefer", "return=representation,plurality=singular")]
           [json| [ { id: 100, address: "xxx" }, { id: 101, address: "xxx" } ] |]
         liftIO $ simpleStatus p `shouldBe` status400
 

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -286,7 +286,7 @@ spec = do
         }
 
     it "can combine multiple prefer values" $
-      request methodGet "/items?id=eq.5" [("Prefer","plurality=singular ; future=new; count=none")] ""
+      request methodGet "/items?id=eq.5" [("Prefer","plurality=singular , future=new, count=none")] ""
         `shouldRespondWith` ResponseMatcher {
           matchBody    = Just [json| {"id":5} |]
         , matchStatus  = 200


### PR DESCRIPTION
This is an addon to #634 which addresses @nerfpops' comment about the Prefer header separator. [RFC7240](https://tools.ietf.org/html/rfc7240) specifies that comma rather than semicolon should separate multiple Prefer values.

Closes #627