### PR TITLE
Increase lower and upper bound for optparse-applicative

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -70,7 +70,7 @@ library
                      , lens
                      , lens-aeson
                      , network-uri
-                     , optparse-applicative >= 0.12.0.0 && < 0.13.0.0
+                     , optparse-applicative >= 0.13 && < 0.14
                      , parsec
                      , protolude
                      , Ranged-sets == 0.3.0

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -29,6 +29,7 @@ import qualified Data.CaseInsensitive        as CI
 import qualified Data.Configurator           as C
 import qualified Data.Configurator.Types     as C
 import           Data.List                   (lookup)
+import           Data.Monoid
 import           Data.Text                   (strip, intercalate, lines)
 import           Data.Text.Encoding          (encodeUtf8)
 import           Data.Text.IO                (hPutStrLn)

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ extra-deps:
   - Ranged-sets-0.3.0
   - hasql-pool-0.4.1
   - hasql-transaction-0.5
+  - optparse-applicative-0.13.0.0
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities -fno-warn-redundant-constraints
 nix:


### PR DESCRIPTION
Fix #778

- Compilation OK both with stack and nix (tested with ghc-8 only)

- Adding `import Data.Monoid` should be useless whenever Protolude releases a new version (https://github.com/sdiehl/protolude/commit/0fb7730b0c540c1be28cc18601a39cea50677eb7)

- I didn't update to a more recent LTS-7 version (to minimize PR changes)