### PR TITLE
Binary secrets working and tested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ codex.tags
 .stack-work*
 tags
 site
+*~
+*#*
+.#*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Custom request validation with `--pre-request` argument - @begriffs
 - Ability to order by jsonb keys - @steve-chavez
 - Ability to specify offset for a deeper level - @ruslantalpa
+- Ability to use binary base64 encoded secrets - @TrevorBasinger
 
 ### Fixed
 - Do not apply limit to parent items - @ruslantalpa

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -17,7 +17,7 @@ import           Control.AutoUpdate
 import           Data.ByteString.Base64               (decode)
 import           Data.String                          (IsString (..))
 import           Data.Text                            (stripPrefix, pack)
-import           Data.Text.Encoding                   (encodeUtf8)
+import           Data.Text.Encoding                   (encodeUtf8, decodeUtf8)
 import           Data.Text.IO                         (hPutStrLn, readFile)
 import           Data.Function                        (id)
 import           Data.Time.Clock.POSIX                (getPOSIXTime)
@@ -103,7 +103,7 @@ main = do
 loadSecretFile :: AppConfig -> IO AppConfig
 loadSecretFile conf = extractAndTransform mSecret
   where
-      mSecret   = configJwtSecretOrFile   conf
+      mSecret   = decodeUtf8 <$> configJwtSecret conf
       isB64     = configJwtSecretIsBase64 conf
 
       extractAndTransform :: Maybe Text -> IO AppConfig

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -109,9 +109,10 @@ loadSecretFile conf = extractAndTransform mSecret
     extractAndTransform :: Maybe Text -> IO AppConfig
     extractAndTransform Nothing  = return conf
     extractAndTransform (Just s) =
-      case stripPrefix "@" s of
-        Nothing       -> setSecret <$> transformString isB64 s
-        Just filename -> fmap setSecret $ transformString isB64 =<< readFile (toS filename)
+      fmap setSecret $ transformString isB64 =<<
+        case stripPrefix "@" s of
+            Nothing       -> return s
+            Just filename -> readFile (toS filename)
 
     transformString :: Bool -> Text -> IO ByteString
     transformString False t = return . encodeUtf8 $ t

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -14,9 +14,11 @@ import           PostgREST.OpenAPI                    (isMalformedProxyUri)
 import           PostgREST.DbStructure
 
 import           Control.AutoUpdate
+import           Data.ByteString.Base64               (decode)
 import           Data.String                          (IsString (..))
-import           Data.Text                            (stripPrefix)
-import           Data.Text.IO                         (hPutStrLn)
+import           Data.Text                            (stripPrefix, pack)
+import           Data.Text.Encoding                   (encodeUtf8)
+import           Data.Text.IO                         (hPutStrLn, readFile)
 import           Data.Function                        (id)
 import           Data.Time.Clock.POSIX                (getPOSIXTime)
 import qualified Hasql.Query                          as H
@@ -99,9 +101,24 @@ main = do
   runSettings appSettings $ postgrest conf refDbStructure pool getTime
 
 loadSecretFile :: AppConfig -> IO AppConfig
-loadSecretFile conf = do
-  let s = configJwtSecret conf
-  real <- case join (stripPrefix "@" <$> s) of
-            Nothing -> return s -- the string is the secret, not a filename
-            Just filename -> sequence . Just $ readFile (toS filename)
-  return conf { configJwtSecret = real }
+loadSecretFile conf = extractAndTransform mSecret
+  where
+      mSecret   = configJwtSecretOrFile   conf
+      isB64     = configJwtSecretIsBase64 conf
+
+      extractAndTransform :: Maybe Text -> IO AppConfig
+      extractAndTransform Nothing  = return conf
+      extractAndTransform (Just s) =
+        case stripPrefix "@" s of
+          Nothing       -> setSecret <$> transformString isB64 s
+          Just filename -> fmap setSecret $ transformString isB64 =<< readFile (toS filename)
+
+      transformString :: Bool -> Text -> IO ByteString
+      transformString False t = return . encodeUtf8 $ t
+      transformString True  t =
+        case decode (encodeUtf8 t) of
+          Left errMsg -> panic $ pack errMsg
+          Right bs    -> return bs
+
+      setSecret bs = conf { configJwtSecret = Just bs }
+        

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -16,7 +16,7 @@ import           PostgREST.DbStructure
 import           Control.AutoUpdate
 import           Data.ByteString.Base64               (decode)
 import           Data.String                          (IsString (..))
-import           Data.Text                            (stripPrefix, pack)
+import           Data.Text                            (stripPrefix, pack, replace)
 import           Data.Text.Encoding                   (encodeUtf8, decodeUtf8)
 import           Data.Text.IO                         (hPutStrLn, readFile)
 import           Data.Function                        (id)
@@ -116,9 +116,11 @@ loadSecretFile conf = extractAndTransform mSecret
     transformString :: Bool -> Text -> IO ByteString
     transformString False t = return . encodeUtf8 $ t
     transformString True  t =
-      case decode (encodeUtf8 t) of
+      case decode (encodeUtf8 $ replaceUrlChars t) of
         Left errMsg -> panic $ pack errMsg
         Right bs    -> return bs
 
     setSecret bs = conf { configJwtSecret = Just bs }
+
+    replaceUrlChars = replace "_" "/" . replace "-" "+" . replace "." "="
         

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -103,22 +103,22 @@ main = do
 loadSecretFile :: AppConfig -> IO AppConfig
 loadSecretFile conf = extractAndTransform mSecret
   where
-      mSecret   = decodeUtf8 <$> configJwtSecret conf
-      isB64     = configJwtSecretIsBase64 conf
+    mSecret   = decodeUtf8 <$> configJwtSecret conf
+    isB64     = configJwtSecretIsBase64 conf
 
-      extractAndTransform :: Maybe Text -> IO AppConfig
-      extractAndTransform Nothing  = return conf
-      extractAndTransform (Just s) =
-        case stripPrefix "@" s of
-          Nothing       -> setSecret <$> transformString isB64 s
-          Just filename -> fmap setSecret $ transformString isB64 =<< readFile (toS filename)
+    extractAndTransform :: Maybe Text -> IO AppConfig
+    extractAndTransform Nothing  = return conf
+    extractAndTransform (Just s) =
+      case stripPrefix "@" s of
+        Nothing       -> setSecret <$> transformString isB64 s
+        Just filename -> fmap setSecret $ transformString isB64 =<< readFile (toS filename)
 
-      transformString :: Bool -> Text -> IO ByteString
-      transformString False t = return . encodeUtf8 $ t
-      transformString True  t =
-        case decode (encodeUtf8 t) of
-          Left errMsg -> panic $ pack errMsg
-          Right bs    -> return bs
+    transformString :: Bool -> Text -> IO ByteString
+    transformString False t = return . encodeUtf8 $ t
+    transformString True  t =
+      case decode (encodeUtf8 t) of
+        Left errMsg -> panic $ pack errMsg
+        Right bs    -> return bs
 
-      setSecret bs = conf { configJwtSecret = Just bs }
+    setSecret bs = conf { configJwtSecret = Just bs }
         

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -38,6 +38,8 @@ executable postgrest
                      , text
                      , time
                      , warp
+                     , bytestring
+                     , base64-bytestring
   if !os(windows)
     build-depends:     unix
 
@@ -108,6 +110,7 @@ Test-Suite spec
   Hs-Source-Dirs:      test
   Main-Is:             Main.hs
   Other-Modules:       Feature.AuthSpec
+                     , Feature.BinaryJwtSecretSpec
                      , Feature.ConcurrentSpec
                      , Feature.CorsSpec
                      , Feature.DeleteSpec
@@ -126,8 +129,7 @@ Test-Suite spec
                      , async
                      , auto-update
                      , base
-                     , base64-string
-                     , bytestring
+                     , base64-bytestring
                      , case-insensitive
                      , cassava
                      , contravariant

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -129,6 +129,7 @@ Test-Suite spec
                      , async
                      , auto-update
                      , base
+                     , bytestring
                      , base64-bytestring
                      , case-insensitive
                      , cassava

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -29,7 +29,7 @@ import           Network.HTTP.Types.Status
 import           Network.HTTP.Types.URI    (renderSimpleQuery)
 import           Network.Wai
 import           Network.Wai.Middleware.RequestLogger (logStdout)
-import           Web.JWT                   (secret)
+import           Web.JWT                   (binarySecret)
 
 import           Data.Aeson
 import           Data.Aeson.Types          (emptyArray)
@@ -83,7 +83,7 @@ postgrest conf refDbStructure pool getTime =
     response <- case userApiRequest (configSchema conf) req body of
       Left err -> return $ apiRequestErrResponse err
       Right apiRequest -> do
-        let jwtSecret = secret <$> configJwtSecret conf
+        let jwtSecret = binarySecret <$> configJwtSecret conf
             eClaims = jwtClaims jwtSecret (iJWT apiRequest) time
             authed = containsRole eClaims
             handleReq = runWithClaims conf eClaims (app dbStructure conf) apiRequest

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -30,6 +30,7 @@ import qualified Data.Configurator           as C
 import qualified Data.Configurator.Types     as C
 import           Data.List                   (lookup)
 import           Data.Text                   (strip, intercalate, lines)
+import           Data.Text.Encoding          (encodeUtf8)
 import           Data.Text.IO                (hPutStrLn)
 import           Data.Version                (versionBranch)
 import           Network.Wai
@@ -37,7 +38,7 @@ import           Network.Wai.Middleware.Cors (CorsResourcePolicy (..))
 import           Options.Applicative hiding  (str)
 import           Paths_postgrest             (version)
 import           Text.Heredoc
-import           Text.PrettyPrint.ANSI.Leijen hiding ((<>))
+import           Text.PrettyPrint.ANSI.Leijen hiding ((<>), (<$>))
 
 import           Protolude hiding            (intercalate
                                              , (<>))
@@ -50,9 +51,10 @@ data AppConfig = AppConfig {
   , configSchema            :: Text
   , configHost              :: Text
   , configPort              :: Int
-  , configJwtSecretOrFile   :: Maybe Text
+
   , configJwtSecret         :: Maybe B.ByteString
   , configJwtSecretIsBase64 :: Bool
+
   , configPool              :: Int
   , configMaxRows           :: Maybe Integer
   , configReqCheck          :: Maybe Text
@@ -114,7 +116,7 @@ readOptions = do
     cReqCheck <- C.lookup conf "pre-request"
 
     return $ AppConfig cDbUri cDbAnon cProxy cDbSchema cHost cPort
-          cJwtSec Nothing cJwtB64 cPool cMaxRows cReqCheck False
+          (encodeUtf8 <$> cJwtSec) cJwtB64 cPool cMaxRows cReqCheck False
 
  where
   opts = info (helper <*> pathParser) $

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -162,6 +162,7 @@ readOptions = do
         |## choose a secret to enable JWT auth
         |## (use "@filename" to load from separate file)
         |# jwt-secret = "foo"
+        |# secret-is-base64 = false
         |
         |## limit rows in response
         |# max-rows = 1000

--- a/test/Feature/BinaryJwtSecretSpec.hs
+++ b/test/Feature/BinaryJwtSecretSpec.hs
@@ -1,0 +1,21 @@
+module Feature.BinaryJwtSecretSpec where
+
+-- {{{ Imports
+import Test.Hspec
+import Test.Hspec.Wai
+import Network.HTTP.Types
+
+import SpecHelper
+import Network.Wai (Application)
+
+import Protolude hiding (get)
+-- }}}
+
+spec :: SpecWith Application
+spec = describe "server started with binary JWT secret" $ do
+
+  -- this test will stop working 9999999999s after the UNIX EPOCH
+  it "succeeds with jwt token encoded with a binary secret" $ do
+    let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTksInJvbGUiOiJwb3N0Z3Jlc3RfdGVzdF9hdXRob3IiLCJpZCI6Impkb2UifQ.l_EcSRWeNtL4OKUTIplrHyioNrff9Rd0MV7RXNCxCyk"
+    request methodGet "/authors_only" [auth] ""
+      `shouldRespondWith` 200

--- a/test/Feature/BinaryJwtSecretSpec.hs
+++ b/test/Feature/BinaryJwtSecretSpec.hs
@@ -12,7 +12,7 @@ import Protolude hiding (get)
 -- }}}
 
 spec :: SpecWith Application
-spec = describe "server started with binary JWT secret" $ do
+spec = describe "server started with binary JWT secret" $
 
   -- this test will stop working 9999999999s after the UNIX EPOCH
   it "succeeds with jwt token encoded with a binary secret" $ do

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -55,14 +55,14 @@ getEnvVarWithDefault var def = do
   return $ toS varValue
 
 _baseCfg :: AppConfig
-                      -- Connection Settings
-_baseCfg =  AppConfig mempty "postgrest_test_anonymous" Nothing "test" "localhost" 3000
-                      -- Jwt settings
-                      (Just $ encodeUtf8 "safe") False
-                      -- Connection Modifiers
-                      10 Nothing (Just "test.switch_role")
-                      -- Debug Settings
-                      True
+_baseCfg =  -- Connection Settings
+  AppConfig mempty "postgrest_test_anonymous" Nothing "test" "localhost" 3000
+            -- Jwt settings
+            (Just $ encodeUtf8 "safe") False
+            -- Connection Modifiers
+            10 Nothing (Just "test.switch_role")
+            -- Debug Settings
+            True
 
 testCfg :: Text -> AppConfig
 testCfg testDbConn = _baseCfg { configDatabase = testDbConn }

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -58,7 +58,7 @@ _baseCfg :: AppConfig
 _baseCfg =  AppConfig -- Connection Settings
                       mempty "postgrest_test_anonymous" Nothing "test" "localhost" 3000
                       -- Jwt settings
-                      (Just "safe") (Just $ encodeUtf8 "safe") False
+                      (Just $ encodeUtf8 "safe") False
                       -- Connection Modifiers
                       10 Nothing (Just "test.switch_role")
                       -- Debug Settings
@@ -68,7 +68,7 @@ testCfg :: Text -> AppConfig
 testCfg testDbConn = _baseCfg { configDatabase = testDbConn }
 
 testCfgNoJWT :: Text -> AppConfig
-testCfgNoJWT testDbConn = (testCfg testDbConn) { configJwtSecretOrFile = Nothing, configJwtSecret = Nothing }
+testCfgNoJWT testDbConn = (testCfg testDbConn) { configJwtSecret = Nothing }
 
 testUnicodeCfg :: Text -> AppConfig
 testUnicodeCfg testDbConn = (testCfg testDbConn) { configSchema = "تست" }
@@ -80,9 +80,8 @@ testProxyCfg :: Text -> AppConfig
 testProxyCfg testDbConn = (testCfg testDbConn) { configProxyUri = Just "https://postgrest.com/openapi.json" }
 
 testCfgBinaryJWT :: Text -> AppConfig
-testCfgBinaryJWT testDbConn = (testCfg testDbConn) { configJwtSecretOrFile = Just secret, configJwtSecret = Just secretBs }
-  where secret   = "h2CGB1FoBd51aQooCS2g+UmRgYQfTPQ6v3+9ALbaqM4="
-        secretBs = B64.decodeLenient "h2CGB1FoBd51aQooCS2g+UmRgYQfTPQ6v3+9ALbaqM4="
+testCfgBinaryJWT testDbConn = (testCfg testDbConn) { configJwtSecret = Just secretBs }
+  where secretBs = B64.decodeLenient "h2CGB1FoBd51aQooCS2g+UmRgYQfTPQ6v3+9ALbaqM4="
 
 
 resetDb :: Text -> IO ()

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -55,8 +55,8 @@ getEnvVarWithDefault var def = do
   return $ toS varValue
 
 _baseCfg :: AppConfig
-_baseCfg =  AppConfig -- Connection Settings
-                      mempty "postgrest_test_anonymous" Nothing "test" "localhost" 3000
+                      -- Connection Settings
+_baseCfg =  AppConfig mempty "postgrest_test_anonymous" Nothing "test" "localhost" 3000
                       -- Jwt settings
                       (Just $ encodeUtf8 "safe") False
                       -- Connection Modifiers


### PR DESCRIPTION
Backstory: Auth0 generates binary secrets and gives the user a base64URL encoded value to use. I was decoding that payload into a file and then trying to run postgrest with `jwt-secret = "@path/to/key"`. When postgrest would read that key file, it would read the contents as a string `[Char]`, convert to `Text`, and attempt to decode the jwt using this bastardized secret.

My solution was to have postgrest optionally accept base64 encoded secrets. All secrets are then converted to a `ByteString` and then decoded with the `binarySecret` function included in the jwt library.

The one "gotcha" is that if a service like Auth0 gives you a base64URL encoded value, you would need to convert* that into a base64 value when you insert that into your configuration file or `@secretfile`.

Auth0 is working great now for me.

I'd also be happy to write the supporting docs for Auth0. It requires you to write a rule to add the role into the scope of the token.

#660 and #495 also elaborate on parts of this.

* Replace `-` with `+` and `_` with `/` as referenced [here](https://en.wikipedia.org/wiki/Base64#URL_applications)