### PR TITLE
Accept empty string as empty json body when calling an rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #791, malformed nested JSON error - @diogob
 - Resource embedding in views referencing tables in public schema - @fab1an
+- #777, Empty body is enforced when calling a non-parameterized RPC - @koulakis
 
 ## [0.4.0.0] - 2017-01-19
 

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -125,13 +125,13 @@ userApiRequest schema req reqBody
   payload =
     case decodeContentType . fromMaybe "application/json" $ lookupHeader "content-type" of
       CTApplicationJSON ->
-        (if BL.null reqBody && isTargetingProc
-           then Right emptyObject
-           else JSON.eitherDecode reqBody)
-         >>= note "All object keys must match" . ensureUniform . pluralize
+        note "All object keys must match" . ensureUniform . pluralize
+          =<< if BL.null reqBody && isTargetingProc
+               then Right emptyObject
+               else JSON.eitherDecode reqBody
       CTTextCSV ->
-        CSV.decodeByName reqBody
-        >>= note "All lines must have same number of fields" . ensureUniform . csvToJson
+        note "All lines must have same number of fields" . ensureUniform . csvToJson
+          =<< CSV.decodeByName reqBody
       CTOther "application/x-www-form-urlencoded" ->
         Right . PayloadJSON . V.singleton . M.fromList
                     . map (toS *** JSON.String . toS) . parseSimpleQuery

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -5,6 +5,7 @@ import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 import Network.HTTP.Types
 import Network.Wai.Test (SResponse(simpleHeaders,simpleStatus,simpleBody))
+import qualified Data.ByteString.Lazy as BL (empty)
 
 import SpecHelper
 import Text.Heredoc
@@ -481,7 +482,6 @@ spec = do
             , matchHeaders = ["Content-Range" <:> "0-0/2"]
             }
 
-
       it "returns proper json" $
         post "/rpc/getitemrange" [json| { "min": 2, "max": 4 } |] `shouldRespondWith`
           [json| [ {"id": 3}, {"id":4} ] |]
@@ -590,6 +590,12 @@ spec = do
           [json| { "integer": "7", "double": "2.71828", "varchar" : "forms are fun"
                  , "boolean":"false", "date":"1900-01-01", "money":"$3.99", "enum":"foo" } |]
                  { matchHeaders = [matchContentTypeJson] }
+
+    context "a proc that receives no parameters" $
+      it "interprets empty string as empty json object on a post request" $
+        post "/rpc/noparamsproc" BL.empty `shouldRespondWith`
+          [json| "Return value of no parameters procedure." |]
+          { matchHeaders = [matchContentTypeJson] }
 
   describe "weird requests" $ do
     it "can query as normal" $ do

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -173,6 +173,15 @@ CREATE FUNCTION getitemrange(min bigint, max bigint) RETURNS SETOF items
     SELECT * FROM test.items WHERE id > $1 AND id <= $2;
 $_$;
 
+--
+-- Name: version(); Type: FUNCTION; Schema: test; Owner: -
+--
+
+CREATE FUNCTION noparamsproc() RETURNS text
+	LANGUAGE sql
+	AS $$
+		SELECT a FROM (VALUES ('Return value of no parameters procedure.')) s(a);
+	$$;
 
 --
 -- Name: insert_insertable_view_with_join(); Type: FUNCTION; Schema: test; Owner: -


### PR DESCRIPTION
Fixes #777. I added the non-parametric stored procedure mentioned in the issue to the test database and wrote a test that simulates the curl command which makes an rpc call without a json body. Then located the call of the rpc in the request API and mapped the empty ByteString for rpc calls to an empty JSON body.

I added two imports in order to use empty ByteStrings and JSON Values, since I could find no elegant way to build them from the existing libraries. Would be happy to change that if there is some alternative I am missing. 