### PR TITLE
Add port in environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV POSTGREST_ANONYMOUS postgres
 ENV POSTGREST_JWT_SECRET thisisnotarealsecret
 ENV POSTGREST_MAX_ROWS 1000000
 ENV POSTGREST_POOL 200
+ENV POSTGREST_PORT 3000
 
 RUN apt-get update && \
     apt-get install -y tar xz-utils wget libpq-dev && \
@@ -17,11 +18,11 @@ RUN wget http://github.com/begriffs/postgrest/releases/download/v${POSTGREST_VER
     rm postgrest-${POSTGREST_VERSION}-ubuntu.tar.xz
 
 CMD exec postgrest postgres://${PG_ENV_POSTGRES_USER}:${PG_ENV_POSTGRES_PASSWORD}@${PG_PORT_5432_TCP_ADDR}:${PG_PORT_5432_TCP_PORT}/${PG_ENV_POSTGRES_DB} \
-              --port 3000 \
+              --port ${POSTGREST_PORT} \
               --schema ${POSTGREST_SCHEMA} \
               --anonymous ${POSTGREST_ANONYMOUS} \
               --pool ${POSTGREST_POOL} \
               --jwt-secret ${POSTGREST_JWT_SECRET} \
               --max-rows ${POSTGREST_MAX_ROWS}
 
-EXPOSE 3000
+EXPOSE ${POSTGREST_PORT}


### PR DESCRIPTION
At the moment I have 2 databases on the same postgres, but postgrest needs to specify the `PG_ENV_POSTGRES_DB` to work.
An alternative could be without `PG_ENV_POSTGRES_DB` changing url like /database/table instead of /table

Thank you