### PR TITLE
Fix embeded relations error message

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -315,10 +315,6 @@ contentRangeH lower upper total =
       totalNotZero  = fromMaybe True ((/=) 0 <$> total)
       fromInRange   = lower <= upper
 
-formatRelationError :: Text -> Text
-formatRelationError = formatGeneralError
-  "could not find foreign keys between these entities"
-
 formatParserError :: ParseError -> Text
 formatParserError e = formatGeneralError message details
   where
@@ -327,14 +323,15 @@ formatParserError e = formatGeneralError message details
        $ showErrorMessages "or" "unknown parse error" "expecting" "unexpected" "end of input" (errorMessages e)
 
 formatGeneralError :: Text -> Text -> Text
-formatGeneralError message details = toS $ encode $ object [
-  "message" .= message,
-  "details" .= details]
+formatGeneralError message details = message <> ", " <> details
 
 augumentRequestWithJoin :: Schema ->  [Relation] ->  ReadRequest -> Either Text ReadRequest
 augumentRequestWithJoin schema allRels request =
   (first formatRelationError . addRelations schema allRels Nothing) request
   >>= addJoinConditions schema
+  where
+    formatRelationError = formatGeneralError
+      "could not find foreign keys between these entities"
 
 addFiltersOrdersRanges :: ApiRequest -> Either ParseError (ReadRequest -> ReadRequest)
 addFiltersOrdersRanges apiRequest = foldr1 (liftA2 (.)) [

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -7,7 +7,6 @@ module PostgREST.Error (apiRequestErrResponse, pgErrResponse, errResponse, prett
 import           Protolude
 import           Data.Aeson                ((.=))
 import qualified Data.Aeson                as JSON
-import qualified Data.Text                 as T
 import qualified Hasql.Pool                as P
 import qualified Hasql.Session             as H
 import qualified Network.HTTP.Types.Status as HT
@@ -22,9 +21,10 @@ apiRequestErrResponse err =
     ErrorInvalidRange -> errResponse HT.status416 "HTTP Range error"
 
 errResponse :: HT.Status -> Text -> Response
-errResponse status message = responseLBS status
-  [toHeader CTApplicationJSON]
-  (toS $ T.concat ["{\"message\":\"",message,"\"}"])
+errResponse status message = jsonErrResponse status $ JSON.object ["message" .= message]
+
+jsonErrResponse :: HT.Status -> JSON.Value -> Response
+jsonErrResponse status message = responseLBS status [toHeader CTApplicationJSON] $ JSON.encode message
 
 pgErrResponse :: Bool -> P.UsageError -> Response
 pgErrResponse authed e =

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -132,6 +132,14 @@ spec = do
       get "/items?order=anti_id.desc" `shouldRespondWith`
         [json| [{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}] |]
 
+    it "matches filtering nested items 2" $
+      get "/clients?select=id,projects{id,tasks2{id,name}}&projects.tasks.name=like.Design*"
+        `shouldRespondWith` ResponseMatcher {
+          matchBody    = Just [json| {"message":"could not find foreign keys between these entities, no relation between projects and tasks2"}|]
+        , matchStatus  = 400
+        , matchHeaders = []
+        }
+
     it "matches filtering nested items" $
       get "/clients?select=id,projects{id,tasks{id,name}}&projects.tasks.name=like.Design*" `shouldRespondWith`
         [str|[{"id":1,"projects":[{"id":1,"tasks":[{"id":1,"name":"Design w7"}]},{"id":2,"tasks":[{"id":3,"name":"Design w10"}]}]},{"id":2,"projects":[{"id":3,"tasks":[{"id":5,"name":"Design IOS"}]},{"id":4,"tasks":[{"id":7,"name":"Design OSX"}]}]}]|]


### PR DESCRIPTION
The `formatGeneralError` function was being used in the same context as other plain text error messages. It seems to me that we don't need that JSON formatting for those error messages.

If we would keep the message/details structure for that message we would need a more extensive code change.

I also fixed a bug with our `errResponse` that would generate messages using text concatenation which could create an invalid json body.