### PR TITLE
Reduce app function

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -54,6 +54,7 @@ library
                      , configurator
                      , containers
                      , contravariant
+                     , either
                      , hasql
                      , hasql-pool == 0.4.1
                      , hasql-transaction == 0.4.5.1

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -1,4 +1,12 @@
-module PostgREST.ApiRequest where
+module PostgREST.ApiRequest ( ApiRequest(..)
+                            , ContentType(..)
+                            , Action(..), Target(..)
+                            , PreferRepresentation (..)
+                            , mutuallyAgreeable
+                            , ctToHeader
+                            , userApiRequest
+                            , toHeader
+                            ) where
 
 import           Protolude
 
@@ -281,6 +289,3 @@ ensureUniform arr =
   if (V.length objs == V.length arr) && areKeysUniform
     then Just (UniformObjects objs)
     else Nothing
-
-readBSMaybe :: Read a => ByteString -> Maybe a
-readBSMaybe = readMaybe . toS

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -54,6 +54,7 @@ data Target = TargetIdent QualifiedIdentifier
             | TargetProc  QualifiedIdentifier
             | TargetRoot
             | TargetUnknown [Text]
+            deriving Eq
 -- | How to return the inserted data
 data PreferRepresentation = Full | HeadersOnly | None deriving Eq
                           --
@@ -120,9 +121,9 @@ userApiRequest schema req reqBody =
                else ActionInappropriate
           else
             case method of
-               "GET"     -> case target of
-                              TargetRoot -> ActionInspect
-                              _ -> ActionRead
+               "GET"     -> if target == TargetRoot
+                              then ActionInspect
+                              else ActionRead
                "POST"    -> ActionCreate
                "PATCH"   -> ActionUpdate
                "DELETE"  -> ActionDelete

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -121,8 +121,8 @@ userApiRequest schema req reqBody =
           else
             case method of
                "GET"     -> case target of
-                                       TargetRoot -> ActionInspect
-                                       _ -> ActionRead
+                              TargetRoot -> ActionInspect
+                              _ -> ActionRead
                "POST"    -> ActionCreate
                "PATCH"   -> ActionUpdate
                "DELETE"  -> ActionDelete

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -55,9 +55,11 @@ data PreferRepresentation = Full | HeadersOnly | None deriving Eq
 data ContentType = CTApplicationJSON | CTTextCSV | CTOpenAPI
                  | CTAny | CTOther BS.ByteString deriving Eq
 
+-- | Convert from ContentType to a full HTTP Header
 ctToHeader :: ContentType -> Header
 ctToHeader ct = (hContentType, toHeader ct <> "; charset=utf-8")
 
+-- | Convert from ContentType to a ByteString representing the mime type
 toHeader :: ContentType -> ByteString
 toHeader CTApplicationJSON = "application/json"
 toHeader CTTextCSV         = "text/csv"

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -265,7 +265,7 @@ app dbStructure conf apiRequest =
 
       mapSnd f (a, b) = (a, f b)
       readDbRequest = DbRead <$> readRequestOrError (configMaxRows conf) (dbRelations dbStructure) (map (mapSnd pdReturnType) $ dbProcs dbStructure) apiRequest
-      mutateDbRequest = DbMutate <$> buildMutateRequest apiRequest
+      mutateDbRequest = DbMutate <$> mutateRequestOrError apiRequest
       selectQuery = requestToQuery schema False <$> readDbRequest
       mutateQuery = requestToQuery schema False <$> mutateDbRequest
       countQuery = requestToCountQuery schema <$> readDbRequest
@@ -424,8 +424,8 @@ readRequestOrError maxRows allRels allProcs apiRequest  =
       _       -> allRels
       where fakeSourceRelations = mapMaybe (toSourceRelation rootTableName) allRels -- see comment in toSourceRelation
 
-buildMutateRequest :: ApiRequest -> Either Response MutateRequest
-buildMutateRequest apiRequest = mapLeft (errResponse status400) $
+mutateRequestOrError :: ApiRequest -> Either Response MutateRequest
+mutateRequestOrError apiRequest = mapLeft (errResponse status400) $
   case action of
     ActionCreate -> Insert rootTableName <$> pure payload
     ActionUpdate -> Update rootTableName <$> pure payload <*> filters

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -100,7 +100,7 @@ transactionMode _ = HT.Write
 app :: DbStructure -> AppConfig -> ApiRequest -> H.Transaction Response
 app dbStructure conf apiRequest =
   case responseContentTypeOrError (iAccepts apiRequest) (iAction apiRequest) of
-    Left r -> return r
+    Left errorResponse -> return errorResponse
     Right contentType ->
       case (iAction apiRequest, iTarget apiRequest, iPayload apiRequest) of
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -38,13 +38,14 @@ import qualified Hasql.Transaction         as H
 
 import qualified Data.HashMap.Strict       as M
 
-import           PostgREST.ApiRequest   (ApiRequest(..), ContentType(..)
-                                            , Action(..), Target(..)
-                                            , PreferRepresentation (..)
-                                            , userApiRequest, mutuallyAgreeable
-                                            , ctToHeader
-                                            , userApiRequest
-                                            , toHeader)
+import           PostgREST.ApiRequest   ( ApiRequest(..), ContentType(..)
+                                        , Action(..), Target(..)
+                                        , PreferRepresentation (..)
+                                        , mutuallyAgreeable
+                                        , ctToHeader
+                                        , userApiRequest
+                                        , toHeader
+                                        )
 import           PostgREST.Auth            (jwtClaims, containsRole)
 import           PostgREST.Config          (AppConfig (..))
 import           PostgREST.DbStructure

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -201,7 +201,7 @@ app dbStructure conf apiRequest =
           let acceptH = (hAllow, if tableInsertable table then "GET,POST,PATCH,DELETE" else "GET") in
           return $ responseLBS status200 [allOrigins, acceptH] ""
 
-    (ActionInvoke, TargetProc qi, Just (PayloadJSON (UniformObjects payload))) -> do
+    (ActionInvoke, TargetProc qi, Just (PayloadJSON (UniformObjects payload))) ->
         servesMatchingContentTypes' $ \_ ->
           servesReadRequest' $ \q cq -> do
             let p = V.head payload
@@ -212,7 +212,7 @@ app dbStructure conf apiRequest =
                 (status, contentRange) = rangeHeader queryTotal tableTotal
             return $ responseLBS status [jsonH, contentRange] (toS . encode $ body)
 
-    (ActionInspect, TargetRoot, Nothing) -> do
+    (ActionInspect, TargetRoot, Nothing) ->
       servesMatchingContentTypes' $ \_ -> do
         let host = configHost conf
             port = toInteger $ configPort conf

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -284,14 +284,14 @@ responseContentTypeOrError accepts action =
   where
     contentTypesForRequest =
       case action of
-        ActionRead   -> [CTApplicationJSON, CTTextCSV]
+        ActionRead -> [CTApplicationJSON, CTTextCSV]
         ActionCreate -> [CTApplicationJSON, CTTextCSV]
         ActionUpdate -> [CTApplicationJSON, CTTextCSV]
         ActionDelete -> [CTApplicationJSON, CTTextCSV]
         ActionInvoke -> [CTApplicationJSON]
         ActionInspect -> [CTOpenAPI]
-        ActionInfo   -> [CTTextCSV]
-        _ -> []
+        ActionInfo -> [CTTextCSV]
+        ActionInappropriate -> []
     serves sProduces cAccepts =
       case mutuallyAgreeable sProduces cAccepts of
         Nothing -> do

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -15,6 +15,7 @@ import           Data.Ranged.Ranges        (emptyRange)
 import           Data.Text                 (replace, strip, isInfixOf, dropWhile, drop, intercalate)
 import           Data.Time.Clock.POSIX     (POSIXTime)
 import           Data.Tree
+import           Data.Either.Combinators   (mapLeft)
 
 import qualified Hasql.Pool                as P
 import qualified Hasql.Transaction         as HT
@@ -377,10 +378,6 @@ treeRestrictRange maxRows_ request = pure $ nodeRestrictRange maxRows_ `fmap` re
   where
     nodeRestrictRange :: Maybe Integer -> ReadNode -> ReadNode
     nodeRestrictRange m (q@Select {range_=r}, i) = (q{range_=restrictRange m r }, i)
-
-mapLeft :: (a -> b) -> Either a c -> Either b c
-mapLeft f (Left x) = Left $ f x
-mapLeft _ (Right x) = Right x
 
 readRequest :: Maybe Integer -> [Relation] -> [(Text, Text)] -> ApiRequest -> Either Response ReadRequest
 readRequest maxRows allRels allProcs apiRequest  =

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -12,17 +12,17 @@ import qualified Hasql.Pool                as P
 import qualified Hasql.Session             as H
 import qualified Network.HTTP.Types.Status as HT
 import           Network.Wai               (Response, responseLBS)
-import           PostgREST.ApiRequest      (ctToHeader, ContentType(..))
+import           PostgREST.ApiRequest      (toHeader, ContentType(..))
 
 errResponse :: HT.Status -> Text -> Response
 errResponse status message = responseLBS status
-  [ctToHeader CTApplicationJSON]
+  [toHeader CTApplicationJSON]
   (toS $ T.concat ["{\"message\":\"",message,"\"}"])
 
 pgErrResponse :: Bool -> P.UsageError -> Response
 pgErrResponse authed e =
   let status = httpStatus authed e
-      jsonType = ctToHeader CTApplicationJSON
+      jsonType = toHeader CTApplicationJSON
       wwwAuth = ("WWW-Authenticate", "Bearer")
       hdrs = if status == HT.status401
                 then [jsonType, wwwAuth]

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -15,7 +15,7 @@ import           Network.Wai.Middleware.Gzip   (def, gzip)
 import           Network.Wai.Middleware.Static (only, staticPolicy)
 
 import           PostgREST.ApiRequest          (ApiRequest(..), ContentType(..),
-                                                ctToHeader)
+                                                toHeader)
 import           PostgREST.Auth                (claimsToSQL, JWTAttempt(..))
 import           PostgREST.Config              (AppConfig (..), corsPolicy)
 import           PostgREST.Error               (errResponse)
@@ -40,7 +40,7 @@ runWithClaims conf eClaims app req =
     anon = String . toS $ configAnonRole conf
     customReqCheck = (\f -> "select " <> toS f <> "();") <$> configReqCheck conf
     unauthed message = responseLBS unauthorized401
-      [ ctToHeader CTApplicationJSON
+      [ toHeader CTApplicationJSON
       , ( "WWW-Authenticate"
         , "Bearer error=\"invalid_token\", " <>
           "error_description=\"" <> message <> "\""

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -20,14 +20,14 @@ import           Protolude hiding              (concat, (&), Proxy, get, interca
 
 import           Data.Swagger
 
-import           PostgREST.ApiRequest        (ContentType(..), toHeader)
+import           PostgREST.ApiRequest        (ContentType(..), toMime)
 import           PostgREST.Config            (prettyVersion)
 import           PostgREST.QueryBuilder      (operators)
 import           PostgREST.Types             (Table(..), Column(..), PgArg(..),
                                               Proxy(..), ProcDescription(..))
 
 makeMimeList :: [ContentType] -> MimeList
-makeMimeList cs = MimeList $ map (fromString . toS . toHeader) cs
+makeMimeList cs = MimeList $ map (fromString . toS . toMime) cs
 
 toSwaggerType :: Text -> SwaggerType t
 toSwaggerType "text"      = SwaggerString


### PR DESCRIPTION
This PR is a small refactor in preparation for a series of refactors with the goal of reducing and simplifying the big `app` function.

It extracts the content type negotiation to a separate function (`servesMatchingContentTypes `) that later could be entirely removed and coded in terms of a new type called `InvalidResponse` that would encompass several error cases closer to the domain level.

It also extracts some common cases that checked for valid db requests into the functions `servesMutateRequest` and `servesReadRequest'`. This reduces duplication and improves a bit the readability of the big case body in the `app` function.

As part of readability improvements some lines were moved to bring definitions closer to their respective usage.

There is also some naming improvements, `ctToHeader` is not `toHeader` and the old `toHeader` is `toMime` as these names seem more precise.