### PR TITLE
Downgrade postgrest version in Dockerfile until new version is released

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-ENV POSTGREST_VERSION 0.4.0.0
+ENV POSTGREST_VERSION 0.3.2.0
 
 RUN apt-get update && \
     apt-get install -y tar xz-utils wget libpq-dev && \


### PR DESCRIPTION
Dockerhub is getting confused