### PR TITLE
Big bag of JWT fixes for accumulated issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Ability to generate an OpenAPI spec - @mainx07, @hudayou, @ruslantalpa, @begriffs
-- Ability to generate an OpenAPI spec behind a proxy- @hudayou
+- Ability to generate an OpenAPI spec behind a proxy - @hudayou
 - Ability to set addresses to listen on - @hudayou
 - Filtering, shaping and embedding with &select for the /rpc path - @ruslantalpa
 - Output names of used-defined types (instead of 'USER-DEFINED') - @martingms
 - Implement support for singular representation responses for POST/PATCH requests - @ehamberg
 - Include RPC endpoints in OpenAPI output - @begriffs, @LogvinovLeon
+- Custom request validation with `--pre-request` argument - @begriffs
 
 ### Fixed
 - Do not apply limit to parent items - @ruslantalpa
@@ -23,6 +24,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Remove non-OpenAPI schema description - @begriffs
 - Use comma rather than semicolon to separate Prefer header values - @begriffs
 - Omit total query count by default - @begriffs
+- No more reserved `jwt_claims` return type - @begriffs
+- HTTP 401 rather than 400 for expired JWT - @begriffs
+- Remove default JWT secret - @begriffs
 
 ## [0.3.2.0] - 2016-06-10
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -88,7 +88,7 @@ main = do
 loadSecretFile :: AppConfig -> IO AppConfig
 loadSecretFile conf = do
   let s = configJwtSecret conf
-  real <- case stripPrefix "@" s of
+  real <- case join (stripPrefix "@" <$> s) of
             Nothing -> return s -- the string is the secret, not a filename
-            Just filename -> readFile (toS filename)
+            Just filename -> sequence . Just $ readFile (toS filename)
   return conf { configJwtSecret = real }

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -11,9 +11,11 @@ import           PostgREST.Config                     (AppConfig (..),
 import           PostgREST.OpenAPI                    (isMalformedProxyUri)
 import           PostgREST.DbStructure
 
+import           Control.AutoUpdate
 import           Data.String                          (IsString (..))
 import           Data.Text                            (stripPrefix)
 import           Data.Function                        (id)
+import           Data.Time.Clock.POSIX                (getPOSIXTime)
 import qualified Hasql.Query                          as H
 import qualified Hasql.Session                        as H
 import qualified Hasql.Decoders                       as HD
@@ -83,7 +85,11 @@ main = do
    ) Nothing
 #endif
 
-  runSettings appSettings $ postgrest conf refDbStructure pool
+  -- ask for the OS time at most once per second
+  getTime <- mkAutoUpdate
+    defaultUpdateSettings { updateAction = getPOSIXTime }
+
+  runSettings appSettings $ postgrest conf refDbStructure pool getTime
 
 loadSecretFile :: AppConfig -> IO AppConfig
 loadSecretFile conf = do

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -143,6 +143,7 @@ Test-Suite spec
                      , Feature.CorsSpec
                      , Feature.DeleteSpec
                      , Feature.InsertSpec
+                     , Feature.NoJwtSpec
                      , Feature.QuerySpec
                      , Feature.QueryLimitedSpec
                      , Feature.RangeSpec

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -30,6 +30,7 @@ executable postgrest
     "-with-rtsopts=-N -I2"
   default-language:    Haskell2010
   build-depends:       aeson (>= 0.8 && < 0.10) || (>= 0.11 && < 0.12)
+                     , auto-update
                      , base >= 4.8 && < 6
                      , bytestring
                      , bytestring-tree-builder == 0.2.7
@@ -152,6 +153,7 @@ Test-Suite spec
                      , SpecHelper
                      , TestTypes
   Build-Depends:       aeson
+                     , auto-update
                      , aeson-qq
                      , async
                      , base

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -7,7 +7,6 @@ module PostgREST.App (
 ) where
 
 import           Control.Applicative
-import           Control.Monad             ((>>))
 import qualified Data.ByteString.Char8     as BS
 import           Data.IORef                (IORef, readIORef)
 import           Data.List                 (delete, lookup)
@@ -98,8 +97,6 @@ transactionMode _ = HT.Write
 
 app :: DbStructure -> AppConfig -> ApiRequest -> H.Transaction Response
 app dbStructure conf apiRequest =
-  exposeSecretToSQL (configJwtSecret conf) >>
-
   case (iAction apiRequest, iTarget apiRequest, iPayload apiRequest) of
 
     (ActionRead, TargetIdent qi, Nothing) ->

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -13,6 +13,7 @@ import           Data.List                 (delete, lookup)
 import           Data.Maybe                (fromJust)
 import           Data.Ranged.Ranges        (emptyRange)
 import           Data.Text                 (replace, strip, isInfixOf, dropWhile, drop, intercalate)
+import           Data.Time.Clock.POSIX     (POSIXTime)
 import           Data.Tree
 
 import qualified Hasql.Pool                as P
@@ -32,7 +33,6 @@ import           Web.JWT                   (secret)
 
 import           Data.Aeson
 import           Data.Aeson.Types          (emptyArray)
-import           Data.Time.Clock.POSIX     (getPOSIXTime)
 import qualified Data.Vector               as V
 import qualified Hasql.Transaction         as H
 
@@ -69,12 +69,13 @@ import           Data.Foldable (foldr1)
 import           Data.Function (id)
 import           Protolude                hiding (dropWhile, drop, intercalate, Proxy)
 
-postgrest :: AppConfig -> IORef DbStructure -> P.Pool -> Application
-postgrest conf refDbStructure pool =
+postgrest :: AppConfig -> IORef DbStructure -> P.Pool -> IO POSIXTime ->
+             Application
+postgrest conf refDbStructure pool getTime =
   let middle = (if configQuiet conf then id else logStdout) . defaultMiddle in
 
   middle $ \ req respond -> do
-    time <- getPOSIXTime
+    time <- getTime
     body <- strictRequestBody req
     dbStructure <- readIORef refDbStructure
 

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -16,6 +16,7 @@ module PostgREST.Auth (
   , containsRole
   , jwtClaims
   , tokenJWT
+  , JWTAttempt(..)
   ) where
 
 import           Protolude
@@ -47,17 +48,24 @@ claimsToSQL claims = roleStmts <> varStmts
   valueToVariable = pgFmtLit . unquoted
 
 {-|
-  Receives the JWT secret (from config) and a JWT and
-  returns a map of JWT claims
-  In case there is any problem decoding the JWT it returns an error Text
+  Possible situations encountered with client JWTs
 -}
-jwtClaims :: JWT.Secret -> Text -> NominalDiffTime -> Either Text (M.HashMap Text Value)
-jwtClaims _ "" _ = Right M.empty
+data JWTAttempt = JWTExpired
+                | JWTInvalid
+                | JWTClaims (M.HashMap Text Value)
+                deriving Eq
+
+{-|
+  Receives the JWT secret (from config) and a JWT and returns a map
+  of JWT claims.
+-}
+jwtClaims :: JWT.Secret -> Text -> NominalDiffTime -> JWTAttempt
+jwtClaims _ "" _ = JWTClaims M.empty
 jwtClaims secret jwt time =
   case isExpired <$> mClaims of
-    Just True -> Left "JWT expired"
-    Nothing -> Left "Invalid JWT"
-    Just False -> Right $ value2map $ fromJust mClaims
+    Just True -> JWTExpired
+    Nothing -> JWTInvalid
+    Just False -> JWTClaims $ value2map $ fromJust mClaims
  where
   isExpired claims =
     let mExp = claims ^? key "exp" . _Integer
@@ -80,6 +88,6 @@ tokenJWT secret _ = tokenJWT secret emptyArray
 {-|
   Whether a response from jwtClaims contains a role claim
 -}
-containsRole :: Either Text (M.HashMap Text Value) -> Bool
-containsRole (Left _) = False
-containsRole (Right claims) = M.member "role" claims
+containsRole :: JWTAttempt -> Bool
+containsRole (JWTClaims claims) = M.member "role" claims
+containsRole _ = False

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -31,7 +31,6 @@ import           Options.Applicative
 import           Paths_postgrest             (version)
 import           Protolude hiding            (intercalate)
 import           Safe                        (readMay)
-import           Web.JWT                     (Secret, secret)
 
 -- | Data type to store all command line options
 data AppConfig = AppConfig {
@@ -41,7 +40,7 @@ data AppConfig = AppConfig {
   , configSchema    :: Text
   , configHost      :: Text
   , configPort      :: Int
-  , configJwtSecret :: Secret
+  , configJwtSecret :: Text
   , configPool      :: Int
   , configMaxRows   :: Maybe Integer
   , configQuiet     :: Bool
@@ -55,8 +54,7 @@ argParser = AppConfig
   <*> (toS <$> strOption    (long "schema"     <> short 's' <> help "schema to use for API routes" <> metavar "NAME" <> value "public" <> showDefault))
   <*> (toS <$> strOption    (long "host"       <> short 'l' <> help "hostname or ip on which to run HTTP server" <> metavar "HOST" <> value "*4" <> showDefault))
   <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
-  <*> (secret . toS <$>
-      strOption    (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET" <> value "secret" <> showDefault))
+  <*> (toS <$> strOption (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET"))
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)
   <*> (readMay <$> strOption  (long "max-rows"   <> short 'm' <> help "max rows in response" <> metavar "COUNT" <> value "infinity" <> showDefault))
   <*> pure False

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -43,6 +43,7 @@ data AppConfig = AppConfig {
   , configJwtSecret :: Maybe Text
   , configPool      :: Int
   , configMaxRows   :: Maybe Integer
+  , configReqCheck  :: Maybe Text
   , configQuiet     :: Bool
   }
 
@@ -57,6 +58,7 @@ argParser = AppConfig
   <*> (optional . map toS <$> strOption) (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET")
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)
   <*> (readMay <$> strOption  (long "max-rows"   <> short 'm' <> help "max rows in response" <> metavar "COUNT" <> value "infinity" <> showDefault))
+  <*> (optional . map toS . strOption) (long "pre-request"  <> help "schema-qualified name of proc to call to validate requests" <> metavar "FUNCTION")
   <*> pure False
 
 defaultCorsPolicy :: CorsResourcePolicy

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -40,7 +40,7 @@ data AppConfig = AppConfig {
   , configSchema    :: Text
   , configHost      :: Text
   , configPort      :: Int
-  , configJwtSecret :: Text
+  , configJwtSecret :: Maybe Text
   , configPool      :: Int
   , configMaxRows   :: Maybe Integer
   , configQuiet     :: Bool
@@ -54,7 +54,7 @@ argParser = AppConfig
   <*> (toS <$> strOption    (long "schema"     <> short 's' <> help "schema to use for API routes" <> metavar "NAME" <> value "public" <> showDefault))
   <*> (toS <$> strOption    (long "host"       <> short 'l' <> help "hostname or ip on which to run HTTP server" <> metavar "HOST" <> value "*4" <> showDefault))
   <*> option auto  (long "port"       <> short 'p' <> help "port number on which to run HTTP server" <> metavar "PORT" <> value 3000 <> showDefault)
-  <*> (toS <$> strOption (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET"))
+  <*> (optional . map toS <$> strOption) (long "jwt-secret" <> short 'j' <> help "secret used to encrypt and decrypt JWT tokens" <> metavar "SECRET")
   <*> option auto  (long "pool"       <> short 'o' <> help "max connections in database pool" <> metavar "COUNT" <> value 10 <> showDefault)
   <*> (readMay <$> strOption  (long "max-rows"   <> short 'm' <> help "max rows in response" <> metavar "COUNT" <> value "infinity" <> showDefault))
   <*> pure False

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -19,7 +19,6 @@ import           PostgREST.ApiRequest          (ApiRequest(..), ContentType(..),
 import           PostgREST.Auth                (claimsToSQL, JWTAttempt(..))
 import           PostgREST.Config              (AppConfig (..), corsPolicy)
 import           PostgREST.Error               (errResponse)
-import           PostgREST.QueryBuilder        (pgFmtLit)
 
 import           Protolude                     hiding (concat, null)
 
@@ -45,11 +44,6 @@ runWithClaims conf eClaims app req =
         )
       ]
       (toS $ "{\"message\":\""<>message<>"\"}")
-
-exposeSecretToSQL :: Maybe Text -> H.Transaction ()
-exposeSecretToSQL mS =
-  for_ mS $ \s ->
-    H.sql $ "set local postgrest.jwt_secret = " <> toS (pgFmtLit s) <> ";"
 
 defaultMiddle :: Application -> Application
 defaultMiddle =

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -19,6 +19,7 @@ import           PostgREST.ApiRequest          (ApiRequest(..), ContentType(..),
 import           PostgREST.Auth                (claimsToSQL, JWTAttempt(..))
 import           PostgREST.Config              (AppConfig (..), corsPolicy)
 import           PostgREST.Error               (errResponse)
+import           PostgREST.QueryBuilder        (pgFmtLit)
 
 import           Protolude                     hiding (concat, null)
 
@@ -45,6 +46,10 @@ runWithClaims conf eClaims app req =
       ]
       (toS $ "{\"message\":\""<>message<>"\"}")
 
+exposeSecretToSQL :: Maybe Text -> H.Transaction ()
+exposeSecretToSQL mS = do
+  for_ mS $ \s ->
+    H.sql $ "set local postgrest.jwt_secret = " <> toS (pgFmtLit s) <> ";"
 
 defaultMiddle :: Application -> Application
 defaultMiddle =

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -47,7 +47,7 @@ runWithClaims conf eClaims app req =
       (toS $ "{\"message\":\""<>message<>"\"}")
 
 exposeSecretToSQL :: Maybe Text -> H.Transaction ()
-exposeSecretToSQL mS = do
+exposeSecretToSQL mS =
   for_ mS $ \s ->
     H.sql $ "set local postgrest.jwt_secret = " <> toS (pgFmtLit s) <> ";"
 

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -7,16 +7,17 @@ import           Data.Aeson                    (Value (..))
 import qualified Data.HashMap.Strict           as M
 import qualified Hasql.Transaction             as H
 
-import           Network.HTTP.Types.Status     (badRequest400, unauthorized401)
-import           Network.Wai                   (Application, Response)
+import           Network.HTTP.Types.Status     (unauthorized401)
+import           Network.Wai                   (Application, Response,
+                                                responseLBS)
 import           Network.Wai.Middleware.Cors   (cors)
 import           Network.Wai.Middleware.Gzip   (def, gzip)
 import           Network.Wai.Middleware.Static (only, staticPolicy)
 
-import           PostgREST.ApiRequest          (ApiRequest(..))
+import           PostgREST.ApiRequest          (ApiRequest(..), ContentType(..),
+                                                ctToHeader)
 import           PostgREST.Auth                (claimsToSQL, JWTAttempt(..))
 import           PostgREST.Config              (AppConfig (..), corsPolicy)
-import           PostgREST.Error               (errResponse)
 
 import           Protolude                     hiding (concat, null)
 
@@ -25,14 +26,23 @@ runWithClaims :: AppConfig -> JWTAttempt ->
                  ApiRequest -> H.Transaction Response
 runWithClaims conf eClaims app req =
   case eClaims of
-    JWTExpired -> return $ errResponse unauthorized401 "JWT expired"
-    JWTInvalid -> return $ errResponse badRequest400 "JWT invalid"
+    JWTExpired -> return $ unauthed "JWT expired"
+    JWTInvalid -> return $ unauthed "JWT invalid"
     JWTClaims claims -> do
       -- role claim defaults to anon if not specified in jwt
       H.sql . mconcat . claimsToSQL $ M.union claims (M.singleton "role" anon)
       app req
   where
     anon = String . toS $ configAnonRole conf
+    unauthed message = responseLBS unauthorized401
+      [ ctToHeader CTApplicationJSON
+      , ( "WWW-Authenticate"
+        , "Bearer error=\"invalid_token\", " <>
+          "error_description=\"" <> message <> "\""
+        )
+      ]
+      (toS $ "{\"message\":\""<>message<>"\"}")
+
 
 defaultMiddle :: Application -> Application
 defaultMiddle =

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -12,6 +12,7 @@ import Network.Wai (Application)
 
 spec :: SpecWith Application
 spec = describe "authorization" $ do
+  let single = ("Prefer","plurality=singular")
 
   it "denies access to tables that anonymous does not own" $
     get "/authors_only" `shouldRespondWith` ResponseMatcher {
@@ -38,17 +39,18 @@ spec = describe "authorization" $ do
       }
 
   it "returns jwt functions as jwt tokens" $
-    post "/rpc/login" [json| { "id": "jdoe", "pass": "1234" } |]
+    request methodPost "/rpc/login" [single]
+      [json| { "id": "jdoe", "pass": "1234" } |]
       `shouldRespondWith` ResponseMatcher {
-          matchBody = Just [json| {"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"} |]
+          matchBody = Just [json| {"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xuYW1lIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.P2G9EVSVI22MWxXWFuhEYd9BZerLS1WDlqzdqplM15s"} |]
         , matchStatus = 200
         , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8"]
         }
 
   it "sql functions can encode custom and standard claims" $
-    post "/rpc/jwt_test" "{}"
+    request methodPost  "/rpc/jwt_test" [single] "{}"
       `shouldRespondWith` ResponseMatcher {
-          matchBody = Just [json| {"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmdW4iLCJqdGkiOiJmb28iLCJuYmYiOjEzMDA4MTkzODAsImV4cCI6MTMwMDgxOTM4MCwiaHR0cDovL3Bvc3RncmVzdC5jb20vZm9vIjp0cnVlLCJpc3MiOiJqb2UiLCJyb2xlIjoicG9zdGdyZXN0X3Rlc3QiLCJpYXQiOjEzMDA4MTkzODAsImF1ZCI6ImV2ZXJ5b25lIn0._tQCF79-ZZGMlLktd3csM_bVaiMg7A8YvIb6K2hcu5w"} |]
+          matchBody = Just [json| {"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJqb2UiLCJzdWIiOiJmdW4iLCJhdWQiOiJldmVyeW9uZSIsImV4cCI6MTMwMDgxOTM4MCwibmJmIjoxMzAwODE5MzgwLCJpYXQiOjEzMDA4MTkzODAsImp0aSI6ImZvbyIsInJvbGUiOiJwb3N0Z3Jlc3RfdGVzdCIsImh0dHA6Ly9wb3N0Z3Jlc3QuY29tL2ZvbyI6dHJ1ZX0.IHF16ZSU6XTbOnUWO8CCpUn2fJwt8P00rlYVyXQjpWc"} |]
         , matchStatus = 200
         , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8"]
         }

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -80,12 +80,26 @@ spec = describe "authorization" $ do
   it "fails with an expired token" $ do
     let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NDY2NzgxNDksInJvbGUiOiJwb3N0Z3Jlc3RfdGVzdF9hdXRob3IiLCJpZCI6Impkb2UifQ.enk_qZ_u6gZsXY4R8bREKB_HNExRpM0lIWSLktk9JJQ"
     request methodGet "/authors_only" [auth] ""
-      `shouldRespondWith` 401
+      `shouldRespondWith` ResponseMatcher {
+          matchBody = Nothing
+        , matchStatus = 401
+        , matchHeaders = [
+            "WWW-Authenticate" <:>
+            "Bearer error=\"invalid_token\", error_description=\"JWT expired\""
+          ]
+        }
 
   it "hides tables from users with invalid JWT" $ do
     let auth = authHeaderJWT "ey9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"
     request methodGet "/authors_only" [auth] ""
-      `shouldRespondWith` 400
+      `shouldRespondWith` ResponseMatcher {
+          matchBody = Nothing
+        , matchStatus = 401
+        , matchHeaders = [
+            "WWW-Authenticate" <:>
+            "Bearer error=\"invalid_token\", error_description=\"JWT invalid\""
+          ]
+        }
 
   it "should fail when jwt contains no claims" $ do
     let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.lu-rG8aSCiw-aOlN0IxpRGz5r7Jwq7K9r3tuMPUpytI"

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -103,6 +103,11 @@ spec = describe "authorization" $ do
           ]
         }
 
+  it "runs a custom request validation proc" $ do
+    let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYmFkX3JvbGUifQ.ENAiheEOlskpfoT5byj-gKJkOhHKTvETQu1Zso3c4Ts"
+    request methodGet "/items" [auth] ""
+      `shouldRespondWith` 400
+
   it "should fail when jwt contains no claims" $ do
     let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.lu-rG8aSCiw-aOlN0IxpRGz5r7Jwq7K9r3tuMPUpytI"
     request methodGet "/authors_only" [auth] ""

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -80,7 +80,7 @@ spec = describe "authorization" $ do
   it "fails with an expired token" $ do
     let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NDY2NzgxNDksInJvbGUiOiJwb3N0Z3Jlc3RfdGVzdF9hdXRob3IiLCJpZCI6Impkb2UifQ.enk_qZ_u6gZsXY4R8bREKB_HNExRpM0lIWSLktk9JJQ"
     request methodGet "/authors_only" [auth] ""
-      `shouldRespondWith` 400
+      `shouldRespondWith` 401
 
   it "hides tables from users with invalid JWT" $ do
     let auth = authHeaderJWT "ey9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"
@@ -88,16 +88,16 @@ spec = describe "authorization" $ do
       `shouldRespondWith` 400
 
   it "should fail when jwt contains no claims" $ do
-    let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.MKYc_lOECtB0LJOiykilAdlHodB-I0_id2qHKq35dmc"
+    let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.lu-rG8aSCiw-aOlN0IxpRGz5r7Jwq7K9r3tuMPUpytI"
     request methodGet "/authors_only" [auth] ""
-      `shouldRespondWith` 400
+      `shouldRespondWith` 401
 
   it "hides tables from users with JWT that contain no claims about role" $ do
-    let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Impkb2UifQ.zyohGMnrDy4_8eJTl6I2AUXO3MeCCiwR24aGWRkTE9o"
+    let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Impkb2UifQ.Jneso9X519Vh0z7i9PbXIu7W1HEoq9RRw9BBbyQKFCQ"
     request methodGet "/authors_only" [auth] ""
-      `shouldRespondWith` 400
+      `shouldRespondWith` 401
 
-  it "recovers after 400 error with logged in user" $ do
+  it "recovers after 401 error with logged in user" $ do
     _ <- post "/authors_only" [json| { "owner": "jdoe", "secret": "test content" } |]
     let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"
     _ <- request methodPost "/rpc/problem" [auth] ""

--- a/test/Feature/NoJwtSpec.hs
+++ b/test/Feature/NoJwtSpec.hs
@@ -1,0 +1,24 @@
+module Feature.NoJwtSpec where
+
+-- {{{ Imports
+import Test.Hspec
+import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
+import Network.HTTP.Types
+
+import SpecHelper
+import Network.Wai (Application)
+-- }}}
+
+spec :: SpecWith Application
+spec = describe "server started without JWT secret" $ do
+
+  -- this test will stop working 9999999999s after the UNIX EPOCH
+  it "responds with error on attempted auth" $ do
+    let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTksInJvbGUiOiJwb3N0Z3Jlc3RfdGVzdF9hdXRob3IiLCJpZCI6Impkb2UifQ.QaPPLWTuyydMu_q7H4noMT7Lk6P4muet1OpJXF6ofhc"
+    request methodGet "/authors_only" [auth] ""
+      `shouldRespondWith` 500
+
+  it "responds with error when attempting to generate JWT token" $
+    post "/rpc/login" [json| { "id": "jdoe", "pass": "1234" } |]
+      `shouldRespondWith` 500

--- a/test/Feature/NoJwtSpec.hs
+++ b/test/Feature/NoJwtSpec.hs
@@ -18,6 +18,6 @@ spec = describe "server started without JWT secret" $ do
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 500
 
-  it "behaves normally when user does not attempt auth" $ do
+  it "behaves normally when user does not attempt auth" $
     request methodGet "/items" [] ""
       `shouldRespondWith` 200

--- a/test/Feature/NoJwtSpec.hs
+++ b/test/Feature/NoJwtSpec.hs
@@ -3,7 +3,6 @@ module Feature.NoJwtSpec where
 -- {{{ Imports
 import Test.Hspec
 import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
 import Network.HTTP.Types
 
 import SpecHelper
@@ -19,6 +18,6 @@ spec = describe "server started without JWT secret" $ do
     request methodGet "/authors_only" [auth] ""
       `shouldRespondWith` 500
 
-  it "responds with error when attempting to generate JWT token" $
-    post "/rpc/login" [json| { "id": "jdoe", "pass": "1234" } |]
-      `shouldRespondWith` 500
+  it "behaves normally when user does not attempt auth" $ do
+    request methodGet "/items" [] ""
+      `shouldRespondWith` 200

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -15,6 +15,7 @@ import qualified Feature.ConcurrentSpec
 import qualified Feature.CorsSpec
 import qualified Feature.DeleteSpec
 import qualified Feature.InsertSpec
+import qualified Feature.NoJwtSpec
 import qualified Feature.QueryLimitedSpec
 import qualified Feature.QuerySpec
 import qualified Feature.RangeSpec
@@ -34,6 +35,7 @@ main = do
       ltdApp  = return $ postgrest testLtdRowsCfg refDbStructure pool
       unicodeApp = return $ postgrest testUnicodeCfg refDbStructure pool
       proxyApp = return $ postgrest testProxyCfg refDbStructure pool
+      noJwtApp = return $ postgrest testCfgNoJWT refDbStructure pool
 
   hspec $ do
     mapM_ (beforeAll_ resetDb . before withApp) specs
@@ -49,6 +51,10 @@ main = do
     -- this test runs with a proxy
     beforeAll_ resetDb . before proxyApp $
       describe "Feature.ProxySpec" Feature.ProxySpec.spec
+
+    -- this test runs without a JWT secret
+    beforeAll_ resetDb . before noJwtApp $
+      describe "Feature.NoJwtSpec" Feature.NoJwtSpec.spec
 
  where
   specs = map (uncurry describe) [

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -72,8 +72,10 @@ testProxyCfg =
 setupDb :: IO ()
 setupDb = do
   void $ readProcess "psql" ["-d", "postgres", "-a", "-f", "test/fixtures/database.sql"] []
+  void $ readProcess "psql" ["-d", "postgrest_test", "-a", "-c", "CREATE EXTENSION IF NOT EXISTS pgcrypto;"] []
   loadFixture "roles"
   loadFixture "schema"
+  loadFixture "jwt"
   loadFixture "privileges"
   resetDb
 

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -51,19 +51,23 @@ testDbConn = "postgres://postgrest_test_authenticator@localhost:5432/postgrest_t
 
 testCfg :: AppConfig
 testCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 "safe" 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (Just "safe") 10 Nothing True
+
+testCfgNoJWT :: AppConfig
+testCfgNoJWT =
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 Nothing 10 Nothing True
 
 testUnicodeCfg :: AppConfig
 testUnicodeCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "تست" "localhost" 3000 "safe" 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "تست" "localhost" 3000 (Just "safe") 10 Nothing True
 
 testLtdRowsCfg :: AppConfig
 testLtdRowsCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 "safe" 10 (Just 2) True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (Just "safe") 10 (Just 2) True
 
 testProxyCfg :: AppConfig
 testProxyCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" (Just "https://postgrest.com/openapi.json") "test" "localhost" 3000 "safe" 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" (Just "https://postgrest.com/openapi.json") "test" "localhost" 3000 (Just "safe") 10 Nothing True
 
 setupDb :: IO ()
 setupDb = do

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -51,23 +51,23 @@ testDbConn = "postgres://postgrest_test_authenticator@localhost:5432/postgrest_t
 
 testCfg :: AppConfig
 testCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (Just "safe") 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (Just "safe") 10 Nothing (Just "test.block_bad_role") True
 
 testCfgNoJWT :: AppConfig
 testCfgNoJWT =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 Nothing 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 Nothing 10 Nothing Nothing True
 
 testUnicodeCfg :: AppConfig
 testUnicodeCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "تست" "localhost" 3000 (Just "safe") 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "تست" "localhost" 3000 (Just "safe") 10 Nothing Nothing True
 
 testLtdRowsCfg :: AppConfig
 testLtdRowsCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (Just "safe") 10 (Just 2) True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (Just "safe") 10 (Just 2) Nothing True
 
 testProxyCfg :: AppConfig
 testProxyCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" (Just "https://postgrest.com/openapi.json") "test" "localhost" 3000 (Just "safe") 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" (Just "https://postgrest.com/openapi.json") "test" "localhost" 3000 (Just "safe") 10 Nothing Nothing True
 
 setupDb :: IO ()
 setupDb = do

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -51,7 +51,7 @@ testDbConn = "postgres://postgrest_test_authenticator@localhost:5432/postgrest_t
 
 testCfg :: AppConfig
 testCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (Just "safe") 10 Nothing (Just "test.block_bad_role") True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (Just "safe") 10 Nothing (Just "test.switch_role") True
 
 testCfgNoJWT :: AppConfig
 testCfgNoJWT =

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -8,7 +8,6 @@ import Data.CaseInsensitive (CI(..))
 import Text.Regex.TDFA ((=~))
 import qualified Data.ByteString.Char8 as BS
 import System.Process (readProcess)
-import Web.JWT (secret)
 
 import PostgREST.Config (AppConfig(..))
 
@@ -52,19 +51,19 @@ testDbConn = "postgres://postgrest_test_authenticator@localhost:5432/postgrest_t
 
 testCfg :: AppConfig
 testCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (secret "safe") 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 "safe" 10 Nothing True
 
 testUnicodeCfg :: AppConfig
 testUnicodeCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "تست" "localhost" 3000 (secret "safe") 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "تست" "localhost" 3000 "safe" 10 Nothing True
 
 testLtdRowsCfg :: AppConfig
 testLtdRowsCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 (secret "safe") 10 (Just 2) True
+  AppConfig testDbConn "postgrest_test_anonymous" Nothing "test" "localhost" 3000 "safe" 10 (Just 2) True
 
 testProxyCfg :: AppConfig
 testProxyCfg =
-  AppConfig testDbConn "postgrest_test_anonymous" (Just "https://postgrest.com/openapi.json") "test" "localhost" 3000 (secret "safe") 10 Nothing True
+  AppConfig testDbConn "postgrest_test_anonymous" (Just "https://postgrest.com/openapi.json") "test" "localhost" 3000 "safe" 10 Nothing True
 
 setupDb :: IO ()
 setupDb = do

--- a/test/fixtures/database.sql
+++ b/test/fixtures/database.sql
@@ -2,3 +2,5 @@ DROP DATABASE IF EXISTS postgrest_test;
 DROP ROLE IF EXISTS postgrest_test;
 CREATE USER postgrest_test createdb createrole;
 CREATE DATABASE postgrest_test OWNER postgrest_test;
+
+ALTER DATABASE postgrest_test SET postgrest.claims.id = '-1';

--- a/test/fixtures/jwt.sql
+++ b/test/fixtures/jwt.sql
@@ -1,0 +1,64 @@
+-- From michelp/pgjwt commit c02bbd3
+BEGIN;
+DROP SCHEMA IF EXISTS jwt CASCADE;
+CREATE SCHEMA jwt;
+
+
+CREATE OR REPLACE FUNCTION jwt.url_encode(data bytea) RETURNS text LANGUAGE sql AS $$
+    SELECT translate(encode(data, 'base64'), E'+/=\n', '-_');
+$$;
+
+
+CREATE OR REPLACE FUNCTION jwt.url_decode(data text) RETURNS bytea LANGUAGE sql AS $$
+WITH t AS (SELECT translate(data, '-_', '+/')),
+     rem AS (SELECT length((SELECT * FROM t)) % 4) -- compute padding size
+    SELECT decode(
+        (SELECT * FROM t) ||
+        CASE WHEN (SELECT * FROM rem) > 0
+           THEN repeat('=', (4 - (SELECT * FROM rem)))
+           ELSE '' END,
+    'base64');
+$$;
+
+
+CREATE OR REPLACE FUNCTION jwt.algorithm_sign(signables text, secret text, algorithm text)
+RETURNS text LANGUAGE sql AS $$
+WITH
+  alg AS (
+    SELECT CASE
+      WHEN algorithm = 'HS256' THEN 'sha256'
+      WHEN algorithm = 'HS384' THEN 'sha384'
+      WHEN algorithm = 'HS512' THEN 'sha512'
+      ELSE '' END)  -- hmac throws error
+SELECT jwt.url_encode(hmac(signables, secret, (select * FROM alg)));
+$$;
+
+
+CREATE OR REPLACE FUNCTION jwt.sign(payload json, secret text, algorithm text DEFAULT 'HS256')
+RETURNS text LANGUAGE sql AS $$
+WITH
+  header AS (
+    SELECT jwt.url_encode(convert_to('{"alg":"' || algorithm || '","typ":"JWT"}', 'utf8'))
+    ),
+  payload AS (
+    SELECT jwt.url_encode(convert_to(payload::text, 'utf8'))
+    ),
+  signables AS (
+    SELECT (SELECT * FROM header) || '.' || (SELECT * FROM payload)
+    )
+SELECT
+    (SELECT * FROM signables)
+    || '.' ||
+    jwt.algorithm_sign((SELECT * FROM signables), secret, algorithm);
+$$;
+
+
+CREATE OR REPLACE FUNCTION jwt.verify(token text, secret text, algorithm text DEFAULT 'HS256')
+RETURNS table(header json, payload json, valid boolean) LANGUAGE sql AS $$
+  SELECT
+    convert_from(jwt.url_decode(r[1]), 'utf8')::json AS header,
+    convert_from(jwt.url_decode(r[2]), 'utf8')::json AS payload,
+    r[3] = jwt.algorithm_sign(r[1] || '.' || r[2], secret, algorithm) AS valid
+  FROM regexp_split_to_array(token, '\.') r;
+$$;
+COMMIT;

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -4,7 +4,7 @@ GRANT USAGE ON SCHEMA
     , test
     , jwt
     , "تست"
-TO postgrest_test_anonymous, bad_role;
+TO postgrest_test_anonymous;
 
 -- Schema test objects
 SET search_path = test, "تست", pg_catalog;

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -4,7 +4,7 @@ GRANT USAGE ON SCHEMA
     , test
     , jwt
     , "تست"
-TO postgrest_test_anonymous;
+TO postgrest_test_anonymous, bad_role;
 
 -- Schema test objects
 SET search_path = test, "تست", pg_catalog;

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -2,6 +2,7 @@
 GRANT USAGE ON SCHEMA
       postgrest
     , test
+    , jwt
     , "تست"
 TO postgrest_test_anonymous;
 

--- a/test/fixtures/roles.sql
+++ b/test/fixtures/roles.sql
@@ -1,7 +1,8 @@
-DROP ROLE IF EXISTS postgrest_test_authenticator, postgrest_test_anonymous, postgrest_test_default_role, postgrest_test_author;
+DROP ROLE IF EXISTS postgrest_test_authenticator, postgrest_test_anonymous, postgrest_test_default_role, postgrest_test_author, bad_role;
 CREATE ROLE postgrest_test_authenticator WITH login noinherit;
 CREATE ROLE postgrest_test_anonymous;
 CREATE ROLE postgrest_test_default_role;
 CREATE ROLE postgrest_test_author;
+CREATE ROLE bad_role;
 
-GRANT postgrest_test_anonymous, postgrest_test_default_role, postgrest_test_author TO postgrest_test_authenticator;
+GRANT postgrest_test_anonymous, postgrest_test_default_role, postgrest_test_author, bad_role TO postgrest_test_authenticator;

--- a/test/fixtures/roles.sql
+++ b/test/fixtures/roles.sql
@@ -1,8 +1,7 @@
-DROP ROLE IF EXISTS postgrest_test_authenticator, postgrest_test_anonymous, postgrest_test_default_role, postgrest_test_author, bad_role;
+DROP ROLE IF EXISTS postgrest_test_authenticator, postgrest_test_anonymous, postgrest_test_default_role, postgrest_test_author;
 CREATE ROLE postgrest_test_authenticator WITH login noinherit;
 CREATE ROLE postgrest_test_anonymous;
 CREATE ROLE postgrest_test_default_role;
 CREATE ROLE postgrest_test_author;
-CREATE ROLE bad_role;
 
-GRANT postgrest_test_anonymous, postgrest_test_default_role, postgrest_test_author, bad_role TO postgrest_test_authenticator;
+GRANT postgrest_test_anonymous, postgrest_test_default_role, postgrest_test_author TO postgrest_test_authenticator;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -237,6 +237,14 @@ SELECT jwt.sign(
   ) r;
 $$;
 
+create function block_bad_role() returns void
+language plpgsql as $$
+begin
+  if current_role = 'bad_role' then
+    raise invalid_password using message = 'role is not allowed';
+  end if;
+end
+$$;
 
 --
 -- Name: reveal_big_jwt(); Type: FUNCTION; Schema: test; Owner: -

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -194,7 +194,7 @@ CREATE FUNCTION login(id text, pass text) RETURNS public.jwt_token
     LANGUAGE sql SECURITY DEFINER
     AS $$
 SELECT jwt.sign(
-    row_to_json(r), current_setting('postgrest.jwt_secret')
+    row_to_json(r), 'safe'
   ) as token
   FROM (
     SELECT rolname::text, id::text
@@ -227,7 +227,7 @@ CREATE FUNCTION jwt_test() RETURNS public.jwt_token
     LANGUAGE sql SECURITY DEFINER
     AS $$
 SELECT jwt.sign(
-    row_to_json(r), current_setting('postgrest.jwt_secret')
+    row_to_json(r), 'safe'
   ) as token
   FROM (
     SELECT 'joe'::text as iss, 'fun'::text as sub, 'everyone'::text as aud,


### PR DESCRIPTION
Taking the opportunity to make some breaking changes for v0.4

This is a work in progress. It removes the default value of `"secret"` for JWTs, and responds with an error if someone tries authenticating against a postgrest server which has not been configured with a secret. The new code also adds the convention that a secret beginning with `@` means a filename from which to read the real secret. Reading from a file should allow unicode and binary secrets alike (but this requires testing). Reading from a file also removes sensitive information from the unix process list.

Two other JWT requested features not yet addressed are #505 and #567. Are these issues something we still want to fix?

I'll also be incorporating the custom validation discussed in #632...