### PR TITLE
Moves request error handling to user api request

### DIFF
--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -182,9 +182,7 @@ userApiRequest schema req reqBody
               other         -> TargetUnknown other
   shouldParsePayload = action `elem` [ActionCreate, ActionUpdate, ActionInvoke]
   relevantPayload = if shouldParsePayload
-                      then case payload of
-                        Right p -> Just p
-                        Left _ -> Nothing
+                      then rightToMaybe payload
                       else Nothing
   path            = pathInfo req
   method          = requestMethod req

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -162,15 +162,13 @@ userApiRequest schema req reqBody
       ct ->
         Left $ toS $ "Content-Type not acceptable: " <> toMime ct
   topLevelRange = fromMaybe allRange $ M.lookup "limit" ranges
-  action =
-    if isTargetingProc
-      then ActionInvoke
-      else
-        case method of
+  action = case method of
             "GET"     -> if target == TargetRoot
                           then ActionInspect
                           else ActionRead
-            "POST"    -> ActionCreate
+            "POST"    -> if isTargetingProc
+                          then ActionInvoke
+                          else ActionCreate
             "PATCH"   -> ActionUpdate
             "DELETE"  -> ActionDelete
             "OPTIONS" -> ActionInfo

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -48,7 +48,6 @@ data Action = ActionCreate | ActionRead
             | ActionUpdate | ActionDelete
             | ActionInfo   | ActionInvoke
             | ActionInspect
-            | ActionInappropriate
             deriving Eq
 -- | The target db object of a user action
 data Target = TargetIdent QualifiedIdentifier
@@ -181,7 +180,7 @@ userApiRequest schema req reqBody
             "PATCH"   -> ActionUpdate
             "DELETE"  -> ActionDelete
             "OPTIONS" -> ActionInfo
-            _         -> ActionInappropriate
+            _         -> ActionInspect
   target = case path of
               []            -> TargetRoot
               [table]       -> TargetIdent

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -95,8 +95,8 @@ postgrest conf refDbStructure pool getTime =
           (HT.run handleReq HT.ReadCommitted txMode)
         respond resp
   where
-    respondToError error =
-      case error of
+    respondToError err =
+      case err of
         ErrorActionInappropriate -> errResponse status405 "Bad Request"
         ErrorInvalidBody errorMessage -> errResponse status400 $ toS errorMessage
 
@@ -286,10 +286,7 @@ app dbStructure conf apiRequest =
           else response
 
 responseContentTypeOrError :: [ContentType] -> Action -> Either Response ContentType
-responseContentTypeOrError accepts action =
-  case action of
-    ActionInappropriate -> Left $ errResponse status405 "Unsupported HTTP verb"
-    _ -> serves contentTypesForRequest accepts
+responseContentTypeOrError accepts action = serves contentTypesForRequest accepts
   where
     contentTypesForRequest =
       case action of
@@ -300,7 +297,6 @@ responseContentTypeOrError accepts action =
         ActionInvoke -> [CTApplicationJSON]
         ActionInspect -> [CTOpenAPI]
         ActionInfo -> [CTTextCSV]
-        ActionInappropriate -> []
     serves sProduces cAccepts =
       case mutuallyAgreeable sProduces cAccepts of
         Nothing -> do

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -240,10 +240,6 @@ app dbStructure conf apiRequest =
           body <- encodeApi . toTableInfo <$> H.query schema accessibleTables
           return $ responseLBS status200 [toHeader CTOpenAPI] $ toS body
 
-        (_, _, Just (PayloadParseError e)) ->
-          return $ errResponse status400 $
-            toS (formatGeneralError "Cannot parse request payload" (toS e))
-
         _ -> return notFound
 
     where

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
-module PostgREST.Error (pgErrResponse, errResponse, prettyUsageError) where
+module PostgREST.Error (apiRequestErrResponse, pgErrResponse, errResponse, prettyUsageError) where
 
 import           Protolude
 import           Data.Aeson                ((.=))
@@ -12,7 +12,14 @@ import qualified Hasql.Pool                as P
 import qualified Hasql.Session             as H
 import qualified Network.HTTP.Types.Status as HT
 import           Network.Wai               (Response, responseLBS)
-import           PostgREST.ApiRequest      (toHeader, ContentType(..))
+import           PostgREST.ApiRequest      (toHeader, ContentType(..), ApiRequestError(..))
+
+apiRequestErrResponse :: ApiRequestError -> Response
+apiRequestErrResponse err =
+  case err of
+    ErrorActionInappropriate -> errResponse HT.status405 "Bad Request"
+    ErrorInvalidBody errorMessage -> errResponse HT.status400 $ toS errorMessage
+    ErrorInvalidRange -> errResponse HT.status416 "HTTP Range error"
 
 errResponse :: HT.Status -> Text -> Response
 errResponse status message = responseLBS status

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -113,7 +113,6 @@ createReadStatement selectQuery countQuery isSingle countTotal asCsv =
 createWriteStatement :: QualifiedIdentifier -> SqlQuery -> SqlQuery -> Bool ->
                         PreferRepresentation -> [Text] -> Bool -> Payload ->
                         H.Query UniformObjects (Maybe ResultsWithCount)
-createWriteStatement _ _ _ _ _ _ _ (PayloadParseError _) = undefined
 createWriteStatement _ _ mutateQuery _ None
                      _ _ (PayloadJSON (UniformObjects _)) =
   unicodeStatement sql encodeUniformObjs decodeStandardMay True
@@ -322,8 +321,6 @@ requestToCountQuery schema (DbRead (Node (Select _ _ conditions _ _, (mainTbl, _
    localConditions = filter fn conditions
 
 requestToQuery :: Schema -> Bool -> DbRequest -> SqlQuery
-requestToQuery _ _ (DbMutate (Insert _ (PayloadParseError _))) = undefined
-requestToQuery _ _ (DbMutate (Update _ (PayloadParseError _) _)) = undefined
 requestToQuery schema isParent (DbRead (Node (Select colSelects tbls conditions ord range, (nodeName, maybeRelation, _)) forest)) =
   query
   where

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -2,7 +2,6 @@ module PostgREST.Types where
 import           Protolude
 import qualified GHC.Show
 import           Data.Aeson
-import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as BL
 import           Data.Tree
 import qualified Data.Vector          as V
@@ -112,7 +111,7 @@ unUniformObjects (UniformObjects objs) = objs
 -- have a special payload just for CSV, but until
 -- then CSV is converted to a JSON array.
 data Payload = PayloadJSON UniformObjects
-             | PayloadParseError BS.ByteString
+             | PayloadParseError ByteString
              deriving (Show, Eq)
 
 data Proxy = Proxy {

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -110,9 +110,7 @@ unUniformObjects (UniformObjects objs) = objs
 -- | When Hasql supports the COPY command then we can
 -- have a special payload just for CSV, but until
 -- then CSV is converted to a JSON array.
-data Payload = PayloadJSON UniformObjects
-             | PayloadParseError ByteString
-             deriving (Show, Eq)
+data Payload = PayloadJSON UniformObjects deriving (Show, Eq)
 
 data Proxy = Proxy {
   proxyScheme     :: Text

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -101,16 +101,11 @@ data Relation = Relation {
 
 -- | An array of JSON objects that has been verified to have
 -- the same keys in every object
-newtype UniformObjects = UniformObjects (V.Vector Object)
+newtype PayloadJSON = PayloadJSON (V.Vector Object)
   deriving (Show, Eq)
 
-unUniformObjects :: UniformObjects -> V.Vector Object
-unUniformObjects (UniformObjects objs) = objs
-
--- | When Hasql supports the COPY command then we can
--- have a special payload just for CSV, but until
--- then CSV is converted to a JSON array.
-data Payload = PayloadJSON UniformObjects deriving (Show, Eq)
+unPayloadJSON :: PayloadJSON -> V.Vector Object
+unPayloadJSON (PayloadJSON objs) = objs
 
 data Proxy = Proxy {
   proxyScheme     :: Text
@@ -130,9 +125,9 @@ type NodeName = Text
 type SelectItem = (Field, Maybe Cast, Maybe Alias)
 type Path = [Text]
 data ReadQuery = Select { select::[SelectItem], from::[TableName], flt_::[Filter], order::Maybe [OrderTerm], range_::NonnegRange } deriving (Show, Eq)
-data MutateQuery = Insert { in_::TableName, qPayload::Payload }
+data MutateQuery = Insert { in_::TableName, qPayload::PayloadJSON }
                  | Delete { in_::TableName, where_::[Filter] }
-                 | Update { in_::TableName, qPayload::Payload, where_::[Filter] } deriving (Show, Eq)
+                 | Update { in_::TableName, qPayload::PayloadJSON, where_::[Filter] } deriving (Show, Eq)
 data Filter = Filter {field::Field, operator::Operator, value::FValue} deriving (Show, Eq)
 type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias))
 type ReadRequest = Tree ReadNode


### PR DESCRIPTION
The idea behind this refactor is to extract error cases that were inside the `ApiRequest` type (namely as the `ActionInappropriate` and `PayloadParseError` constructors).

Now this error cases are handled by the `userApiRequest` that returns an `Either ApiRequestError ApiRequest`.

The type `ApiRequestError` has a function inside the error module that converts this type into an HTTP response. This function is used in the `postgrest` function making the `app` function slightly simpler as well.