### PR TITLE
Dockerfile that works with postgrest 0.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,6 @@ RUN wget http://github.com/begriffs/postgrest/releases/download/v${POSTGREST_VER
 
 # PostgREST reads /etc/postgrest.conf so map the configuration
 # file in when you run this container
-CMD exec postgrest
+CMD exec postgrest /etc/postgrest.conf
 
 EXPOSE 3000

--- a/docker/config.conf
+++ b/docker/config.conf
@@ -1,0 +1,3 @@
+db-uri = "postgres://app_user:password@postgres:5432/app_db"
+db-schema = "public"
+db-anon-role = "app_user"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+stgrest:
+  image: begriffs/postgrest:latest
+  ports:
+    - "3000:3000"
+  volumes:
+    - ./config.conf:/etc/postgrest.conf
+  links:
+    - postgres:postgres
+
+postgres:
+  image: postgres
+  ports:
+    - "5432:5432"
+  environment:
+    POSTGRES_DB: app_db
+    POSTGRES_USER: app_user
+    POSTGRES_PASSWORD: password


### PR DESCRIPTION
Updated the Dockerfile command to point postgrest at a config file. Verified that docker compose could spin it up locally when using a local image I built from the Dockerfile. After merging this I can generate a new "latest" on dockerhub.

This supports the direction I talked about in #808