### PR TITLE
Fix alias in select for mutate queries and small refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fatal error on postgres unsupported version, format supported version in error message - @steve-chavez
 - Prevent database memory cosumption by prepared statements caches - @ruslantalpa
 - Use specific columns in the RETURNING section - @ruslantalpa
+- Fix columns alias for RETURNING - @steve-chavez
 
 ### Changed
 - Replace `Prefer: plurality=singular` with `Accept: application/vnd.pgrst.object` - @begriffs

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -421,8 +421,8 @@ mutateRequest apiRequest readReq = mapLeft (errResponse status400) $
         _ -> undefined
     fieldNames :: ReadRequest -> PreferRepresentation -> [FieldName]
     fieldNames _ None = []
-    fieldNames (Node (Select colSelects _ _ _ _, (_, _, _)) forest) _ =
-      map (fst . view _1) colSelects ++ map colName fks
+    fieldNames (Node (sel, _) forest) _ =
+      map (fst . view _1) (select sel) ++ map colName fks
       where
         fks = concatMap (fromMaybe [] . f) forest
         f (Node (_, (_, Just Relation{relFColumns=cols, relType=Parent}, _)) _) = Just cols

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -21,7 +21,6 @@ import qualified Hasql.Transaction          as HT
 import qualified Hasql.Transaction.Sessions as HT
 
 import           Text.Parsec.Error
-import           Text.ParserCombinators.Parsec (parse)
 
 import           Network.HTTP.Types.Header
 import           Network.HTTP.Types.Status
@@ -388,7 +387,7 @@ readRequest maxRows allRels allProcs apiRequest  =
 
     parseReadRequest :: Either ParseError ReadRequest
     parseReadRequest = addFiltersOrdersRanges apiRequest <*>
-      parse (pRequestSelect rootName) ("failed to parse select parameter <<" <> toS selStr <> ">>") (toS selStr)
+      pRequestSelect rootName selStr
       where
         selStr = iSelect apiRequest
         rootName = if action == ActionRead

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -125,9 +125,9 @@ type NodeName = Text
 type SelectItem = (Field, Maybe Cast, Maybe Alias)
 type Path = [Text]
 data ReadQuery = Select { select::[SelectItem], from::[TableName], flt_::[Filter], order::Maybe [OrderTerm], range_::NonnegRange } deriving (Show, Eq)
-data MutateQuery = Insert { in_::TableName, qPayload::PayloadJSON }
-                 | Delete { in_::TableName, where_::[Filter] }
-                 | Update { in_::TableName, qPayload::PayloadJSON, where_::[Filter] } deriving (Show, Eq)
+data MutateQuery = Insert { in_::TableName, qPayload::PayloadJSON, returning::[FieldName] }
+                 | Delete { in_::TableName, where_::[Filter], returning::[FieldName] }
+                 | Update { in_::TableName, qPayload::PayloadJSON, where_::[Filter], returning::[FieldName] } deriving (Show, Eq)
 data Filter = Filter {field::Field, operator::Operator, value::FValue} deriving (Show, Eq)
 type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias))
 type ReadRequest = Tree ReadNode

--- a/test/Feature/DeleteSpec.hs
+++ b/test/Feature/DeleteSpec.hs
@@ -35,6 +35,9 @@ spec =
           , matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "*/*"]
           }
+      it "can rename and cast the selected columns" $
+        request methodDelete "/complex_items?id=eq.3&select=ciId:id::text,ciName:name" [("Prefer", "return=representation")] ""
+          `shouldRespondWith` [str|[{"ciId":"3","ciName":"Three"}]|]
       it "can embed (parent) entities" $
         request methodDelete "/tasks?id=eq.8&select=id,name,project{id}" [("Prefer", "return=representation")] ""
           `shouldRespondWith` ResponseMatcher {

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -289,7 +289,7 @@ spec = do
                             "Location" <:> "/no_pk?a=is.null&b=eq.foo"]
           }
 
-      it "only returns the requested column header with his associated data" $
+      it "only returns the requested column header with its associated data" $
         request methodPost "/projects?select=id"
                      [("Content-Type", "text/csv"), ("Accept", "text/csv"), ("Prefer", "return=representation")]
                      "id,name,client_id\n8,Xenix,1\n9,Windows NT,1"

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -289,6 +289,17 @@ spec = do
                             "Location" <:> "/no_pk?a=is.null&b=eq.foo"]
           }
 
+      it "only returns the requested column header with his associated data" $
+        request methodPost "/projects?select=id"
+                     [("Content-Type", "text/csv"), ("Accept", "text/csv"), ("Prefer", "return=representation")]
+                     "id,name,client_id\n8,Xenix,1\n9,Windows NT,1"
+          `shouldRespondWith` ResponseMatcher {
+            matchBody    = Just "id\n8\n9"
+          , matchStatus  = 201
+          , matchHeaders = ["Content-Type" <:> "text/csv; charset=utf-8",
+                            "Content-Range" <:> "*/*"]
+          }
+
     context "with wrong number of columns" $
       it "fails for too few" $ do
         p <- request methodPost "/no_pk" [("Content-Type", "text/csv")] "a,b\nfoo,bar\nbaz"

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -49,6 +49,7 @@ spec = do
           , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8"]
           }
 
+    context "requesting full representation" $ do
       it "includes related data after insert" $
         request methodPost "/projects?select=id,name,clients{id,name}"
                 [("Prefer", "return=representation"), ("Prefer", "count=exact")]
@@ -58,6 +59,17 @@ spec = do
           , matchHeaders = [ "Content-Type" <:> "application/json; charset=utf-8"
                            , "Location" <:> "/projects?id=eq.6"
                            , "Content-Range" <:> "*/1" ]
+          }
+
+      it "can rename and cast the selected columns" $
+        request methodPost "/projects?select=pId:id::text,pName:name,cId:client_id::text"
+                [("Prefer", "return=representation")] 
+          [str|{"id":7,"name":"New Project","client_id":2}|] `shouldRespondWith` ResponseMatcher {
+            matchBody    = Just [str|[{"pId":"7","pName":"New Project","cId":"2"}]|]
+          , matchStatus  = 201
+          , matchHeaders = [ "Content-Type" <:> "application/json; charset=utf-8"
+                           , "Location" <:> "/projects?id=eq.7"
+                           , "Content-Range" <:> "*/*" ]
           }
 
     context "from an html form" $


### PR DESCRIPTION
Currently when doing this request:

```
POST /projects?select=pId:id,name,client_id
Prefer: return=representation
{"id":7,"name":"New Project","client_id":2}
```

This response is obtained:

```json
{"hint":null,"details":null,"code":"42703","message":"column pg_source.id does not exist"}
```

The error comes from the ```returningF``` function that allows the RETURNING to use alias and the subsequent SELECT made to shape the response doesn't consider the renamed columns.

This PR fixes that and also I refactored because I think that the RETURNING section fits better in the ```MutateQuery``` type since it's a part of the sql syntax for each of the sql mutate statements.
