### PR TITLE
built with nix, worked on my box

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,14 +6,16 @@ dependencies:
     - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar zx -C /tmp
     - sudo mv /tmp/stack-1.1.2-linux-x86_64/stack /usr/bin
     - sudo apt-get update; sudo apt-get install --only-upgrade binutils
-    - curl https://nixos.org/nix/install | sh && . /home/ubuntu/.nix-profile/etc/profile.d/nix.sh
-
+    - curl https://nixos.org/nix/install | sh 
   override:
     - stack setup
     - rm -fr $(stack path --dist-dir) $(stack path --local-install-root)
     - stack install hlint packdeps cabal-install
     - stack build --fast
     - stack build --fast --test --no-run-tests
+  post:
+    . /home/ubuntu/.nix-profile/etc/profile.d/nix.sh
+
 compile:
   post:
     - nix-build

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
     - stack install hlint packdeps cabal-install
     - stack build --fast
     - stack build --fast --test --no-run-tests
-    - nix-build
+    # - nix-build
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,8 @@ dependencies:
     - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar zx -C /tmp
     - sudo mv /tmp/stack-1.1.2-linux-x86_64/stack /usr/bin
     - sudo apt-get update; sudo apt-get install --only-upgrade binutils
-    - curl https://nixos.org/nix/install | sh
+    - curl https://nixos.org/nix/install | sh && . /home/ubuntu/.nix-profile/etc/profile.d/nix.sh
+
   override:
     - stack setup
     - rm -fr $(stack path --dist-dir) $(stack path --local-install-root)

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,9 @@ dependencies:
     - stack install hlint packdeps cabal-install
     - stack build --fast
     - stack build --fast --test --no-run-tests
-    # - nix-build
+compile:
+  post:
+    - nix-build
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,6 @@ dependencies:
   cache_directories:
     - "~/.stack"
     - ".stack-work"
-    - "/nix/store"
   pre:
     - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar zx -C /tmp
     - sudo mv /tmp/stack-1.1.2-linux-x86_64/stack /usr/bin

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,6 @@ test:
     - stack exec --no-ghc-package-path -- cabal install --only-d --dry-run
     - stack exec -- packdeps *.cabal || true
     - stack exec -- cabal check
+    - stack exec result/bin/postgrest
     - stack haddock --no-haddock-deps
     - stack sdist
-    - stack exec result/bin/postgrest

--- a/circle.yml
+++ b/circle.yml
@@ -14,11 +14,11 @@ dependencies:
     - stack build --fast
     - stack build --fast --test --no-run-tests
   post:
-    . /home/ubuntu/.nix-profile/etc/profile.d/nix.sh
+    - . /home/ubuntu/.nix-profile/etc/profile.d/nix.sh
 
 compile:
   post:
-    - nix-build
+    - nix-build --no-check-certificate
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -2,16 +2,19 @@ dependencies:
   cache_directories:
     - "~/.stack"
     - ".stack-work"
+    - "/nix/store"
   pre:
     - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar zx -C /tmp
     - sudo mv /tmp/stack-1.1.2-linux-x86_64/stack /usr/bin
     - sudo apt-get update; sudo apt-get install --only-upgrade binutils
+    - curl https://nixos.org/nix/install | sh
   override:
     - stack setup
     - rm -fr $(stack path --dist-dir) $(stack path --local-install-root)
     - stack install hlint packdeps cabal-install
     - stack build --fast
     - stack build --fast --test --no-run-tests
+    - nix-build
 
 test:
   override:
@@ -23,3 +26,4 @@ test:
     - stack exec -- cabal check
     - stack haddock --no-haddock-deps
     - stack sdist
+    - stack exec result/bin/postgrest

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,56 @@
+let
+  # inherit (nixpkgs) pkgs;
+  channel = "nixos-16.09";
+  sysPkgs = import <nixpkgs> {};
+
+  # Use `runCommand` to grab the SHA of the latest build of the channel. This
+  # ensures that the `nixpkgs` set we end up with has already passed through
+  # Hydra and therefore has passed its tests and has a binary cache available.
+  latestRevision = import (sysPkgs.runCommand "latestRevision"
+    { buildInputs = [ sysPkgs.wget ];
+      # Force the input to be different each time or else Nix won't check for
+      # updates to the channel next time we evaluate this expression
+      dummy = builtins.currentTime;
+    }
+    ''
+      SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+      # nixos.org/channels/$channel always points to the latest released
+      # revision of the channel, which contains a file with its git SHA. Once we
+      # have it, we have to wrap it in quotes so it will become a string when we
+      # `import` $out
+      wget -O - https://nixos.org/channels/${channel}/git-revision |\
+        sed 's#\(.*\)#"\1"#' > $out
+    '');
+  # Now that we have the SHA we can just use Github to get the tarball and thus
+  # the `nixpkgs` expressions
+    # unstablePkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs-channels/archive/nixpkgs-unstable.tar.gz") {};
+# https://github.com/NixOS/nixpkgs.git/commit/e362a3d5c94ba379d428fbd2cc40470719a61556
+# pkgs/top-level/release.nix
+# haskellPackages.swagger2.x86_64-linux
+# src = nixpkgs.fetchgit {
+#               url = git://github.com/ghcjs/ghcjs-jquery;
+#               rev = "c5eeeafcf81c0d3237b8b9fcb98c4b3633a1297f";
+#               sha256 = "3b2de54224963ee17857a9737b65d49edc423e06ad7e9c9b85d9f69ca923676a";
+#             };
+
+  config = {
+      packageOverrides = pkgs: rec {
+        # ghc = pkgs.haskell.packages.ghc7103;
+        haskellPackages = pkgs.haskellPackages.override {
+          overrides = haskellPackagesNew: haskllPackagesOld: rec {
+            swagger2 = haskellPackagesNew.callPackage ./nixExternalLibs/swagger2.nix { };
+
+            hasql-transaction =
+              haskellPackagesNew.callPackage ./nixExternalLibs/hasql-transaction.nix { };
+          };
+        };
+      };
+      allowUnfree = true;
+    };
+    pkgs = import (fetchTarball
+      "https://github.com/NixOS/nixpkgs-channels/archive/${latestRevision}.tar.gz"
+    ) { inherit config; };
+
+    # pkgs = import <nixpkgs> { inherit config; };
+in
+  { postgrest = pkgs.haskellPackages.callPackage ./postgrest.nix { }; }

--- a/default.nix
+++ b/default.nix
@@ -21,21 +21,8 @@ let
       wget -O - https://nixos.org/channels/${channel}/git-revision |\
         sed 's#\(.*\)#"\1"#' > $out
     '');
-  # Now that we have the SHA we can just use Github to get the tarball and thus
-  # the `nixpkgs` expressions
-    # unstablePkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs-channels/archive/nixpkgs-unstable.tar.gz") {};
-# https://github.com/NixOS/nixpkgs.git/commit/e362a3d5c94ba379d428fbd2cc40470719a61556
-# pkgs/top-level/release.nix
-# haskellPackages.swagger2.x86_64-linux
-# src = nixpkgs.fetchgit {
-#               url = git://github.com/ghcjs/ghcjs-jquery;
-#               rev = "c5eeeafcf81c0d3237b8b9fcb98c4b3633a1297f";
-#               sha256 = "3b2de54224963ee17857a9737b65d49edc423e06ad7e9c9b85d9f69ca923676a";
-#             };
-
   config = {
       packageOverrides = pkgs: rec {
-        # ghc = pkgs.haskell.packages.ghc7103;
         haskellPackages = pkgs.haskellPackages.override {
           overrides = haskellPackagesNew: haskllPackagesOld: rec {
             swagger2 = haskellPackagesNew.callPackage ./nixExternalLibs/swagger2.nix { };
@@ -51,6 +38,5 @@ let
       "https://github.com/NixOS/nixpkgs-channels/archive/${latestRevision}.tar.gz"
     ) { inherit config; };
 
-    # pkgs = import <nixpkgs> { inherit config; };
 in
   { postgrest = pkgs.haskellPackages.callPackage ./postgrest.nix { }; }

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,4 @@
 let
-  # inherit (nixpkgs) pkgs;
   channel = "nixos-16.09";
   sysPkgs = import <nixpkgs> {};
 
@@ -25,10 +24,10 @@ let
       packageOverrides = pkgs: rec {
         haskellPackages = pkgs.haskellPackages.override {
           overrides = haskellPackagesNew: haskllPackagesOld: rec {
-            swagger2 = haskellPackagesNew.callPackage ./nixExternalLibs/swagger2.nix { };
-
             hasql-transaction =
               haskellPackagesNew.callPackage ./nixExternalLibs/hasql-transaction.nix { };
+            swagger2 = haskellPackagesNew.callPackage ./nixExternalLibs/swagger2.nix { };
+
           };
         };
       };

--- a/nixExternalLibs/hasql-transaction.nix
+++ b/nixExternalLibs/hasql-transaction.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, async, base, base-prelude, bytestring
+, bytestring-tree-builder, contravariant, contravariant-extras
+, hasql, mtl, rebase, stdenv, transformers
+}:
+mkDerivation {
+  pname = "hasql-transaction";
+  version = "0.5";
+  sha256 = "0hdkw0rrma0cys1gd4phw9ajrimgbaabmsyp533fm6x5fznk7m0w";
+  libraryHaskellDepends = [
+    base base-prelude bytestring bytestring-tree-builder contravariant
+    contravariant-extras hasql mtl transformers
+  ];
+  testHaskellDepends = [ async hasql rebase ];
+  doCheck = false;
+  homepage = "https://github.com/nikita-volkov/hasql-transaction";
+  description = "A composable abstraction over the retryable transactions for Hasql";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nixExternalLibs/swagger2.nix
+++ b/nixExternalLibs/swagger2.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, aeson, aeson-qq, base, base-compat, bytestring
+, containers, doctest, generics-sop, Glob, hashable, hspec
+, http-media, HUnit, insert-ordered-containers, lens, mtl, network
+, QuickCheck, scientific, stdenv, template-haskell, text, time
+, transformers, unordered-containers, uuid-types, vector
+}:
+mkDerivation {
+  pname = "swagger2";
+  version = "2.1.3";
+  sha256 = "1vs4qsygw2mfmcdn8jjk5y0ms8nglqnhiwr1nvb4iz1qnl5g652d";
+  libraryHaskellDepends = [
+    aeson base base-compat bytestring containers generics-sop hashable
+    http-media insert-ordered-containers lens mtl network scientific
+    template-haskell text time transformers unordered-containers
+    uuid-types vector
+  ];
+  testHaskellDepends = [
+    aeson aeson-qq base base-compat bytestring containers doctest Glob
+    hashable hspec HUnit insert-ordered-containers lens mtl QuickCheck
+    text time unordered-containers vector
+  ];
+  doCheck = false;
+  hyperlinkSource = false;
+  homepage = "https://github.com/GetShopTV/swagger2";
+  description = "Swagger 2.0 data model";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/postgrest.nix
+++ b/postgrest.nix
@@ -1,0 +1,43 @@
+{ mkDerivation, aeson, aeson-qq, ansi-wl-pprint, async, auto-update
+, base, base64-bytestring, bytestring, case-insensitive, cassava
+, configurator, containers, contravariant, either, hasql
+, hasql-pool, hasql-transaction, heredoc, hjsonpointer, hjsonschema
+, hspec, hspec-wai, hspec-wai-json, HTTP, http-types
+, insert-ordered-containers, interpolatedstring-perl6, jwt, lens
+, lens-aeson, monad-control, network-uri, optparse-applicative
+, parsec, process, protolude, Ranged-sets, regex-tdfa, safe
+, scientific, stdenv, swagger2, text, time, transformers-base, unix
+, unordered-containers, vector, wai, wai-cors, wai-extra
+, wai-middleware-static, warp
+}:
+mkDerivation {
+  pname = "postgrest";
+  version = "0.4.0.0";
+  sha256 = "16s8ncmvr2hsy5sp7y2pj1rbxnds4cxi2875bn6nv8ksni60f73q";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson ansi-wl-pprint base bytestring case-insensitive cassava
+    configurator containers contravariant either hasql hasql-pool
+    hasql-transaction heredoc HTTP http-types insert-ordered-containers
+    interpolatedstring-perl6 jwt lens lens-aeson network-uri
+    optparse-applicative parsec protolude Ranged-sets regex-tdfa safe
+    scientific swagger2 text time unordered-containers vector wai
+    wai-cors wai-extra wai-middleware-static
+  ];
+  executableHaskellDepends = [
+    auto-update base base64-bytestring bytestring hasql hasql-pool
+    protolude text time unix warp
+  ];
+  testHaskellDepends = [
+    aeson aeson-qq async auto-update base base64-bytestring bytestring
+    case-insensitive cassava containers contravariant hasql hasql-pool
+    heredoc hjsonpointer hjsonschema hspec hspec-wai hspec-wai-json
+    http-types lens lens-aeson monad-control process protolude
+    regex-tdfa time transformers-base wai wai-extra
+  ];
+  doCheck = false;
+  homepage = "https://github.com/begriffs/postgrest";
+  description = "REST API for any Postgres database";
+  license = stdenv.lib.licenses.mit;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./default.nix).postgrest.env


### PR DESCRIPTION
to build,
$ nix-build
symlink to executable will be ./result/bin/postgrest

to drop into shell with postgrest dependencies,
$  nix-shell
from nix-shell, should be able to build with,
$ cabal configure
$ cabal build
should also be able to import postgrest dependencies in ghci from nix-shell.

also swagger2.nix and hasql.nix generated e.g.
cabal2nix cabal://swagger2-2.1.3 > ./nixExternalLibs/swagger2.nix  
in the future this might be improved by moving this into default.nix with callHackage or another superior helper method see discussion here:
https://github.com/Gabriel439/haskell-nix/issues/6

also just noticed I included some crufty commented out code, sorry :P. 