### PR TITLE
Introduce new 'Prefer' header, rpcParams=asJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
+- New `Prefer` header value: `params=single-object` to pass all form values as a single json object to a stored procedure - @dsimunic
 - Ability to generate an OpenAPI spec - @mainx07, @hudayou, @ruslantalpa, @begriffs
 - Ability to generate an OpenAPI spec behind a proxy - @hudayou
 - Ability to set addresses to listen on - @hudayou

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -97,7 +97,7 @@ data ApiRequest = ApiRequest {
   -- | If client wants first row as raw object
   , iPreferSingular :: Bool
   -- | Pass all parameters as a single json object to a stored procedure
-  , iPreferSingleJsonParameter :: Bool
+  , iPreferSingleObjectParameter :: Bool
   -- | Whether the client wants a result count (slower)
   , iPreferCount :: Bool
   -- | Filters on the result ("id", "eq.10")
@@ -174,7 +174,7 @@ userApiRequest schema req reqBody =
   , iPayload = relevantPayload
   , iPreferRepresentation = representation
   , iPreferSingular = singular
-  , iPreferSingleJsonParameter = asJson
+  , iPreferSingleObjectParameter = singleObject
   , iPreferCount = not singular && hasPrefer "count=exact"
   , iFilters = [ (toS k, toS $ fromJust v) | (k,v) <- qParams, isJust v, k /= "select", not (endingIn ["order", "limit", "offset"] k) ]
   , iSelect = toS $ fromMaybe "*" $ fromMaybe (Just "*") $ lookup "select" qParams
@@ -200,7 +200,7 @@ userApiRequest schema req reqBody =
         split :: BS.ByteString -> [Text]
         split = map T.strip . T.split (==',') . toS
   singular        = hasPrefer "plurality=singular"
-  asJson          = hasPrefer "rpcParams=asJson"
+  singleObject    = hasPrefer "params=single-object"
   representation
     | hasPrefer "return=representation" = Full
     | hasPrefer "return=minimal" = None

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -96,6 +96,8 @@ data ApiRequest = ApiRequest {
   , iPreferRepresentation :: PreferRepresentation
   -- | If client wants first row as raw object
   , iPreferSingular :: Bool
+  -- | Pass all parameters as a single json object to a stored procedure
+  , iPreferSingleJsonParameter :: Bool
   -- | Whether the client wants a result count (slower)
   , iPreferCount :: Bool
   -- | Filters on the result ("id", "eq.10")
@@ -172,6 +174,7 @@ userApiRequest schema req reqBody =
   , iPayload = relevantPayload
   , iPreferRepresentation = representation
   , iPreferSingular = singular
+  , iPreferSingleJsonParameter = asJson
   , iPreferCount = not singular && hasPrefer "count=exact"
   , iFilters = [ (toS k, toS $ fromJust v) | (k,v) <- qParams, isJust v, k /= "select", not (endingIn ["order", "limit", "offset"] k) ]
   , iSelect = toS $ fromMaybe "*" $ fromMaybe (Just "*") $ lookup "select" qParams
@@ -197,6 +200,7 @@ userApiRequest schema req reqBody =
         split :: BS.ByteString -> [Text]
         split = map T.strip . T.split (==',') . toS
   singular        = hasPrefer "plurality=singular"
+  asJson          = hasPrefer "rpcParams=asJson"
   representation
     | hasPrefer "return=representation" = Full
     | hasPrefer "return=minimal" = None

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -215,8 +215,8 @@ app dbStructure conf apiRequest =
             Right (q, cq) -> respondToRange $ do
               let p = V.head payload
                   singular = iPreferSingular apiRequest
-                  paramsAsJson = iPreferSingleJsonParameter apiRequest
-              row <- H.query () (callProc qi p q cq topLevelRange shouldCount singular paramsAsJson)
+                  paramsAsSingleObject = iPreferSingleObjectParameter apiRequest
+              row <- H.query () (callProc qi p q cq topLevelRange shouldCount singular paramsAsSingleObject)
               let (tableTotal, queryTotal, body) =
                     fromMaybe (Just 0, 0, emptyArray) row
                   (status, contentRange) = rangeHeader queryTotal tableTotal

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -215,7 +215,8 @@ app dbStructure conf apiRequest =
             Right (q, cq) -> respondToRange $ do
               let p = V.head payload
                   singular = iPreferSingular apiRequest
-              row <- H.query () (callProc qi p q cq topLevelRange shouldCount singular)
+                  paramsAsJson = iPreferSingleJsonParameter apiRequest
+              row <- H.query () (callProc qi p q cq topLevelRange shouldCount singular paramsAsJson)
               let (tableTotal, queryTotal, body) =
                     fromMaybe (Just 0, 0, emptyArray) row
                   (status, contentRange) = rangeHeader queryTotal tableTotal

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -182,12 +182,14 @@ makePostParams tn =
     & schema .~ ParamBody (Ref (Reference tn))
   ]
 
-makeProcParam :: Text -> Param
+makeProcParam :: Text -> [Param]
 makeProcParam refName =
-  (mempty :: Param)
+  [ makePreferParam ["params=single-object"]
+  , (mempty :: Param)
     & name     .~ "args"
     & required ?~ True
     & schema   .~ ParamBody (Ref (Reference refName))
+  ]
 
 makeDeleteParams :: [Param]
 makeDeleteParams =
@@ -224,7 +226,7 @@ makeProcPathItem :: ProcDescription -> (FilePath, PathItem)
 makeProcPathItem pd = ("/rpc/" ++ toS (pdName pd), pe)
   where
     postOp = (mempty :: Operation)
-      & parameters .~ [Inline (makeProcParam $ "(rpc) " <> pdName pd)]
+      & parameters .~ map Inline (makeProcParam $ "(rpc) " <> pdName pd)
       & tags .~ Set.fromList ["(rpc) " <> pdName pd]
       & produces ?~ makeMimeList [CTApplicationJSON]
       & at 200 ?~ "OK"

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -501,7 +501,8 @@ insertableValue JSON.Null = "null"
 insertableValue v = (<> "::unknown") . pgFmtLit $ unquoted v
 
 insertableValueWithType :: Text -> JSON.Value -> SqlFragment
-insertableValueWithType t v = (<> "::" <> t) . pgFmtLit $ unquoted v
+insertableValueWithType t v =
+  pgFmtLit (unquoted v) <> "::" <> t
 
 whiteList :: Text -> SqlFragment
 whiteList val = fromMaybe

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -609,6 +609,20 @@ spec = do
       post "/rpc/callcounter" [json| {} |] `shouldRespondWith`
         [json|2|]
 
+    context "expects a single json object" $ do
+      it "does not expand posted json into parameters" $
+        request methodPost "/rpc/singlejsonparam"
+          [("Prefer","params=single-object")] [json| { "p1": 1, "p2": "text", "p3" : {"obj":"text"} } |] `shouldRespondWith`
+          [json| { "p1": 1, "p2": "text", "p3" : {"obj":"text"} } |]
+
+      it "accepts parameters from an html form" $ do
+        request methodPost "/rpc/singlejsonparam"
+          [("Prefer","params=single-object"),("Content-Type", "application/x-www-form-urlencoded")]
+          ("integer=7&double=2.71828&varchar=forms+are+fun&" <>
+           "boolean=false&date=1900-01-01&money=$3.99&enum=foo") `shouldRespondWith`
+          [json| { "integer": 7, "double": 2.71828, "varchar" : "forms are fun"
+                 , "boolean":false, "date":"1900-01-01", "money":"$3.99", "enum":"foo" } |]
+
   describe "weird requests" $ do
     it "can query as normal" $ do
       get "/Escap3e;" `shouldRespondWith`

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -620,8 +620,8 @@ spec = do
           [("Prefer","params=single-object"),("Content-Type", "application/x-www-form-urlencoded")]
           ("integer=7&double=2.71828&varchar=forms+are+fun&" <>
            "boolean=false&date=1900-01-01&money=$3.99&enum=foo") `shouldRespondWith`
-          [json| { "integer": 7, "double": 2.71828, "varchar" : "forms are fun"
-                 , "boolean":false, "date":"1900-01-01", "money":"$3.99", "enum":"foo" } |]
+          [json| { "integer": "7", "double": "2.71828", "varchar" : "forms are fun"
+                 , "boolean":"false", "date":"1900-01-01", "money":"$3.99", "enum":"foo" } |]
 
   describe "weird requests" $ do
     it "can query as normal" $ do

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -615,7 +615,7 @@ spec = do
           [("Prefer","params=single-object")] [json| { "p1": 1, "p2": "text", "p3" : {"obj":"text"} } |] `shouldRespondWith`
           [json| { "p1": 1, "p2": "text", "p3" : {"obj":"text"} } |]
 
-      it "accepts parameters from an html form" $ do
+      it "accepts parameters from an html form" $ 
         request methodPost "/rpc/singlejsonparam"
           [("Prefer","params=single-object"),("Content-Type", "application/x-www-form-urlencoded")]
           ("integer=7&double=2.71828&varchar=forms+are+fun&" <>

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -33,7 +33,7 @@ spec = do
         r <- simpleBody <$> get "/"
         let ref = r ^? key "paths" . key "/rpc/varied_arguments"
                      . key "post"  . key "parameters"
-                     . nth 0       . key "schema"
+                     . nth 1       . key "schema"
                      . key "$ref"  . _String
             args = r ^? key "definitions" . key "(rpc) varied_arguments"
 

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -323,6 +323,16 @@ CREATE FUNCTION callcounter() RETURNS bigint
 $_$;
 
 --
+-- Name: singlejsonparam(json); Type: FUNCTION; Schema: test; Owner: -
+--
+
+CREATE FUNCTION singlejsonparam(single_param json) RETURNS json
+    LANGUAGE sql
+    AS $_$
+    SELECT single_param;
+$_$;
+
+--
 -- Name: test_empty_rowset(); Type: FUNCTION; Schema: test; Owner: -
 --
 


### PR DESCRIPTION
At present, the parameters from an urlencoded form POST are first converted to JSON, and then this json is expaned into named parameters in [`callProc`](https://github.com/begriffs/postgrest/blob/41c1cf6e018b1ced2f720219fd4928cdc2259fa6/src/PostgREST/QueryBuilder.hs#L261). 

This flag instructs `callProc` to pass all parameters as a single JSON object to a stored procedure. If the request contains the header `Prefer: rpcParams=asJson`, then the call assumes a stored procedure with a single input JSON parameter and passes the complete params object as JSON.

This is super-useful for letting the database dispatch on more complicated HTML forms, or when the application has dynamically generated forms. Instead of creating multiple stored procedure for every possible combination of fields, a single procedure can take care of inspecting, modifying, and dispatching the request as needed.

For static HTML forms, this requires merely adding the header on the reverse proxy, without having to manipulate the request any further.