### PR TITLE
Refactor error type and fix nested error message [fix #791]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- #791, malformed nested JSON error - @diogob
 - Resource embedding in views referencing tables in public schema - @fab1an
 
 ## [0.4.0.0] - 2017-01-19

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -9,7 +9,7 @@ import           PostgREST.Config                     (AppConfig (..),
                                                        minimumPgVersion,
                                                        prettyVersion,
                                                        readOptions)
-import           PostgREST.Error                      (prettyUsageError)
+import           PostgREST.Error                      (encodeError)
 import           PostgREST.OpenAPI                    (isMalformedProxyUri)
 import           PostgREST.DbStructure
 
@@ -74,7 +74,7 @@ main = do
     getDbStructure (toS $ configSchema conf)
 
   forM_ (lefts [result]) $ \e -> do
-    hPutStrLn stderr (prettyUsageError e)
+    hPutStrLn stderr (toS $ encodeError e)
     exitFailure
 
   refDbStructure <- newIORef $ either (panic . show) id result
@@ -124,4 +124,3 @@ loadSecretFile conf = extractAndTransform mSecret
     setSecret bs = conf { configJwtSecret = Just bs }
 
     replaceUrlChars = replace "_" "/" . replace "-" "+" . replace "." "="
-        

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -62,9 +62,9 @@ data ContentType = CTApplicationJSON | CTTextCSV | CTOpenAPI
                  | CTSingularJSON | CTOctetStream
                  | CTAny | CTOther BS.ByteString deriving Eq
 
-data ApiRequestError = ErrorActionInappropriate
-                     | ErrorInvalidBody ByteString
-                     | ErrorInvalidRange
+data ApiRequestError = ActionInappropriate
+                     | InvalidBody ByteString
+                     | InvalidRange
                      deriving (Show, Eq)
 
 -- | Convert from ContentType to a full HTTP Header
@@ -120,9 +120,9 @@ data ApiRequest = ApiRequest {
 -- | Examines HTTP request and translates it into user intent.
 userApiRequest :: Schema -> Request -> RequestBody -> Either ApiRequestError ApiRequest
 userApiRequest schema req reqBody
-  | isTargetingProc && method /= "POST" = Left ErrorActionInappropriate
-  | topLevelRange == emptyRange = Left ErrorInvalidRange
-  | shouldParsePayload && isLeft payload = either (Left . ErrorInvalidBody . toS) undefined payload
+  | isTargetingProc && method /= "POST" = Left ActionInappropriate
+  | topLevelRange == emptyRange = Left InvalidRange
+  | shouldParsePayload && isLeft payload = either (Left . InvalidBody . toS) undefined payload
   | otherwise = Right ApiRequest {
       iAction = action
       , iTarget = target

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -42,7 +42,7 @@ import           PostgREST.DbRequestBuilder( readRequest
                                            , mutateRequest
                                            , fieldNames
                                            )
-import           PostgREST.Error           ( errResponse, pgErrResponse
+import           PostgREST.Error           ( simpleErrorResponse, pgErrResponse
                                            , apiRequestErrResponse
                                            , singularityError, binaryFieldError
                                            )
@@ -291,7 +291,7 @@ responseContentTypeOrError accepts action = serves contentTypesForRequest accept
       case mutuallyAgreeable sProduces cAccepts of
         Nothing -> do
           let failed = intercalate ", " $ map (toS . toMime) cAccepts
-          Left $ errResponse status415 $
+          Left $ simpleErrorResponse status415 $
             "None of these Content-Types are available: " <> failed
         Just ct -> Right ct
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -33,9 +33,7 @@ import           PostgREST.ApiRequest   ( ApiRequest(..), ContentType(..)
                                         , Action(..), Target(..)
                                         , PreferRepresentation (..)
                                         , mutuallyAgreeable
-                                        , toHeader
                                         , userApiRequest
-                                        , toMime
                                         )
 import           PostgREST.Auth            (jwtClaims, containsRole)
 import           PostgREST.Config          (AppConfig (..))
@@ -104,7 +102,7 @@ app dbStructure conf apiRequest =
           case partsField of
             Left errorResponse -> return errorResponse
             Right ((q, cq), bField) -> do
-              let stm = createReadStatement q cq (contentType == CTSingularJSON) shouldCount 
+              let stm = createReadStatement q cq (contentType == CTSingularJSON) shouldCount
                                             (contentType == CTTextCSV) bField
               row <- H.query () stm
               let (tableTotal, queryTotal, _ , body) = row
@@ -298,7 +296,7 @@ responseContentTypeOrError accepts action = serves contentTypesForRequest accept
         Just ct -> Right ct
 
 binaryField :: ContentType -> [FieldName] -> Either Response (Maybe FieldName)
-binaryField CTOctetStream fldNames = 
+binaryField CTOctetStream fldNames =
   if length fldNames == 1 && fieldName /= Just "*"
     then Right fieldName
     else Left binaryFieldError

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -25,7 +25,7 @@ import           PostgREST.ApiRequest   ( ApiRequest(..)
                                         , Action(..), Target(..)
                                         , PreferRepresentation (..)
                                         )
-import           PostgREST.Error           (apiRequestErrResponse)
+import           PostgREST.Error           (apiRequestError)
 import           PostgREST.Parsers
 import           PostgREST.RangeQuery      (NonnegRange, restrictRange)
 import           PostgREST.QueryBuilder (getJoinConditions, sourceCTEName)
@@ -37,7 +37,7 @@ import           Unsafe                  (unsafeHead)
 
 readRequest :: Maybe Integer -> [Relation] -> [(Text, Text)] -> ApiRequest -> Either Response ReadRequest
 readRequest maxRows allRels allProcs apiRequest  =
-  mapLeft apiRequestErrResponse $
+  mapLeft apiRequestError $
   treeRestrictRange maxRows =<<
   augumentRequestWithJoin schema relations =<<
   parseReadRequest
@@ -245,7 +245,7 @@ toSourceRelation mt r@(Relation t _ ft _ _ rt _ _)
   | otherwise = Nothing
 
 mutateRequest :: ApiRequest -> [FieldName] -> Either Response MutateRequest
-mutateRequest apiRequest fldNames = mapLeft apiRequestErrResponse $
+mutateRequest apiRequest fldNames = mapLeft apiRequestError $
   case action of
     ActionCreate -> Right $ Insert rootTableName payload returnings
     ActionUpdate -> Update rootTableName <$> pure payload <*> filters <*> pure returnings

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -28,6 +28,8 @@ apiRequestErrResponse err = errorResponse status err
       case err of
         ActionInappropriate -> HT.status405
         InvalidBody _ -> HT.status400
+        ParseRequestError _ _ -> HT.status400
+        NoRelationBetween _ _ -> HT.status400
         InvalidRange -> HT.status416
         _ -> HT.status500
 
@@ -82,6 +84,12 @@ instance JSON.ToJSON ApiRequestError where
     "message" .= (toS errorMessage :: Text)]
   toJSON InvalidRange = JSON.object [
     "message" .= ("HTTP Range error" :: Text)]
+  toJSON UnknownRelation = JSON.object [
+    "message" .= ("Unknown relation" :: Text)]
+  toJSON (NoRelationBetween parent child) = JSON.object [
+    "message" .= ("Could not find foreign keys between these entities, No relation found between " <> parent <> " and " <> child :: Text)]
+  toJSON UnsupportedVerb = JSON.object [
+    "message" .= ("Unsupported HTTP verb" :: Text)]
 
 instance JSON.ToJSON P.UsageError where
   toJSON (P.ConnectionError e) = JSON.object [

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -27,11 +27,12 @@ apiRequestError err = errorResponse status err
     status =
       case err of
         ActionInappropriate -> HT.status405
+        UnsupportedVerb -> HT.status405
         InvalidBody _ -> HT.status400
         ParseRequestError _ _ -> HT.status400
         NoRelationBetween _ _ -> HT.status400
         InvalidRange -> HT.status416
-        _ -> HT.status500
+        UnknownRelation -> HT.status404
 
 simpleError :: HT.Status -> Text -> Response
 simpleError status message =

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -21,7 +21,7 @@ import qualified Hasql.Pool                as P
 import qualified Hasql.Session             as H
 import qualified Network.HTTP.Types.Status as HT
 import           Network.Wai               (Response, responseLBS)
-import           PostgREST.ApiRequest      (toHeader, toMime, ContentType(..), ApiRequestError(..))
+import           PostgREST.Types
 import           Text.Parsec.Error
 
 apiRequestErrResponse :: ApiRequestError -> Response
@@ -64,7 +64,7 @@ singularityError numRows =
         ]
 
 binaryFieldError :: Response
-binaryFieldError = 
+binaryFieldError =
   errResponse HT.status406 (toS (toMime CTOctetStream) <>
   " requested but a single column was not selected")
 

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -27,9 +27,9 @@ import           Text.Parsec.Error
 apiRequestErrResponse :: ApiRequestError -> Response
 apiRequestErrResponse err =
   case err of
-    ErrorActionInappropriate -> errResponse HT.status405 "Bad Request"
-    ErrorInvalidBody errorMessage -> errResponse HT.status400 $ toS errorMessage
-    ErrorInvalidRange -> errResponse HT.status416 "HTTP Range error"
+    ActionInappropriate -> errResponse HT.status405 "Bad Request"
+    InvalidBody errorMessage -> errResponse HT.status400 $ toS errorMessage
+    InvalidRange -> errResponse HT.status416 "HTTP Range error"
 
 errResponse :: HT.Status -> Text -> Response
 errResponse status message = jsonErrResponse status $ JSON.object ["message" .= message]

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -17,7 +17,7 @@ import           Network.Wai.Middleware.Static (only, staticPolicy)
 import           PostgREST.ApiRequest          (ApiRequest(..))
 import           PostgREST.Auth                (claimsToSQL, JWTAttempt(..))
 import           PostgREST.Config              (AppConfig (..), corsPolicy)
-import           PostgREST.Error               (simpleErrorResponse)
+import           PostgREST.Error               (simpleError)
 import           PostgREST.Types               (ContentType (..), toHeader)
 
 import           Protolude                     hiding (concat, null)
@@ -29,7 +29,7 @@ runWithClaims conf eClaims app req =
   case eClaims of
     JWTExpired -> return $ unauthed "JWT expired"
     JWTInvalid -> return $ unauthed "JWT invalid"
-    JWTMissingSecret -> return $ simpleErrorResponse status500 "Server lacks JWT secret"
+    JWTMissingSecret -> return $ simpleError status500 "Server lacks JWT secret"
     JWTClaims claims -> do
       -- role claim defaults to anon if not specified in jwt
       let setClaims = claimsToSQL (M.union claims (M.singleton "role" anon))

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -17,7 +17,7 @@ import           Network.Wai.Middleware.Static (only, staticPolicy)
 import           PostgREST.ApiRequest          (ApiRequest(..))
 import           PostgREST.Auth                (claimsToSQL, JWTAttempt(..))
 import           PostgREST.Config              (AppConfig (..), corsPolicy)
-import           PostgREST.Error               (errResponse)
+import           PostgREST.Error               (simpleErrorResponse)
 import           PostgREST.Types               (ContentType (..), toHeader)
 
 import           Protolude                     hiding (concat, null)
@@ -29,7 +29,7 @@ runWithClaims conf eClaims app req =
   case eClaims of
     JWTExpired -> return $ unauthed "JWT expired"
     JWTInvalid -> return $ unauthed "JWT invalid"
-    JWTMissingSecret -> return $ errResponse status500 "Server lacks JWT secret"
+    JWTMissingSecret -> return $ simpleErrorResponse status500 "Server lacks JWT secret"
     JWTClaims claims -> do
       -- role claim defaults to anon if not specified in jwt
       let setClaims = claimsToSQL (M.union claims (M.singleton "role" anon))

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -14,11 +14,11 @@ import           Network.Wai.Middleware.Cors   (cors)
 import           Network.Wai.Middleware.Gzip   (def, gzip)
 import           Network.Wai.Middleware.Static (only, staticPolicy)
 
-import           PostgREST.ApiRequest          (ApiRequest(..), ContentType(..),
-                                                toHeader)
+import           PostgREST.ApiRequest          (ApiRequest(..))
 import           PostgREST.Auth                (claimsToSQL, JWTAttempt(..))
 import           PostgREST.Config              (AppConfig (..), corsPolicy)
 import           PostgREST.Error               (errResponse)
+import           PostgREST.Types               (ContentType (..), toHeader)
 
 import           Protolude                     hiding (concat, null)
 

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -20,11 +20,11 @@ import           Protolude hiding              (concat, (&), Proxy, get, interca
 
 import           Data.Swagger
 
-import           PostgREST.ApiRequest        (ContentType(..), toMime)
+import           PostgREST.ApiRequest        (ContentType(..))
 import           PostgREST.Config            (prettyVersion)
 import           PostgREST.QueryBuilder      (operators)
 import           PostgREST.Types             (Table(..), Column(..), PgArg(..),
-                                              Proxy(..), ProcDescription(..))
+                                              Proxy(..), ProcDescription(..), toMime)
 
 makeMimeList :: [ContentType] -> MimeList
 makeMimeList cs = MimeList $ map (fromString . toS . toMime) cs

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -16,6 +16,7 @@ data ContentType = CTApplicationJSON | CTTextCSV | CTOpenAPI
 data ApiRequestError = ActionInappropriate
                      | InvalidBody ByteString
                      | InvalidRange
+                     | ParseRequestError Text Text
                      deriving (Show, Eq)
 
 data DbStructure = DbStructure {

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -6,6 +6,17 @@ import qualified Data.ByteString.Lazy as BL
 import           Data.Tree
 import qualified Data.Vector          as V
 import           PostgREST.RangeQuery (NonnegRange)
+import           Network.HTTP.Types.Header (hContentType, Header)
+
+-- | Enumeration of currently supported response content types
+data ContentType = CTApplicationJSON | CTTextCSV | CTOpenAPI
+                 | CTSingularJSON | CTOctetStream
+                 | CTAny | CTOther ByteString deriving Eq
+
+data ApiRequestError = ActionInappropriate
+                     | InvalidBody ByteString
+                     | InvalidRange
+                     deriving (Show, Eq)
 
 data DbStructure = DbStructure {
   dbTables      :: [Table]
@@ -134,7 +145,6 @@ type ReadRequest = Tree ReadNode
 type MutateRequest = MutateQuery
 data DbRequest = DbRead ReadRequest | DbMutate MutateRequest
 
-
 instance ToJSON Column where
   toJSON c = object [
       "schema"    .= tableSchema t
@@ -172,3 +182,17 @@ instance Eq Table where
 instance Eq Column where
   Column{colTable=t1,colName=n1} == Column{colTable=t2,colName=n2} = t1 == t2 && n1 == n2
   _ == _ = False
+
+-- | Convert from ContentType to a full HTTP Header
+toHeader :: ContentType -> Header
+toHeader ct = (hContentType, toMime ct <> "; charset=utf-8")
+
+-- | Convert from ContentType to a ByteString representing the mime type
+toMime :: ContentType -> ByteString
+toMime CTApplicationJSON = "application/json"
+toMime CTTextCSV         = "text/csv"
+toMime CTOpenAPI         = "application/openapi+json"
+toMime CTSingularJSON    = "application/vnd.pgrst.object+json"
+toMime CTOctetStream     = "application/octet-stream"
+toMime CTAny             = "*/*"
+toMime (CTOther ct)      = ct

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -17,6 +17,9 @@ data ApiRequestError = ActionInappropriate
                      | InvalidBody ByteString
                      | InvalidRange
                      | ParseRequestError Text Text
+                     | UnknownRelation
+                     | NoRelationBetween Text Text
+                     | UnsupportedVerb
                      deriving (Show, Eq)
 
 data DbStructure = DbStructure {

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -119,7 +119,7 @@ spec = do
 
     it "matches filtering nested items 2" $
       get "/clients?select=id,projects{id,tasks2{id,name}}&projects.tasks.name=like.Design*"
-        `shouldRespondWith` [json| {"message":"could not find foreign keys between these entities, no relation between projects and tasks2"}|]
+        `shouldRespondWith` [json| {"message":"Could not find foreign keys between these entities, No relation found between projects and tasks2"}|]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }
@@ -599,6 +599,12 @@ spec = do
       get "/ghostBusters" `shouldRespondWith`
         [json| [{"escapeId":1},{"escapeId":3},{"escapeId":5}] |]
         { matchHeaders = [matchContentTypeJson] }
+
+    it "fails if an operator is not given" $ do
+      get "/ghostBusters?id=0" `shouldRespondWith` [json| {"details":"unexpected \"0\" expecting \"not.\" or operator (eq, gt, ...)","message":"\"failed to parse filter (0)\" (line 1, column 1)"} |]
+        { matchStatus  = 400
+        , matchHeaders = [matchContentTypeJson]
+        }
 
     it "will embed a collection" $
       get "/Escap3e;?select=ghostBusters{*}" `shouldRespondWith`

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -600,7 +600,7 @@ spec = do
         [json| [{"escapeId":1},{"escapeId":3},{"escapeId":5}] |]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "fails if an operator is not given" $ do
+    it "fails if an operator is not given" $
       get "/ghostBusters?id=0" `shouldRespondWith` [json| {"details":"unexpected \"0\" expecting \"not.\" or operator (eq, gt, ...)","message":"\"failed to parse filter (0)\" (line 1, column 1)"} |]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]


### PR DESCRIPTION
This PR make fixes the problem of double encoding JSON errors and avoids whenever possible using Text values to represent error information. 

This is related to #791 and #757

Besides the fix there are some extra goals:

* Avoid exposing the `ParseError` type to better encapsulate the `Parsec` module inside our `Parsers`.
* Avoid exposing any formatting error functions from `Error` module so the error representation becomes more opaque.
* Add more constructors to `ApiRequestError` so it can describe in details more error conditions.
* Move the `ApiRequestError` type and some helper functions to the more generic `Types` module since they are used in several modules.
