### PR TITLE
Set request.jwt.claim.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - No more reserved `jwt_claims` return type - @begriffs
 - HTTP 401 rather than 400 for expired JWT - @begriffs
 - Remove default JWT secret - @begriffs
+- Use GUC request.jwt.claim.foo rather than postgrest.claims.foo - @begriffs
 
 ## [0.3.2.0] - 2016-06-10
 

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -43,7 +43,7 @@ claimsToSQL claims = roleStmts <> varStmts
   roleStmts = maybeToList $
     (\r -> "set local role " <> r <> ";") . toS . valueToVariable <$> M.lookup "role" claims
   varStmts = map setVar $ M.toList (M.delete "role" claims)
-  setVar (k, val) = "set local " <> toS (pgFmtIdent $ "postgrest.claims." <> k)
+  setVar (k, val) = "set local " <> toS (pgFmtIdent $ "request.jwt.claim." <> k)
                     <> " = " <> toS (valueToVariable val) <> ";"
   valueToVariable = pgFmtLit . unquoted
 

--- a/test/fixtures/database.sql
+++ b/test/fixtures/database.sql
@@ -3,4 +3,4 @@ DROP ROLE IF EXISTS postgrest_test;
 CREATE USER postgrest_test createdb createrole;
 CREATE DATABASE postgrest_test OWNER postgrest_test;
 
-ALTER DATABASE postgrest_test SET postgrest.claims.id = '-1';
+ALTER DATABASE postgrest_test SET request.jwt.claim.id = '-1';

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -96,7 +96,7 @@ CREATE FUNCTION set_authors_only_owner() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 begin
-  NEW.owner = current_setting('postgrest.claims.id');
+  NEW.owner = current_setting('request.jwt.claim.id');
   RETURN NEW;
 end
 $$;
@@ -243,8 +243,8 @@ CREATE OR REPLACE FUNCTION switch_role() RETURNS void
   AS $$
 declare
   user_id text;
-begin
-  user_id = current_setting('postgrest.claims.id')::text;
+Begin
+  user_id = current_setting('request.jwt.claim.id')::text;
   if user_id = '1'::text then
     execute 'set local role postgrest_test_author';
   elseif user_id = '2'::text then
@@ -273,15 +273,15 @@ CREATE FUNCTION reveal_big_jwt() RETURNS TABLE (
     )
     LANGUAGE sql SECURITY DEFINER
     AS $$
-SELECT current_setting('postgrest.claims.iss') as iss,
-       current_setting('postgrest.claims.sub') as sub,
-       current_setting('postgrest.claims.aud') as aud,
-       current_setting('postgrest.claims.exp')::bigint as exp,
-       current_setting('postgrest.claims.nbf')::bigint as nbf,
-       current_setting('postgrest.claims.iat')::bigint as iat,
-       current_setting('postgrest.claims.jti') as jti,
+SELECT current_setting('request.jwt.claim.iss') as iss,
+       current_setting('request.jwt.claim.sub') as sub,
+       current_setting('request.jwt.claim.aud') as aud,
+       current_setting('request.jwt.claim.exp')::bigint as exp,
+       current_setting('request.jwt.claim.nbf')::bigint as nbf,
+       current_setting('request.jwt.claim.iat')::bigint as iat,
+       current_setting('request.jwt.claim.jti') as jti,
        -- role is not included in the claims list
-       current_setting('postgrest.claims.http://postgrest.com/foo')::boolean
+       current_setting('request.jwt.claim.http://postgrest.com/foo')::boolean
          as "http://postgrest.com/foo";
 $$;
 


### PR DESCRIPTION
Fixes #674 

Saving `request.cookie` and `request.header` for another day after the 0.4 release.