### PR TITLE
Use a mime type to request singular JSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Use specific columns in the RETURNING section - @ruslantalpa
 
 ### Changed
-- Replace `Prefer: plurality=singular` with custom mime type - @begriffs
+- Replace `Prefer: plurality=singular` with `Accept: application/vnd.pgrst.object` - @begriffs
 - Standardize arrays in responses for `Prefer: return=representation` - @begriffs
 - Calling unknown RPC gives 404, not 400 - @begriffs
 - Use HTTP 400 for raise\_exception - @begriffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Allow test database to be on another host - @dsimunic
-- New `Prefer` header value: `params=single-object` to pass all form values as a single json object to a stored procedure - @dsimunic
+- `Prefer: params=single-object` to treat payload as single json argument in RPC - @dsimunic
 - Ability to generate an OpenAPI spec - @mainx07, @hudayou, @ruslantalpa, @begriffs
 - Ability to generate an OpenAPI spec behind a proxy - @hudayou
 - Ability to set addresses to listen on - @hudayou
@@ -30,6 +30,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Use specific columns in the RETURNING section - @ruslantalpa
 
 ### Changed
+- Replace `Prefer: plurality=singular` with custom mime type - @begriffs
+- Standardize arrays in responses for `Prefer: return=representation` - @begriffs
+- Calling unknown RPC gives 404, not 400 - @begriffs
 - Use HTTP 400 for raise\_exception - @begriffs
 - Remove non-OpenAPI schema description - @begriffs
 - Use comma rather than semicolon to separate Prefer header values - @begriffs

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -120,6 +120,7 @@ Test-Suite spec
                      , Feature.QueryLimitedSpec
                      , Feature.QuerySpec
                      , Feature.RangeSpec
+                     , Feature.SingularSpec
                      , Feature.StructureSpec
                      , Feature.UnicodeSpec
                      , SpecHelper

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -60,7 +60,7 @@ library
                      , either
                      , hasql
                      , hasql-pool == 0.4.1
-                     , hasql-transaction == 0.4.5.1
+                     , hasql-transaction == 0.5
                      , heredoc
                      , HTTP
                      , http-types

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -134,6 +134,7 @@ Test-Suite spec
                      , base64-bytestring
                      , case-insensitive
                      , cassava
+                     , containers
                      , contravariant
                      , hasql
                      , hasql-pool

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -38,7 +38,7 @@ import           Data.Ranged.Boundaries
 import           PostgREST.Types           (QualifiedIdentifier (..),
                                             Schema,
                                             PayloadJSON(..))
-import           Data.Ranged.Ranges        (Range(..), singletonRange, rangeIntersection, emptyRange)
+import           Data.Ranged.Ranges        (Range(..), rangeIntersection, emptyRange)
 
 type RequestBody = BL.ByteString
 
@@ -98,8 +98,6 @@ data ApiRequest = ApiRequest {
   , iPayload :: Maybe PayloadJSON
   -- | If client wants created items echoed back
   , iPreferRepresentation :: PreferRepresentation
-  -- | If client wants first row as raw object
-  , iPreferSingular :: Bool
   -- | Pass all parameters as a single json object to a stored procedure
   , iPreferSingleObjectParameter :: Bool
   -- | Whether the client wants a result count (slower)
@@ -130,9 +128,8 @@ userApiRequest schema req reqBody
         map decodeContentType . parseHttpAccept <$> lookupHeader "accept"
       , iPayload = relevantPayload
       , iPreferRepresentation = representation
-      , iPreferSingular = singular
       , iPreferSingleObjectParameter = singleObject
-      , iPreferCount = not singular && hasPrefer "count=exact"
+      , iPreferCount = hasPrefer "count=exact"
       , iFilters = [ (toS k, toS $ fromJust v) | (k,v) <- qParams, isJust v, k /= "select", not (endingIn ["order", "limit", "offset"] k) ]
       , iSelect = toS $ fromMaybe "*" $ fromMaybe (Just "*") $ lookup "select" qParams
       , iOrder = [(toS k, toS $ fromJust v) | (k,v) <- qParams, isJust v, endingIn ["order"] k ]
@@ -194,7 +191,6 @@ userApiRequest schema req reqBody
     where
         split :: BS.ByteString -> [Text]
         split = map T.strip . T.split (==',') . toS
-  singular        = hasPrefer "plurality=singular"
   singleObject    = hasPrefer "params=single-object"
   representation
     | hasPrefer "return=representation" = Full
@@ -208,7 +204,7 @@ userApiRequest schema req reqBody
   endingIn xx key = lastWord `elem` xx
     where lastWord = last $ T.split (=='.') key
 
-  headerRange = if singular && method == "GET" then singletonRange 0 else rangeRequested hdrs
+  headerRange = rangeRequested hdrs
   replaceLast x s = T.intercalate "." $ L.init (T.split (=='.') s) ++ [x]
   limitParams :: M.HashMap ByteString NonnegRange
   limitParams  = M.fromList [(toS (replaceLast "limit" k), restrictRange (readMaybe =<< (toS <$> v)) allRange) | (k,v) <- qParams, isJust v, endingIn ["limit"] k]

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -59,6 +59,7 @@ data PreferRepresentation = Full | HeadersOnly | None deriving Eq
                           --
 -- | Enumeration of currently supported response content types
 data ContentType = CTApplicationJSON | CTTextCSV | CTOpenAPI
+                 | CTSingularJSON
                  | CTAny | CTOther BS.ByteString deriving Eq
 
 data ApiRequestError = ErrorActionInappropriate
@@ -75,6 +76,7 @@ toMime :: ContentType -> ByteString
 toMime CTApplicationJSON = "application/json"
 toMime CTTextCSV         = "text/csv"
 toMime CTOpenAPI         = "application/openapi+json"
+toMime CTSingularJSON    = "application/vnd.pgrst.object+json"
 toMime CTAny             = "*/*"
 toMime (CTOther ct)      = ct
 
@@ -240,11 +242,13 @@ mutuallyAgreeable sProduces cAccepts =
 decodeContentType :: BS.ByteString -> ContentType
 decodeContentType ct =
   case BS.takeWhile (/= BS.c2w ';') ct of
-    "application/json"         -> CTApplicationJSON
-    "text/csv"                 -> CTTextCSV
-    "application/openapi+json" -> CTOpenAPI
-    "*/*"                      -> CTAny
-    ct'                        -> CTOther ct'
+    "application/json"                  -> CTApplicationJSON
+    "text/csv"                          -> CTTextCSV
+    "application/openapi+json"          -> CTOpenAPI
+    "application/vnd.pgrst.object+json" -> CTSingularJSON
+    "application/vnd.pgrst.object"      -> CTSingularJSON
+    "*/*"                               -> CTAny
+    ct'                                 -> CTOther ct'
 
 type CsvData = V.Vector (M.HashMap Text BL.ByteString)
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -130,9 +130,7 @@ app dbStructure conf apiRequest =
               if contentType == CTSingularJSON
                  && not isSingle
                  && iPreferRepresentation apiRequest == Full
-               then do
-                  HT.sql "ROLLBACK;"
-                  return $ singularityError (toInteger $ V.length rows)
+                then return $ singularityError (toInteger $ V.length rows)
                 else do
                   let pKeys = map pkName $ filter (filterPk schema table) allPrKeys -- would it be ok to move primary key detection in the query itself?
                       stm = createWriteStatement sq mq

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -11,7 +11,7 @@ import qualified Data.ByteString.Char8     as BS
 import           Data.IORef                (IORef, readIORef)
 import           Data.List                 (delete, lookup)
 import           Data.Maybe                (fromJust)
-import           Data.Text                 (replace, strip, isInfixOf, dropWhile, drop, intercalate)
+import           Data.Text                 (replace, strip, isInfixOf, dropWhile, drop, intercalate, unwords)
 import           Data.Time.Clock.POSIX     (POSIXTime)
 import           Data.Tree
 import           Data.Either.Combinators   (mapLeft)
@@ -121,7 +121,7 @@ app dbStructure conf apiRequest =
                       [toHeader contentType]
                       $ toS . formatGeneralError
                         "JSON object requested, multiple rows returned"
-                        $ intercalate " "
+                        $ unwords
                           [ "Results contain", show queryTotal, "rows,"
                           , toS (toMime contentType), "requires 1 row"
                           ]

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -180,9 +180,9 @@ app dbStructure conf apiRequest =
                 else do
                   let r = contentRangeH 0 (toInteger $ queryTotal-1)
                             (toInteger <$> if shouldCount then Just queryTotal else Nothing)
-                      s = case () of _ | queryTotal == 0 -> status404
-                                      | iPreferRepresentation apiRequest == Full -> status200
-                                      | otherwise -> status204
+                      s = if iPreferRepresentation apiRequest == Full
+                            then status200
+                            else status204
                   return $ if iPreferRepresentation apiRequest == Full
                     then responseLBS s [toHeader contentType, r] (toS body)
                     else responseLBS s [r] ""
@@ -199,11 +199,9 @@ app dbStructure conf apiRequest =
               let (_, queryTotal, _, body) = extractQueryResult row
                   r = contentRangeH 1 0 $
                         toInteger <$> if shouldCount then Just queryTotal else Nothing
-              return $ if queryTotal == 0
-                then notFound
-                else if iPreferRepresentation apiRequest == Full
-                  then responseLBS status200 [toHeader contentType, r] (toS body)
-                  else responseLBS status204 [r] ""
+              return $ if iPreferRepresentation apiRequest == Full
+                then responseLBS status200 [toHeader contentType, r] (toS body)
+                else responseLBS status204 [r] ""
 
         (ActionInfo, TargetIdent (QualifiedIdentifier tSchema tTable), Nothing) ->
           let mTable = find (\t -> tableName t == tTable && tableSchema t == tSchema) (dbTables dbStructure) in

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -22,8 +22,6 @@ import qualified Hasql.Transaction         as HT
 import           Text.Parsec.Error
 import           Text.ParserCombinators.Parsec (parse)
 
-import qualified Text.InterpolatedString.Perl6 as P6 (q)
-
 import           Network.HTTP.Types.Header
 import           Network.HTTP.Types.Status
 import           Network.HTTP.Types.URI    (renderSimpleQuery)
@@ -109,40 +107,27 @@ app dbStructure conf apiRequest =
           case readSqlParts of
             Left errorResponse -> return errorResponse
             Right (q, cq) -> do
-              let singular = iPreferSingular apiRequest
-                  stm = createReadStatement q cq singular shouldCount (contentType == CTTextCSV)
+              let stm = createReadStatement q cq shouldCount (contentType == CTTextCSV)
               row <- H.query () stm
               let (tableTotal, queryTotal, _ , body) = row
-              if singular
-              then return $ if queryTotal <= 0
-                then notFound
-                else responseLBS status200 [toHeader contentType] (toS body)
-              else do
-                let (status, contentRange) = rangeHeader queryTotal tableTotal
-                    canonical = iCanonicalQS apiRequest
-                    --TargetIdent qi = iTarget apiRequest
-                return $ responseLBS status
-                  [toHeader contentType, contentRange,
-                    ("Content-Location",
-                      "/" <> toS (qiName qi) <>
-                        if BS.null canonical then "" else "?" <> toS canonical
-                    )
-                  ] (toS body)
+                  (status, contentRange) = rangeHeader queryTotal tableTotal
+                  canonical = iCanonicalQS apiRequest
+                  --TargetIdent qi = iTarget apiRequest
+              return $ responseLBS status
+                [toHeader contentType, contentRange,
+                  ("Content-Location",
+                    "/" <> toS (qiName qi) <>
+                      if BS.null canonical then "" else "?" <> toS canonical
+                  )
+                ] (toS body)
 
         (ActionCreate, TargetIdent qi@(QualifiedIdentifier _ table), Just payload@(PayloadJSON rows)) ->
           case mutateSqlParts of
             Left errorResponse -> return errorResponse
             Right (sq, mq) -> do
               let isSingle = (==1) $ V.length rows
-              when (not isSingle && iPreferSingular apiRequest) $
-                HT.sql [P6.q| DO $$
-                          BEGIN RAISE EXCEPTION cardinality_violation
-                          USING MESSAGE =
-                            'plurality=singular specified, but more than one object would be inserted';
-                          END $$;
-                        |]
-              let pKeys = map pkName $ filter (filterPk schema table) allPrKeys -- would it be ok to move primary key detection in the query itself?
-              let stm = createWriteStatement qi sq mq isSingle (iPreferRepresentation apiRequest) pKeys (contentType == CTTextCSV) payload
+                  pKeys = map pkName $ filter (filterPk schema table) allPrKeys -- would it be ok to move primary key detection in the query itself?
+                  stm = createWriteStatement qi sq mq isSingle (iPreferRepresentation apiRequest) pKeys (contentType == CTTextCSV) payload
               row <- H.query payload stm
               let (_, _, fs, body) = extractQueryResult row
                   headers = catMaybes [
@@ -164,18 +149,10 @@ app dbStructure conf apiRequest =
           case mutateSqlParts of
             Left errorResponse -> return errorResponse
             Right (sq, mq) -> do
-              let singular = iPreferSingular apiRequest
-                  stm = createWriteStatement qi sq mq singular (iPreferRepresentation apiRequest) [] (contentType == CTTextCSV) payload
+              let stm = createWriteStatement qi sq mq False (iPreferRepresentation apiRequest) [] (contentType == CTTextCSV) payload
               row <- H.query payload stm
               let (_, queryTotal, _, body) = extractQueryResult row
-              when (singular && queryTotal > 1) $
-                HT.sql [P6.q| DO $$
-                          BEGIN RAISE EXCEPTION cardinality_violation
-                          USING MESSAGE =
-                            'plurality=singular specified, but more than one object would be updated';
-                          END $$;
-                        |]
-              let r = contentRangeH 0 (toInteger $ queryTotal-1)
+                  r = contentRangeH 0 (toInteger $ queryTotal-1)
                         (toInteger <$> if shouldCount then Just queryTotal else Nothing)
                   s = case () of _ | queryTotal == 0 -> status404
                                   | iPreferRepresentation apiRequest == Full -> status200
@@ -213,9 +190,8 @@ app dbStructure conf apiRequest =
             Left errorResponse -> return errorResponse
             Right (q, cq) -> do
               let p = V.head payload
-                  singular = iPreferSingular apiRequest
                   paramsAsSingleObject = iPreferSingleObjectParameter apiRequest
-              row <- H.query () (callProc qi p q cq topLevelRange shouldCount singular paramsAsSingleObject)
+              row <- H.query () (callProc qi p q cq topLevelRange shouldCount False paramsAsSingleObject)
               let (tableTotal, queryTotal, body) =
                     fromMaybe (Just 0, 0, emptyArray) row
                   (status, contentRange) = rangeHeader queryTotal tableTotal

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -251,13 +251,13 @@ responseContentTypeOrError accepts action = serves contentTypesForRequest accept
   where
     contentTypesForRequest =
       case action of
-        ActionRead -> [CTApplicationJSON, CTTextCSV]
-        ActionCreate -> [CTApplicationJSON, CTTextCSV]
-        ActionUpdate -> [CTApplicationJSON, CTTextCSV]
-        ActionDelete -> [CTApplicationJSON, CTTextCSV]
-        ActionInvoke -> [CTApplicationJSON]
+        ActionRead ->    [CTApplicationJSON, CTSingularJSON, CTTextCSV]
+        ActionCreate ->  [CTApplicationJSON, CTSingularJSON, CTTextCSV]
+        ActionUpdate ->  [CTApplicationJSON, CTSingularJSON, CTTextCSV]
+        ActionDelete ->  [CTApplicationJSON, CTSingularJSON, CTTextCSV]
+        ActionInvoke ->  [CTApplicationJSON, CTSingularJSON]
         ActionInspect -> [CTOpenAPI]
-        ActionInfo -> [CTTextCSV]
+        ActionInfo ->    [CTTextCSV]
     serves sProduces cAccepts =
       case mutuallyAgreeable sProduces cAccepts of
         Nothing -> do

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -103,6 +103,7 @@ httpStatus authed (P.SessionError (H.ResultError (H.ServerError c _ _ _))) =
     "P0001"   -> HT.status400 -- default code for "raise"
     'P':'0':_ -> HT.status500 -- PL/pgSQL Error
     'X':'X':_ -> HT.status500 -- internal Error
+    "42883"   -> HT.status404 -- undefined function
     "42P01"   -> HT.status404 -- undefined table
     "42501"   -> if authed then HT.status403 else HT.status401 -- insufficient privilege
     _         -> HT.status400

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -2,16 +2,18 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
-module PostgREST.Error (apiRequestErrResponse, pgErrResponse, errResponse, prettyUsageError) where
+module PostgREST.Error (apiRequestErrResponse, pgErrResponse, errResponse, prettyUsageError, singularityError, formatGeneralError, formatParserError) where
 
 import           Protolude
 import           Data.Aeson                ((.=))
 import qualified Data.Aeson                as JSON
+import           Data.Text                 (replace, strip, unwords)
 import qualified Hasql.Pool                as P
 import qualified Hasql.Session             as H
 import qualified Network.HTTP.Types.Status as HT
 import           Network.Wai               (Response, responseLBS)
-import           PostgREST.ApiRequest      (toHeader, ContentType(..), ApiRequestError(..))
+import           PostgREST.ApiRequest      (toHeader, toMime, ContentType(..), ApiRequestError(..))
+import           Text.Parsec.Error
 
 apiRequestErrResponse :: ApiRequestError -> Response
 apiRequestErrResponse err =
@@ -40,6 +42,28 @@ prettyUsageError :: P.UsageError -> Text
 prettyUsageError (P.ConnectionError e) =
   "Database connection error:\n" <> toS (fromMaybe "" e)
 prettyUsageError e = show $ JSON.encode e
+
+singularityError :: Integer -> Response
+singularityError numRows =
+  responseLBS HT.status406
+    [toHeader CTSingularJSON]
+    $ toS . formatGeneralError
+      "JSON object requested, multiple (or no) rows returned"
+      $ unwords
+        [ "Results contain", show numRows, "rows,"
+        , toS (toMime CTSingularJSON), "requires 1 row"
+        ]
+
+formatParserError :: ParseError -> Text
+formatParserError e = formatGeneralError message details
+  where
+     message = show $ errorPos e
+     details = strip $ replace "\n" " " $ toS
+       $ showErrorMessages "or" "unknown parse error" "expecting" "unexpected" "end of input" (errorMessages e)
+
+formatGeneralError :: Text -> Text -> Text
+formatGeneralError message details = toS . JSON.encode $
+  JSON.object ["message" .= message, "details" .= details]
 
 instance JSON.ToJSON P.UsageError where
   toJSON (P.ConnectionError e) = JSON.object [

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -155,7 +155,7 @@ makeGetParams :: [Column] -> [Param]
 makeGetParams [] =
   makeRangeParams ++
   [ makeSelectParam
-  , makePreferParam ["plurality=singular", "count=none"]
+  , makePreferParam ["count=none"]
   ]
 makeGetParams cs =
   makeRangeParams ++
@@ -168,12 +168,12 @@ makeGetParams cs =
       & in_ .~ ParamQuery
       & type_ .~ SwaggerString
       & enum_ .~ decode (encode $ makeOrderItems cs))
-  , makePreferParam ["plurality=singular", "count=none"]
+  , makePreferParam ["count=none"]
   ]
 
 makePostParams :: Text -> [Param]
 makePostParams tn =
-  [ makePreferParam ["return=representation", "return=representation,plurality=singular",
+  [ makePreferParam ["return=representation",
                      "return=minimal", "return=none"]
   , (mempty :: Param)
     & name        .~ "body"

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -200,17 +200,17 @@ makePathItem (t, cs, _) = ("/" ++ unpack tn, p $ tableInsertable t)
   where
     tOp = (mempty :: Operation)
       & tags .~ Set.fromList [tn]
-      & produces ?~ makeMimeList [CTApplicationJSON, CTTextCSV]
+      & produces ?~ makeMimeList [CTApplicationJSON, CTSingularJSON, CTTextCSV]
       & at 200 ?~ "OK"
     getOp = tOp
       & parameters .~ map Inline (makeGetParams cs ++ rs)
       & at 206 ?~ "Partial Content"
     postOp = tOp
-      & consumes ?~ makeMimeList [CTApplicationJSON, CTTextCSV]
+      & consumes ?~ makeMimeList [CTApplicationJSON, CTSingularJSON, CTTextCSV]
       & parameters .~ map Inline (makePostParams tn)
       & at 201 ?~ "Created"
     patchOp = tOp
-      & consumes ?~ makeMimeList [CTApplicationJSON, CTTextCSV]
+      & consumes ?~ makeMimeList [CTApplicationJSON, CTSingularJSON, CTTextCSV]
       & parameters .~ map Inline (makePostParams tn ++ rs)
       & at 204 ?~ "No Content"
     deletOp = tOp
@@ -228,7 +228,7 @@ makeProcPathItem pd = ("/rpc/" ++ toS (pdName pd), pe)
     postOp = (mempty :: Operation)
       & parameters .~ map Inline (makeProcParam $ "(rpc) " <> pdName pd)
       & tags .~ Set.fromList ["(rpc) " <> pdName pd]
-      & produces ?~ makeMimeList [CTApplicationJSON]
+      & produces ?~ makeMimeList [CTApplicationJSON, CTSingularJSON]
       & at 200 ?~ "OK"
     pe = (mempty :: PathItem) & post ?~ postOp
 

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -228,7 +228,7 @@ addJoinConditions schema (Node nn@(query, (n, r, a)) forest) =
     updatedForest = mapM (addJoinConditions schema) forest
     addCond query' con = query'{flt_=con ++ flt_ query'}
 
-type ProcResults = (Maybe Int64, Int64, JSON.Value)
+type ProcResults = (Maybe Int64, Int64, ByteString)
 callProc :: QualifiedIdentifier -> JSON.Object -> SqlQuery -> SqlQuery -> NonnegRange -> Bool -> Bool -> Bool -> H.Query () (Maybe ProcResults)
 callProc qi params selectQuery countQuery _ countTotal isSingle paramsAsJson =
   unicodeStatement sql HE.unit decodeProc True
@@ -260,7 +260,7 @@ callProc qi params selectQuery countQuery _ countTotal isSingle paramsAsJson =
                    else "null::bigint" :: Text
     decodeProc = HD.maybeRow procRow
     procRow = (,,) <$> HD.nullableValue HD.int8 <*> HD.value HD.int8
-                   <*> HD.value HD.json
+                   <*> HD.value HD.bytea
     bodyF
      | isSingle = asJsonSingleF
      | otherwise = asJsonF

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -380,9 +380,10 @@ requestToQuery schema _ returningSql (DbMutate (Insert mainTbl (PayloadJSON rows
         insInto = unwords [ "INSERT INTO" , fromQi qi,
             if T.null colsString then "" else "(" <> colsString <> ")"
           ]
-        vals = unwords $ if T.null colsString
-                  then ["DEFAULT VALUES"]
-                  else ["SELECT", colsString, "FROM json_populate_recordset(null::" , fromQi qi, ", $1)"]
+        vals = unwords $
+          if T.null colsString
+            then if V.null rows then ["SELECT null WHERE false"] else ["DEFAULT VALUES"]
+            else ["SELECT", colsString, "FROM json_populate_recordset(null::" , fromQi qi, ", $1)"]
 requestToQuery schema _ returningSql (DbMutate (Update mainTbl (PayloadJSON rows) conditions)) =
   case rows V.!? 0 of
     Just obj ->

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -91,9 +91,9 @@ encodeUniformObjs :: HE.Params PayloadJSON
 encodeUniformObjs =
   contramap (JSON.Array . V.map JSON.Object . unPayloadJSON) (HE.value HE.json)
 
-createReadStatement :: SqlQuery -> SqlQuery -> Bool -> Bool -> Bool ->
+createReadStatement :: SqlQuery -> SqlQuery -> Bool -> Bool ->
                        H.Query () ResultsWithCount
-createReadStatement selectQuery countQuery isSingle countTotal asCsv =
+createReadStatement selectQuery countQuery countTotal asCsv =
   unicodeStatement sql HE.unit decodeStandard False
  where
   sql = [qc|
@@ -108,7 +108,6 @@ createReadStatement selectQuery countQuery isSingle countTotal asCsv =
     ]
   bodyF
     | asCsv = asCsvF
-    | isSingle = asJsonSingleF
     | otherwise = asJsonF
 
 createWriteStatement :: QualifiedIdentifier -> SqlQuery -> SqlQuery -> Bool ->

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -91,9 +91,9 @@ encodeUniformObjs :: HE.Params PayloadJSON
 encodeUniformObjs =
   contramap (JSON.Array . V.map JSON.Object . unPayloadJSON) (HE.value HE.json)
 
-createReadStatement :: SqlQuery -> SqlQuery -> Bool -> Bool ->
+createReadStatement :: SqlQuery -> SqlQuery -> Bool -> Bool -> Bool ->
                        H.Query () ResultsWithCount
-createReadStatement selectQuery countQuery countTotal asCsv =
+createReadStatement selectQuery countQuery isSingle countTotal asCsv =
   unicodeStatement sql HE.unit decodeStandard False
  where
   sql = [qc|
@@ -108,6 +108,7 @@ createReadStatement selectQuery countQuery countTotal asCsv =
     ]
   bodyF
     | asCsv = asCsvF
+    | isSingle = asJsonSingleF
     | otherwise = asJsonF
 
 createWriteStatement :: QualifiedIdentifier -> SqlQuery -> SqlQuery -> Bool ->

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ resolver: lts-7.4
 extra-deps:
   - Ranged-sets-0.3.0
   - hasql-pool-0.4.1
-  - hasql-transaction-0.4.5.1
+  - hasql-transaction-0.5
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities
 nix:

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -15,7 +15,7 @@ import Protolude hiding (get)
 
 spec :: SpecWith Application
 spec = describe "authorization" $ do
-  let single = ("Prefer","plurality=singular")
+  let single = ("Accept","application/vnd.pgrst.object+json")
 
   it "denies access to tables that anonymous does not own" $
     get "/authors_only" `shouldRespondWith` ResponseMatcher {

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -61,10 +61,7 @@ spec = describe "authorization" $ do
   it "sql functions can read custom and standard claims variables" $ do
     let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmdW4iLCJqdGkiOiJmb28iLCJuYmYiOjEzMDA4MTkzODAsImV4cCI6OTk5OTk5OTk5OSwiaHR0cDovL3Bvc3RncmVzdC5jb20vZm9vIjp0cnVlLCJpc3MiOiJqb2UiLCJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWF0IjoxMzAwODE5MzgwLCJhdWQiOiJldmVyeW9uZSJ9.AQmCA7CMScvfaDRMqRPeUY6eNf--69gpW-kxaWfq9X0"
     request methodPost "/rpc/reveal_big_jwt" [auth] "{}"
-      `shouldRespondWith` [json| [
-          {"sub":"fun", "jti":"foo", "nbf":1300819380, "exp":9999999999,
-          "http://postgrest.com/foo":true, "iss":"joe", "iat":1300819380,
-          "aud":"everyone"}] |]
+      `shouldRespondWith` [str|[{"iss":"joe","sub":"fun","aud":"everyone","exp":9999999999,"nbf":1300819380,"iat":1300819380,"jti":"foo","http://postgrest.com/foo":true}]|]
 
   it "allows users with permissions to see their tables" $ do
     let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"

--- a/test/Feature/DeleteSpec.hs
+++ b/test/Feature/DeleteSpec.hs
@@ -52,7 +52,7 @@ spec =
           , matchHeaders = ["Content-Range" <:> "0-0/*"]
           }
 
-    context "known route, no records matched" $ do
+    context "known route, no records matched" $
       it "includes [] body if return=rep" $
         request methodDelete "/items?id=eq.101"
           [("Prefer", "return=representation")] ""

--- a/test/Feature/DeleteSpec.hs
+++ b/test/Feature/DeleteSpec.hs
@@ -52,16 +52,13 @@ spec =
           , matchHeaders = ["Content-Range" <:> "0-0/*"]
           }
 
-    context "known route, unknown record" $ do
-      it "fails with 404" $
-        request methodDelete "/items?id=eq.101" [] "" `shouldRespondWith` 404
-
+    context "known route, no records matched" $ do
       it "includes [] body if return=rep" $
         request methodDelete "/items?id=eq.101"
           [("Prefer", "return=representation")] ""
           `shouldRespondWith` ResponseMatcher {
             matchBody    = Just "[]"
-          , matchStatus  = 404
+          , matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "*/*"]
           }
 

--- a/test/Feature/DeleteSpec.hs
+++ b/test/Feature/DeleteSpec.hs
@@ -52,9 +52,18 @@ spec =
           , matchHeaders = ["Content-Range" <:> "0-0/*"]
           }
 
-    context "known route, unknown record" $
+    context "known route, unknown record" $ do
       it "fails with 404" $
         request methodDelete "/items?id=eq.101" [] "" `shouldRespondWith` 404
+
+      it "includes [] body if return=rep" $
+        request methodDelete "/items?id=eq.101"
+          [("Prefer", "return=representation")] ""
+          `shouldRespondWith` ResponseMatcher {
+            matchBody    = Just "[]"
+          , matchStatus  = 404
+          , matchHeaders = ["Content-Range" <:> "*/*"]
+          }
 
     context "totally unknown route" $
       it "fails with 404" $

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -322,16 +322,18 @@ spec = do
             matchStatus  = 204,
             matchHeaders = ["Content-Range" <:> "0-0/*"]
           }
-        liftIO $
-          lookup hContentType (simpleHeaders p) `shouldBe` Nothing
+        liftIO $ lookup hContentType (simpleHeaders p) `shouldBe` Nothing
 
+        -- check it really got updated
         g' <- get "/items?id=eq.42"
         liftIO $ simpleHeaders g'
           `shouldSatisfy` matchHeader "Content-Range" "0-0/\\*"
+        -- put value back for other tests
+        void $ request methodPatch "/items?id=eq.42" [] [json| { "id":2 } |]
 
       it "returns empty array when no rows updated and return=rep" $
         request methodPatch "/items?id=eq.999999"
-          [("Prefer", "return=representation")] [json| { "id":42 } |]
+          [("Prefer", "return=representation")] [json| { "id":999999 } |]
           `shouldRespondWith` ResponseMatcher {
             matchBody    = Just "[]",
             matchStatus  = 200,
@@ -340,9 +342,9 @@ spec = do
 
       it "returns updated object as array when return=rep" $
         request methodPatch "/items?id=eq.2"
-          [("Prefer", "return=representation")] [json| { "id":42 } |]
+          [("Prefer", "return=representation")] [json| { "id":2 } |]
           `shouldRespondWith` ResponseMatcher {
-            matchBody    = Just [str|[{"id":42}]|],
+            matchBody    = Just [str|[{"id":2}]|],
             matchStatus  = 200,
             matchHeaders = ["Content-Range" <:> "0-0/*"]
           }

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -305,7 +305,11 @@ spec = do
       it "indicates no records found to update" $
         request methodPatch "/empty_table" []
           [json| { "extra":20 } |]
-            `shouldRespondWith` 404
+          `shouldRespondWith` ResponseMatcher {
+            matchBody    = Just "",
+            matchStatus  = 204,
+            matchHeaders = ["Content-Range" <:> "*/*"]
+          }
 
     context "in a nonempty table" $ do
       it "can update a single item" $ do
@@ -330,7 +334,7 @@ spec = do
           [("Prefer", "return=representation")] [json| { "id":42 } |]
           `shouldRespondWith` ResponseMatcher {
             matchBody    = Just "[]",
-            matchStatus  = 404,
+            matchStatus  = 200,
             matchHeaders = ["Content-Range" <:> "*/*"]
           }
 
@@ -377,7 +381,12 @@ spec = do
           "/items?always_true=eq.false"
           [("Prefer", "return=representation")]
           [json| { id: 100 } |]
-          `shouldRespondWith` 404
+          `shouldRespondWith` ResponseMatcher {
+            matchBody    = Just "[]",
+            matchStatus  = 200,
+            matchHeaders = ["Content-Range" <:> "*/*"]
+          }
+
       it "can provide a representation" $ do
         _ <- post "/items"
           [json| { id: 1 } |]

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -377,7 +377,7 @@ spec = do
           "/addresses"
           [("Prefer", "return=representation"),("Accept", "application/vnd.pgrst.object+json")]
           [json| [ { id: 100, address: "xxx" }, { id: 101, address: "xxx" } ] |]
-        liftIO $ simpleStatus p `shouldBe` status400
+        liftIO $ simpleStatus p `shouldBe` status406
 
       it "can set a json column to escaped value" $ do
         _ <- post "/json" [json| { data: {"escaped":"bar"} } |]

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -355,27 +355,27 @@ spec = do
         _ <- post "/addresses" [json| { id: 97, address: "A Street" } |]
         p <- request methodPatch
           "/addresses?id=eq.97"
-          [("Prefer", "return=representation,plurality=singular")]
+          [("Prefer", "return=representation"),("Accept", "application/vnd.pgrst.object+json")]
           [json| { address: "B Street" } |]
         liftIO $ simpleBody p `shouldBe` [str|{"id":97,"address":"B Street"}|]
-      it "raises an error when attempting to update multiple entities with plurality=singular" $ do
+      it "raises an error when attempting to update multiple entities with singular object mime accept header" $ do
         _ <- post "/addresses" [json| { id: 98, address: "xxx" } |]
         _ <- post "/addresses" [json| { id: 99, address: "yyy" } |]
         p <- request methodPatch
           "/addresses?id=gt.0"
-          [("Prefer", "return=representation,plurality=singular")]
+          [("Prefer", "return=representation"),("Accept", "application/vnd.pgrst.object+json")]
           [json| { address: "zzz" } |]
         liftIO $ simpleStatus p `shouldBe` status400
       it "can provide a singular representation when creating one entity" $ do
         p <- request methodPost
           "/addresses"
-          [("Prefer", "return=representation,plurality=singular")]
+          [("Prefer", "return=representation"),("Accept", "application/vnd.pgrst.object+json")]
           [json| [ { id: 100, address: "xxx" } ] |]
         liftIO $ simpleBody p `shouldBe` [str|{"id":100,"address":"xxx"}|]
-      it "raises an error when attempting to create multiple entities with plurality=singular" $ do
+      it "raises an error when attempting to create multiple entities with singular object accept header" $ do
         p <- request methodPost
           "/addresses"
-          [("Prefer", "return=representation,plurality=singular")]
+          [("Prefer", "return=representation"),("Accept", "application/vnd.pgrst.object+json")]
           [json| [ { id: 100, address: "xxx" }, { id: 101, address: "xxx" } ] |]
         liftIO $ simpleStatus p `shouldBe` status400
 

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -134,7 +134,7 @@ spec = do
                      [("Prefer", "return=representation")]
                      inserted
         liftIO $ do
-          JSON.decode (simpleBody p) `shouldBe` Just expectedObj
+          JSON.decode (simpleBody p) `shouldBe` Just [expectedObj]
           simpleStatus p `shouldBe` created201
           lookup hLocation (simpleHeaders p) `shouldBe` Just expectedLoc
 

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -500,7 +500,7 @@ spec = do
     context "shaping the response returned by a proc" $ do
       it "returns a project" $
         post "/rpc/getproject" [json| { "id": 1} |] `shouldRespondWith`
-          [json|[{"id":1,"name":"Windows 7","client_id":1}]|]
+          [str|[{"id":1,"name":"Windows 7","client_id":1}]|]
 
       it "can filter proc results" $
         post "/rpc/getallprojects?id=gt.1&id=lt.5&select=id" [json| {} |] `shouldRespondWith`
@@ -516,11 +516,11 @@ spec = do
 
       it "select works on the first level" $
         post "/rpc/getproject?select=id,name" [json| { "id": 1} |] `shouldRespondWith`
-          [json|[{"id":1,"name":"Windows 7"}]|]
+          [str|[{"id":1,"name":"Windows 7"}]|]
 
       it "can embed foreign entities to the items returned by a proc" $
         post "/rpc/getproject?select=id,name,client{id},tasks{id}" [json| { "id": 1} |] `shouldRespondWith`
-          [json|[{"id":1,"name":"Windows 7","client":{"id":1},"tasks":[{"id":1},{"id":2}]}]|]
+          [str|[{"id":1,"name":"Windows 7","client":{"id":1},"tasks":[{"id":1},{"id":2}]}]|]
 
     context "a proc that returns an empty rowset" $
       it "returns empty json array" $

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -302,36 +302,6 @@ spec = do
       get "/projects?id=in.1,3&select=id,name,client_id,client{id,name}" `shouldRespondWith`
         [str|[{"id":1,"name":"Windows 7","client_id":1,"client":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":2,"client":{"id":2,"name":"Apple"}}]|]
 
-
-  describe "Plurality singular" $ do
-    let singular = ("Accept", "application/vnd.pgrst.object+json")
-
-    it "will select an existing object" $
-      request methodGet "/items?id=eq.5" [singular] ""
-        `shouldRespondWith` ResponseMatcher {
-          matchBody    = Just [json| {"id":5} |]
-        , matchStatus  = 200
-        , matchHeaders = []
-        }
-
-    it "can combine multiple prefer values" $
-      request methodGet "/items?id=eq.5" [singular, ("Prefer","count=none")] ""
-        `shouldRespondWith` ResponseMatcher {
-          matchBody    = Just [json| {"id":5} |]
-        , matchStatus  = 200
-        , matchHeaders = []
-        }
-
-    it "will respond with 406 for empty response" $
-      request methodGet "/items?id=eq.9999" [singular] ""
-        `shouldRespondWith` 406
-
-    it "can shape plurality singular object routes" $
-      request methodGet "/projects_view?id=eq.1&select=id,name,clients{*},tasks{id,name}" [singular] ""
-        `shouldRespondWith`
-          [str|{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"},"tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}|]
-
-
   describe "ordering response" $ do
     it "by a column asc" $
       get "/items?id=lte.2&order=id.asc"

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -322,18 +322,9 @@ spec = do
         , matchHeaders = []
         }
 
-    it "works in the presence of a range header" $
-      let headers = singular : rangeHdrs (ByteRangeFromTo 0 9) in
-      request methodGet "/items" headers ""
-        `shouldRespondWith` ResponseMatcher {
-          matchBody    = Just [json| {"id":1} |]
-        , matchStatus  = 200
-        , matchHeaders = []
-        }
-
-    it "will respond with 404 when not found" $
+    it "will respond with 406 for empty response" $
       request methodGet "/items?id=eq.9999" [singular] ""
-        `shouldRespondWith` 404
+        `shouldRespondWith` 406
 
     it "can shape plurality singular object routes" $
       request methodGet "/projects_view?id=eq.1&select=id,name,clients{*},tasks{id,name}" [singular] ""

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -510,13 +510,6 @@ spec = do
              , matchHeaders = ["Content-Range" <:> "1-2/*"]
              }
 
-
-
-      it "prefer singular" $
-        request methodPost "/rpc/getproject"
-          [("Accept", "application/vnd.pgrst.object+json")] [json| { "id": 1} |] `shouldRespondWith`
-          [json|{"id":1,"name":"Windows 7","client_id":1}|]
-
       it "select works on the first level" $
         post "/rpc/getproject?select=id,name" [json| { "id": 1} |] `shouldRespondWith`
           [json|[{"id":1,"name":"Windows 7"}]|]

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -493,6 +493,10 @@ spec = do
         post "/rpc/getitemrange" [json| { "min": 2, "max": 4 } |] `shouldRespondWith`
           [json| [ {"id": 3}, {"id":4} ] |]
 
+    context "unknown function" $
+      it "returns 404" $
+        post "/rpc/fakefunc" [json| {} |] `shouldRespondWith` 404
+
     context "shaping the response returned by a proc" $ do
       it "returns a project" $
         post "/rpc/getproject" [json| { "id": 1} |] `shouldRespondWith`
@@ -541,10 +545,6 @@ spec = do
         request methodPost "/rpc/sayhello"
           (acceptHdrs "application/json") "sdfsdf"
             `shouldRespondWith` 400
-      -- it used to be 404 and it makes sense but in another part we decided that it's good to return
-      -- PostgreSQL errors (and have the proxy handle them) and this saves us an aditional query on each rpc request
-      it "responds with 400 on an unexisting proc" $
-        post "/rpc/fake" "{}" `shouldRespondWith` 400
       it "treats simple plpgsql raise as invalid input" $
         post "/rpc/problem" "{}" `shouldRespondWith` 400
 

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -1,7 +1,11 @@
 module Feature.SingularSpec where
 
+import Text.Heredoc
 import Test.Hspec
 import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
+import Network.HTTP.Types
+import Network.Wai.Test (SResponse(..))
 
 import Network.Wai (Application)
 
@@ -11,9 +15,66 @@ import Protolude hiding (get)
 spec :: SpecWith Application
 spec = do
   describe "Requesting singular json object" $ do
-    let _singular = ("Accept"::Text, "application/vnd.pgrst.object+json"::Text)
+    let pgrstObj = "application/vnd.pgrst.object+json"
+        singular = ("Accept", pgrstObj)
 
-    context "with GET request" $
+    context "with GET request" $ do
       it "fails for zero rows" $
-        get "/items?id=gt.0&id=lt.0"
+        request methodGet  "/items?id=gt.0&id=lt.0" [singular] ""
           `shouldRespondWith` 406
+
+      it "will select an existing object" $
+        request methodGet "/items?id=eq.5" [singular] ""
+          `shouldRespondWith` [str|{"id":5}|]
+
+      it "can combine multiple prefer values" $
+        request methodGet "/items?id=eq.5" [singular, ("Prefer","count=none")] ""
+          `shouldRespondWith` [str|{"id":5}|]
+
+      it "can shape plurality singular object routes" $
+        request methodGet "/projects_view?id=eq.1&select=id,name,clients{*},tasks{id,name}" [singular] ""
+          `shouldRespondWith`
+            [str|{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"},"tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}|]
+
+    context "when updating rows" $ do
+
+      it "works for one row" $ do
+        _ <- post "/addresses" [json| { id: 97, address: "A Street" } |]
+        request methodPatch
+          "/addresses?id=eq.97"
+          [("Prefer", "return=representation"), singular]
+          [json| { address: "B Street" } |]
+          `shouldRespondWith`
+            [str|{"id":97,"address":"B Street"}|]
+
+      it "raises an error for multiple rows" $ do
+        _ <- post "/addresses" [json| { id: 98, address: "xxx" } |]
+        _ <- post "/addresses" [json| { id: 99, address: "yyy" } |]
+        p <- request methodPatch
+          "/addresses?id=gt.0"
+          [("Prefer", "return=representation"), singular]
+          [json| { address: "zzz" } |]
+        liftIO $ simpleStatus p `shouldBe` status400
+
+    context "when creating rows" $ do
+
+      it "works for one row" $ do
+        p <- request methodPost
+          "/addresses"
+          [("Prefer", "return=representation"), singular]
+          [json| [ { id: 100, address: "xxx" } ] |]
+        liftIO $ simpleBody p `shouldBe` [str|{"id":100,"address":"xxx"}|]
+
+      it "raises an error when attempting to create multiple entities with singular object accept header" $ do
+        p <- request methodPost
+          "/addresses"
+          [("Prefer", "return=representation"), singular]
+          [json| [ { id: 100, address: "xxx" }, { id: 101, address: "xxx" } ] |]
+        liftIO $ simpleStatus p `shouldBe` status406
+
+    context "when calling a stored proc" $
+
+      it "returns a single object for json proc" $
+        request methodPost "/rpc/getproject"
+          [singular] [json|{ "id": 1}|] `shouldRespondWith`
+          [str|{"client_id":1,"name":"Windows 7","id":1}|]

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -1,0 +1,19 @@
+module Feature.SingularSpec where
+
+import Test.Hspec
+import Test.Hspec.Wai
+
+import Network.Wai (Application)
+
+import Protolude hiding (get)
+
+
+spec :: SpecWith Application
+spec = do
+  describe "Requesting singular json object" $ do
+    let _singular = ("Accept"::Text, "application/vnd.pgrst.object+json"::Text)
+
+    context "with GET request" $
+      it "fails for zero rows" $
+        get "/items?id=gt.0&id=lt.0"
+          `shouldRespondWith` 406

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -13,7 +13,7 @@ import Protolude hiding (get)
 
 
 spec :: SpecWith Application
-spec = do
+spec =
   describe "Requesting singular json object" $ do
     let pgrstObj = "application/vnd.pgrst.object+json"
         singular = ("Accept", pgrstObj)

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -23,8 +23,12 @@ spec =
         request methodGet  "/items?id=gt.0&id=lt.0" [singular] ""
           `shouldRespondWith` 406
 
-      it "will select an existing object" $
+      it "will select an existing object" $ do
         request methodGet "/items?id=eq.5" [singular] ""
+          `shouldRespondWith` [str|{"id":5}|]
+        -- also test without the +json suffix
+        request methodGet "/items?id=eq.5"
+          [("Accept", "application/vnd.pgrst.object")] ""
           `shouldRespondWith` [str|{"id":5}|]
 
       it "can combine multiple prefer values" $

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -95,9 +95,15 @@ spec =
           simpleStatus p `shouldBe` notAcceptable406
           isErrorFormat (simpleBody p) `shouldBe` True
 
-    context "when calling a stored proc" $
+    context "when calling a stored proc" $ do
 
       it "returns a single object for json proc" $
         request methodPost "/rpc/getproject"
           [singular] [json|{ "id": 1}|] `shouldRespondWith`
           [str|{"client_id":1,"name":"Windows 7","id":1}|]
+
+      it "fails for multiple rows" $ do
+        p <- request methodPost "/rpc/getallprojects" [singular] "{}"
+        liftIO $ do
+          simpleStatus p `shouldBe` notAcceptable406
+          isErrorFormat (simpleBody p) `shouldBe` True

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -60,7 +60,14 @@ spec =
           [("Prefer", "return=representation"), singular]
           [json| { address: "zzz" } |]
         liftIO $ do
-          simpleStatus p `shouldBe` badRequest400
+          simpleStatus p `shouldBe` notAcceptable406
+          isErrorFormat (simpleBody p) `shouldBe` True
+
+      it "raises an error for zero rows" $ do
+        p <- request methodPatch  "/items?id=gt.0&id=lt.0"
+          [("Prefer", "return=representation"), singular] [json|{"id":1}|]
+        liftIO $ do
+          simpleStatus p `shouldBe` notAcceptable406
           isErrorFormat (simpleBody p) `shouldBe` True
 
     context "when creating rows" $ do
@@ -77,7 +84,7 @@ spec =
           "/addresses"
           [("Prefer", "return=representation"), singular]
           [json| [ { id: 100, address: "xxx" }, { id: 101, address: "xxx" } ] |]
-        liftIO $ simpleStatus p `shouldBe` status406
+        liftIO $ simpleStatus p `shouldBe` notAcceptable406
 
       it "raises an error when creating zero entities with vnd.pgrst.object" $ do
         p <- request methodPost

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -79,16 +79,14 @@ spec =
           [json| [ { id: 100, address: "xxx" }, { id: 101, address: "xxx" } ] |]
         liftIO $ simpleStatus p `shouldBe` status406
 
-      it "raises an error when creating zero entities with singular object accept header" $
-        request methodPost
+      it "raises an error when creating zero entities with vnd.pgrst.object" $ do
+        p <- request methodPost
           "/addresses"
           [("Prefer", "return=representation"), singular]
           [json| [ ] |]
-          `shouldRespondWith` ResponseMatcher {
-            matchBody    = Just [json| [] |]
-          , matchStatus  = 406
-          , matchHeaders = ["Content-Range" <:> "*/*"]
-          }
+        liftIO $ do
+          simpleStatus p `shouldBe` notAcceptable406
+          isErrorFormat (simpleBody p) `shouldBe` True
 
     context "when calling a stored proc" $
 

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -97,6 +97,20 @@ spec =
 
     context "when calling a stored proc" $ do
 
+      it "fails for zero rows" $ do
+        p <- request methodPost "/rpc/getproject"
+          [singular] [json|{ "id": 9999999}|]
+        liftIO $ do
+          simpleStatus p `shouldBe` notAcceptable406
+          isErrorFormat (simpleBody p) `shouldBe` True
+
+      -- this one may be controversial, should vnd.pgrst.object include
+      -- the likes of 2 and "hello?"
+      it "succeeds for scalar result" $
+        request methodPost "/rpc/sayhello"
+          [singular] [json|{ "name": "world"}|]
+          `shouldRespondWith` 200
+
       it "returns a single object for json proc" $
         request methodPost "/rpc/getproject"
           [singular] [json|{ "id": 1}|] `shouldRespondWith`

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -100,7 +100,7 @@ spec =
       it "returns a single object for json proc" $
         request methodPost "/rpc/getproject"
           [singular] [json|{ "id": 1}|] `shouldRespondWith`
-          [str|{"client_id":1,"name":"Windows 7","id":1}|]
+          [str|{"id":1,"name":"Windows 7","client_id":1}|]
 
       it "fails for multiple rows" $ do
         p <- request methodPost "/rpc/getallprojects" [singular] "{}"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -23,6 +23,7 @@ import qualified Feature.QueryLimitedSpec
 import qualified Feature.QuerySpec
 import qualified Feature.RangeSpec
 import qualified Feature.StructureSpec
+import qualified Feature.SingularSpec
 import qualified Feature.UnicodeSpec
 import qualified Feature.ProxySpec
 
@@ -81,5 +82,6 @@ main = do
     , ("Feature.InsertSpec"       , Feature.InsertSpec.spec)
     , ("Feature.QuerySpec"        , Feature.QuerySpec.spec)
     , ("Feature.RangeSpec"        , Feature.RangeSpec.spec)
+    , ("Feature.SingularSpec"     , Feature.SingularSpec.spec)
     , ("Feature.StructureSpec"    , Feature.StructureSpec.spec)
     ]

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -7,9 +7,12 @@ import System.Environment (getEnv)
 
 import qualified Data.ByteString.Base64 as B64 (encode, decodeLenient)
 import Data.CaseInsensitive (CI(..))
+import qualified Data.Set as S
+import qualified Data.Map.Strict as M
 import Data.List (lookup)
 import Text.Regex.TDFA ((=~))
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy as BL
 import System.Process (readProcess)
 
 import PostgREST.Config (AppConfig(..))
@@ -21,7 +24,7 @@ import Network.HTTP.Types
 import Network.Wai.Test (SResponse(simpleStatus, simpleHeaders, simpleBody))
 
 import Data.Maybe (fromJust)
-import Data.Aeson (decode)
+import Data.Aeson (decode, Value(..))
 import qualified Data.JsonSchema.Draft4 as D4
 
 import Protolude
@@ -123,3 +126,15 @@ authHeaderBasic u p =
 authHeaderJWT :: BS.ByteString -> Header
 authHeaderJWT token =
   (hAuthorization, "Bearer " <> token)
+
+-- | Can the text be parsed as a json object comtaining the keys
+-- message (required), details (optional), hint (optional) and
+-- no extraneous keys?
+isErrorFormat :: BL.ByteString -> Bool
+isErrorFormat s =
+  "message" `S.member` keys &&
+    S.null (S.difference keys validKeys)
+ where
+  obj = decode s :: Maybe (M.Map Text Value)
+  keys = fromMaybe S.empty (M.keysSet <$> obj)
+  validKeys = S.fromList ["message", "details", "hint"]

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -127,9 +127,9 @@ authHeaderJWT :: BS.ByteString -> Header
 authHeaderJWT token =
   (hAuthorization, "Bearer " <> token)
 
--- | Can the text be parsed as a json object comtaining the keys
--- message (required), details (optional), hint (optional) and
--- no extraneous keys?
+-- | Tests whether the text can be parsed as a json object comtaining
+-- the key "message", and optional keys "details", "hint", "code",
+-- and no extraneous keys
 isErrorFormat :: BL.ByteString -> Bool
 isErrorFormat s =
   "message" `S.member` keys &&
@@ -137,4 +137,4 @@ isErrorFormat s =
  where
   obj = decode s :: Maybe (M.Map Text Value)
   keys = fromMaybe S.empty (M.keysSet <$> obj)
-  validKeys = S.fromList ["message", "details", "hint"]
+  validKeys = S.fromList ["message", "details", "hint", "code"]

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1091,6 +1091,12 @@ CREATE FUNCTION getallprojects() RETURNS SETOF projects
     SELECT * FROM test.projects;
 $_$;
 
+CREATE FUNCTION setprojects(id_l int, id_h int, name text) RETURNS SETOF projects
+    LANGUAGE sql
+    AS $_$
+    update test.projects set name = $3 WHERE id >= $1 AND id <= $2 returning *;
+$_$;
+
 --
 -- PostgreSQL database dump complete
 --


### PR DESCRIPTION
Fixes #748

This PR will remove support for `Prefer: plurality=singular` and add support for a special mime type in the Accept header that is like JSON except it encodes objects only, not arrays.