### PR TITLE
add nix.packages to stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,5 @@ extra-deps:
   - hasql-transaction-0.4.5.1
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities
+nix:
+  packages: [postgresql, zlib]


### PR DESCRIPTION
postgrest depends on postgres and zlib. When using stack's nix
integration, these dependencies must be specified explicitly.

Note that `--nix` must be passed to stack, or `nix.enable:true` must
be set in `stack.yaml` to enable using nix while building.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/begriffs/postgrest/726)

<!-- Reviewable:end -->
