### PR TITLE
Fix fatal error on postgres unsupported version, also fix #577 format…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix bug in relation detection when selecting parents two levels up by using the name of the FK - @ruslantalpa
 - Customize content negotiation per route - @begriffs
 - Allow using nulls order without explicit order direction - @steve-chavez
+- Fatal error on postgres unsupported version, format supported version in error message - @steve-chavez
 
 ### Changed
 - Use HTTP 400 for raise\_exception - @begriffs

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -16,6 +16,7 @@ module PostgREST.Config ( prettyVersion
                         , readOptions
                         , corsPolicy
                         , minimumPgVersion
+                        , PgVersion (..)
                         , AppConfig (..)
                         )
        where
@@ -171,6 +172,12 @@ argParser = CmdArgs <$>
       help "Path to configuration file")) <*>
   switch (long "example-config" <> help "output an example config file")
 
+
+data PgVersion = PgVersion {
+  pgvNum  :: Int32
+, pgvName :: Text
+}
+
 -- | Tells the minimum PostgreSQL version required by this version of PostgREST
-minimumPgVersion :: Integer
-minimumPgVersion = 90300
+minimumPgVersion :: PgVersion
+minimumPgVersion = PgVersion 90300 "9.3"


### PR DESCRIPTION
… of supported version

I tested postgREST on a 9.2.19 postgres and it didn't panic and instead gave the following error:

```
"{\"hint\":\"No function matches the given name and argument types. You might need to add explicit type casts.\",\"details\":null,\"code\":\"42882\",\"message\":\"function pg_relation_is_updatable(regclass, boolean) does not exist\"}"
```

I did a `trace` of [ver](https://github.com/begriffs/postgrest/blob/master/main/Main.hs#L36) and it was giving a 808792116 value so it was a casting problem.

Also I thought of formatting 90300 into "9.3" but after seeing how libpq [does it](https://github.com/postgres/postgres/blob/master/src/interfaces/libpq/fe-exec.c#L978-L1011) I thought is better to just hardcode it.
