### PR TITLE
Read settings from config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - HTTP 401 rather than 400 for expired JWT - @begriffs
 - Remove default JWT secret - @begriffs
 - Use GUC request.jwt.claim.foo rather than postgrest.claims.foo - @begriffs
+- Use config file rather than command line arguments - @begriffs
 
 ## [0.3.2.0] - 2016-06-10
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 FROM debian:jessie
 
-ENV POSTGREST_VERSION 0.3.2.0
-ENV POSTGREST_SCHEMA public
-ENV POSTGREST_ANONYMOUS postgres
-ENV POSTGREST_JWT_SECRET thisisnotarealsecret
-ENV POSTGREST_MAX_ROWS 1000000
-ENV POSTGREST_POOL 200
+ENV POSTGREST_VERSION 0.4.0.0
 
 RUN apt-get update && \
     apt-get install -y tar xz-utils wget libpq-dev && \
@@ -16,12 +11,8 @@ RUN wget http://github.com/begriffs/postgrest/releases/download/v${POSTGREST_VER
     mv postgrest /usr/local/bin/postgrest && \
     rm postgrest-${POSTGREST_VERSION}-ubuntu.tar.xz
 
-CMD exec postgrest postgres://${PG_ENV_POSTGRES_USER}:${PG_ENV_POSTGRES_PASSWORD}@${PG_PORT_5432_TCP_ADDR}:${PG_PORT_5432_TCP_PORT}/${PG_ENV_POSTGRES_DB} \
-              --port 3000 \
-              --schema ${POSTGREST_SCHEMA} \
-              --anonymous ${POSTGREST_ANONYMOUS} \
-              --pool ${POSTGREST_POOL} \
-              --jwt-secret ${POSTGREST_JWT_SECRET} \
-              --max-rows ${POSTGREST_MAX_ROWS}
+# PostgREST reads /etc/postgrest.conf so map the configuration
+# file in when you run this container
+CMD exec postgrest
 
 EXPOSE 3000

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -8,12 +8,14 @@ import           PostgREST.Config                     (AppConfig (..),
                                                        minimumPgVersion,
                                                        prettyVersion,
                                                        readOptions)
+import           PostgREST.Error                      (prettyUsageError)
 import           PostgREST.OpenAPI                    (isMalformedProxyUri)
 import           PostgREST.DbStructure
 
 import           Control.AutoUpdate
 import           Data.String                          (IsString (..))
 import           Data.Text                            (stripPrefix)
+import           Data.Text.IO                         (hPutStrLn)
 import           Data.Function                        (id)
 import           Data.Time.Clock.POSIX                (getPOSIXTime)
 import qualified Hasql.Query                          as H
@@ -67,6 +69,10 @@ main = do
       "Cannot run in this PostgreSQL version, PostgREST needs at least "
       <> show minimumPgVersion)
     getDbStructure (toS $ configSchema conf)
+
+  forM_ (lefts [result]) $ \e -> do
+    hPutStrLn stderr (prettyUsageError e)
+    exitFailure
 
   refDbStructure <- newIORef $ either (panic . show) id result
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -81,7 +81,6 @@ library
                      , wai-cors
                      , wai-extra
                      , wai-middleware-static
-                     , xdg-basedir
 
   Other-Modules:       Paths_postgrest
   Exposed-Modules:     PostgREST.ApiRequest

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -57,6 +57,7 @@ library
                      , hasql
                      , hasql-pool == 0.4.1
                      , hasql-transaction == 0.4.5.1
+                     , heredoc
                      , HTTP
                      , http-types
                      , insert-ordered-containers

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -51,6 +51,7 @@ library
                      , bytestring
                      , case-insensitive
                      , cassava
+                     , configurator
                      , containers
                      , contravariant
                      , hasql
@@ -80,6 +81,7 @@ library
                      , wai-cors
                      , wai-extra
                      , wai-middleware-static
+                     , xdg-basedir
 
   Other-Modules:       Paths_postgrest
   Exposed-Modules:     PostgREST.ApiRequest

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -97,33 +97,26 @@ readOptions = do
 
   when (caExample args) $ do
     putStrLn (
-      [str|db {
-          |  uri = "postgres://user:pass@localhost:5432/dbname"
-          |  schema = "public"
-          |  anon-role = "postgres"
-          |  pool = 10
-          |}
+      [str|db-uri = "postgres://user:pass@localhost:5432/dbname"
+          |db-schema = "public"
+          |db-anon-role = "postgres"
+          |db-pool = 10
           |
-          |server {
-          |  host = "*4"
-          |  port = 3000
+          |server-host = "*4"
+          |server-port = 3000
           |
-          |  ## base url for swagger output
-          |  # proxy-uri = ""
-          |}
+          |## base url for swagger output
+          |# server-proxy-uri = ""
           |
-          |jwt {
-          |  ## choose a secret to enable JWT auth
-          |  # secret = "foo"
-          |}
+          |## choose a secret to enable JWT auth
+          |## (use "@filename" to load from separate file)
+          |# jwt-secret = "foo"
           |
-          |safety {
-          |  ## limit rows in response
-          |  # max-rows = 1000
+          |## limit rows in response
+          |# max-rows = 1000
           |
-          |  ## stored proc to exec immediately after auth
-          |  # pre-request = "stored_proc_name"
-          |}
+          |## stored proc to exec immediately after auth
+          |# pre-request = "stored_proc_name"
           |]::Text)
     exitSuccess
 
@@ -132,19 +125,19 @@ readOptions = do
     configNotfoundHint
 
   -- db ----------------
-  cDbUri    <- C.require conf "db.uri"
-  cDbSchema <- C.require conf "db.schema"
-  cDbAnon   <- C.require conf "db.anon-role"
-  cPool     <- C.lookupDefault 10 conf "db.pool"
+  cDbUri    <- C.require conf "db-uri"
+  cDbSchema <- C.require conf "db-schema"
+  cDbAnon   <- C.require conf "db-anon-role"
+  cPool     <- C.lookupDefault 10 conf "db-pool"
   -- server ------------
-  cHost     <- C.lookupDefault "*4" conf "server.host"
-  cPort     <- C.lookupDefault 3000 conf "server.port"
-  cProxy    <- C.lookup conf "server.proxy-uri"
+  cHost     <- C.lookupDefault "*4" conf "server-host"
+  cPort     <- C.lookupDefault 3000 conf "server-port"
+  cProxy    <- C.lookup conf "server-proxy-uri"
   -- jwt ---------------
-  cJwtSec   <- C.lookup conf "jwt.secret"
+  cJwtSec   <- C.lookup conf "jwt-secret"
   -- safety ------------
-  cMaxRows  <- C.lookup conf "safety.max-rows"
-  cReqCheck <- C.lookup conf "safety.pre-request"
+  cMaxRows  <- C.lookup conf "max-rows"
+  cReqCheck <- C.lookup conf "pre-request"
 
   return $ AppConfig cDbUri cDbAnon cProxy cDbSchema cHost cPort
         cJwtSec cPool cMaxRows cReqCheck False

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 {-|
 Module      : PostgREST.Config
 Description : Manages PostgREST configuration options.

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -83,15 +83,6 @@ corsPolicy req = case lookup "origin" headers of
 prettyVersion :: Text
 prettyVersion = intercalate "." $ map show $ versionBranch version
 
--- | Default OS-specific path to config file
-defConf :: FilePath
-defConf =
-#ifdef mingw32_HOST_OS
-  "%PROGRAMDATA%\\postgrest\\postgrest.conf"
-#else
-  "/etc/postgrest.conf"
-#endif
-
 -- | Function to read and parse options from the command line
 readOptions :: IO AppConfig
 readOptions = do
@@ -179,8 +170,7 @@ argParser :: Parser CmdArgs
 argParser = CmdArgs <$>
   (toS <$> strOption
     (short 'c' <> metavar "filename" <>
-      help "Path to configuration file" <>
-      value defConf <> showDefault)) <*>
+      help "Path to configuration file")) <*>
   switch (long "example-config" <> help "output an example config file")
 
 -- | Tells the minimum PostgreSQL version required by this version of PostgREST

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -4,12 +4,13 @@
 Module      : PostgREST.Config
 Description : Manages PostgREST configuration options.
 
-This module provides a helper function to read the command line arguments using the optparse-applicative
-and the AppConfig type to store them.
-It also can be used to define other middleware configuration that may be delegated to some sort of
-external configuration.
+This module provides a helper function to read the command line
+arguments using the optparse-applicative and the AppConfig type to store
+them.  It also can be used to define other middleware configuration that
+may be delegated to some sort of external configuration.
 
-It currently includes a hardcoded CORS policy but this could easly be turned in configurable behaviour if needed.
+It currently includes a hardcoded CORS policy but this could easly be
+turned in configurable behaviour if needed.
 
 Other hardcoded options such as the minimum version number also belong here.
 -}
@@ -146,12 +147,12 @@ readOptions = do
 
  where
   opts = info (helper <*> argParser) $
-                  fullDesc
-                  <> progDesc (
-                  "PostgREST "
-                  <> toS prettyVersion
-                  <> " / create a REST API to an existing Postgres database"
-                  )
+           fullDesc
+           <> progDesc (
+             "PostgREST "
+             <> toS prettyVersion
+             <> " / create a REST API to an existing Postgres database"
+           )
   parserPrefs = prefs showHelpOnError
 
   configNotfoundHint :: IOError -> IO a

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
-module PostgREST.Error (pgErrResponse, errResponse) where
+module PostgREST.Error (pgErrResponse, errResponse, prettyUsageError) where
 
 import           Protolude
 import           Data.Aeson                ((.=))
@@ -28,6 +28,11 @@ pgErrResponse authed e =
                 then [jsonType, wwwAuth]
                 else [jsonType] in
   responseLBS status hdrs (JSON.encode e)
+
+prettyUsageError :: P.UsageError -> Text
+prettyUsageError (P.ConnectionError e) =
+  "Database connection error:\n" <> toS (fromMaybe "" e)
+prettyUsageError e = show $ JSON.encode e
 
 instance JSON.ToJSON P.UsageError where
   toJSON (P.ConnectionError e) = JSON.object [


### PR DESCRIPTION
Fixes #474

Removes all the command line arguments except an argument `-c` to override path to configuration file. The default config file path is `~/.config/postgrest/conf` or `$XDG_CONFIG_HOME/postgrest/config` if that environment variable is set.

As of this first commit the PR is somewhat lacking because it doesn't provide help text that guides the user to the expected format of the config file.