### PR TITLE
Support conditional requirement for -c argument

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -47,6 +47,7 @@ library
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
   build-depends:       aeson
+                     , ansi-wl-pprint
                      , base >= 4.8 && < 6
                      , bytestring
                      , case-insensitive


### PR DESCRIPTION
Fixes #736

The `readOptions` function is getting ungainly. I added comments to help explain it. The notion of having a command line argument that is conditionally mandatory does not fit Haskell's notion of Applicative, hence using optparse-applicative to parse the args is awkward. However that library is pretty convenient with help text formatting etc that I kept it and am working around it a little.

Code reviews appreciated.