### PR TITLE
Upgrade to fast new hasql

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
     - stack setup
     - rm -fr $(stack path --dist-dir) $(stack path --local-install-root)
     - stack install hlint packdeps cabal-install
-    - stack build --fast
+    - stack build --fast -j1
     - stack build --fast --test --no-run-tests
 
 test:

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -142,7 +142,7 @@ Test-Suite spec
                      , hasql-pool
                      , heredoc
                      , hjsonpointer
-                     , hjsonschema
+                     , hjsonschema == 1.5.0.1
                      , hspec
                      , hspec-wai >= 0.7.0
                      , hspec-wai-json

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
---module PostgREST.App where
+
 module PostgREST.App (
   postgrest
 ) where

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE TupleSections        #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-|
 Module      : PostgREST.QueryBuilder
@@ -149,7 +148,7 @@ callProc :: QualifiedIdentifier -> JSON.Object -> Bool -> SqlQuery -> SqlQuery -
 callProc qi params returnsScalar selectQuery countQuery _ countTotal isSingle paramsAsJson asCsv asBinary binaryField =
   unicodeStatement sql HE.unit decodeProc True
   where
-    sql = 
+    sql =
      if returnsScalar then [qc|
        WITH {sourceCTEName} AS ({_callSql})
        SELECT
@@ -157,7 +156,7 @@ callProc qi params returnsScalar selectQuery countQuery _ countTotal isSingle pa
          1 AS page_total,
          {scalarBodyF} as body
        FROM ({selectQuery}) _postgrest_t;|]
-     else [qc| 
+     else [qc|
        WITH {sourceCTEName} AS ({_callSql})
        SELECT
          {countResultF} AS total_result_set,

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,8 @@ extra-deps:
   - configurator-ng-0.0.0.1
   - critbit-0.2.0.0
   - hasql-pool-0.4.1
+  - hjsonpointer-1.1.1
+  - hjsonschema-1.5.0.1
   - jose-0.5.0.3
   - Ranged-sets-0.3.0
 ghc-options:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.5
+resolver: lts-9.0
 extra-deps:
   - configurator-ng-0.0.0.1
   - critbit-0.2.0.0


### PR DESCRIPTION
Upgrade for the speed improvements prior to releasing a new postgrest version.

@ruslantalpa note that I had to use a stackage snapshot plus hold some other packages' versions back. I'd kind of like to wait for hasql to appear in stackage again and work cleanly with the other packages...