### PR TITLE
Increase Warp connection timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- #827, Avoid Warp reaper, extend socket timeout to 1 hour - @majorcode
 - #791, malformed nested JSON error - @diogob
 - Resource embedding in views referencing tables in public schema - @fab1an
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -57,7 +57,7 @@ main = do
       appSettings = setHost ((fromString . toS) host)
                   . setPort port
                   . setServerName (toS $ "postgrest/" <> prettyVersion)
-                  . setTimeout 86400
+                  . setTimeout 3600
                   $ defaultSettings
 
   when (isMalformedProxyUri $ toS <$> proxy) $ panic

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -57,6 +57,7 @@ main = do
       appSettings = setHost ((fromString . toS) host)
                   . setPort port
                   . setServerName (toS $ "postgrest/" <> prettyVersion)
+                  . setTimeout 86400
                   $ defaultSettings
 
   when (isMalformedProxyUri $ toS <$> proxy) $ panic

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.0
+resolver: lts-8.5
 extra-deps:
   - Ranged-sets-0.3.0
   - hasql-pool-0.4.1


### PR DESCRIPTION
I was able to find a few references to "Thread killed by Warp's timeout reaper" in other projects. One (Hets) resolved the issue by increasing the Warp connection timeout to one day. I'll explain and attempt to justify this below.

If accepted, this pull request resolves #827 in the same way as referred to in a Yesod [issue](https://github.com/yesodweb/wai/issues/351) and [resolved](https://github.com/spechub/Hets/pull/1520) in the Hets project.

---

Some browsers keep TCP connections open for a while, probably to improve the speed of subsequent requests to the same site. This is a reasonable practice.

Warp apparently has a feature to kill (reap) long running connections. The default connection timeout is 60 seconds. I can't find code listing the 60 second default--I see a [default of 30 seconds](https://github.com/yesodweb/wai/blob/3736ea965049777f8a5d95e6f645c04a940608d4/warp/Network/Wai/Handler/Warp/Settings.hs#L133). Perhaps it's being applied twice inside Warp? The Hets project also [observed a timeout message](https://github.com/spechub/Hets/issues/1482) after 60 seconds.

Connection timeouts cause error messages printed to stderr. The messages are harmless notifications from Warp stating that it closed a connection after it's timeout expired. Affected clients/browsers can simply re-connect as needed. PostgREST's ability to serve requests is unaffected. But the messages sound scary and are logged as errors, possibly implying that action is needed to resolve a problem.

Why would Warp do this? It's one step in its protection from a Slow Loris attack (or the like) where an attacker keeps a large number of connections open in an attempt to deny service through connection starvation.

Slow Loris protection is a good thing. But I'm not certain PostgREST needs this feature.

First, with a need for SSL termination on the web, you really should have PostgREST behind a proxy--like Nginx. The proxy has to have Slow Loris protection. In the case of NginX, you can limit the number of requests from the same IP (and do more to [protect it](https://www.nginx.com/blog/mitigating-ddos-attacks-with-nginx-and-nginx-plus/)).

Second--and this is where I have technical questions about how Warp uses Haskell for connection threads--I think the thread overhead in Haskell is so small that it would be very difficult to trigger connection exhaustion. It seems to me that the ulimit would be reached first.

Finally, in my informal tests, I can't get PostgREST to fall over under load. I can get it to use all of my CPU. But, if I'm requesting any end point that hits the database, the database dominates resource usage. Postgres would probably kick the bucket first. Consequently, more exotic DDoS protection provided by a proxy is in order. I believe DDoS prevention features are out of scope for PosgREST.

---

## Questions:

### Is this solution acceptable?
I can not find a way to disable the timeout completely. So a high limit is the next best thing.

### Is 24 hours a good number? 
Would a lower number be better? 24 hours should eliminate all error logs, unless you have a long running dashboard or IoT thing using PostgREST. The best number would be just over the duration of your max site visit. But that varies. Is there a reference to the timeout value used by browsers? I cold not find a reliable source.

### Should it be configurable?
I don't think so because of the need for other DDoS protection.

