### PR TITLE
Add constraint for vanilla cabal builds

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -68,7 +68,7 @@ library
                      , lens
                      , lens-aeson
                      , network-uri
-                     , optparse-applicative
+                     , optparse-applicative >= 0.12.0.0 && < 0.13.0.0
                      , parsec
                      , protolude
                      , Ranged-sets == 0.3.0


### PR DESCRIPTION
In #751 @SkinyMonkey discovered that regular cabal had a build error. The cause was a breaking change in optparse-applicative 0.13.0.0. This is an error we would have seen when upgrading to Stack LTS 7.10 as well actually.

I'm wondering whether I should examine the package versions chosen in the current LTS snapshot and add major version constraints to the packages in the cabal file. This will ensure that people who use cabal can also comfortably contribute to the project.

While I have gotten used to Stack and rather enjoy it, I know some other Haskellers prefer using the constraint solver for finer grained control. Cabal now supports `new-build` as well which can reuse build artifacts so it's really not so bad.