### PR TITLE
Read only proc tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #777, Empty body is allowed when calling a non-parameterized RPC - @koulakis
 - #831, Fix proc resource embedding issue with search_path - @steve-chavez
 - #857, Fix swagger-ui when "server-proxy-uri" is not set - @feynmanliang
+- #547, Use read-only transaction for stable/immutable RPC - @begriffs
 
 ## [0.4.0.0] - 2017-01-19
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -90,6 +90,7 @@ transactionMode structure target action =
   case action of
     ActionRead -> HT.Read
     ActionInfo -> HT.Read
+    ActionInspect -> HT.Read
     ActionInvoke ->
       let proc =
             case target of

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -79,15 +79,28 @@ postgrest conf refDbStructure pool getTime =
             eClaims = jwtClaims jwtSecret (iJWT apiRequest) time
             authed = containsRole eClaims
             handleReq = runWithClaims conf eClaims (app dbStructure conf) apiRequest
-            txMode = transactionMode $ iAction apiRequest
+            txMode = transactionMode dbStructure
+              (iTarget apiRequest) (iAction apiRequest)
         response <- P.use pool $ HT.transaction HT.ReadCommitted txMode handleReq
         return $ either (pgError authed) identity response
     respond response
 
-transactionMode :: Action -> H.Mode
-transactionMode ActionRead = HT.Read
-transactionMode ActionInfo = HT.Read
-transactionMode _ = HT.Write
+transactionMode :: DbStructure -> Target -> Action -> H.Mode
+transactionMode structure target action =
+  case action of
+    ActionRead -> HT.Read
+    ActionInfo -> HT.Read
+    ActionInvoke ->
+      let proc =
+            case target of
+              (TargetProc qi) -> M.lookup (qiName qi) $
+                                   dbProcs structure
+              _               -> Nothing
+          v = fromMaybe Volatile $ pdVolatility <$> proc in
+      if v == Stable || v == Immutable
+         then HT.Read
+         else HT.Write
+    _ -> HT.Write
 
 app :: DbStructure -> AppConfig -> ApiRequest -> H.Transaction Response
 app dbStructure conf apiRequest =

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -110,7 +110,7 @@ accessibleProcs =
                             HD.value HD.bool <*>
                             HD.value HD.char)
                         <*> (parseVolatility <$>
-                            HD.value HD.text)
+                            HD.value HD.char)
       )
     ) True
  where
@@ -140,10 +140,10 @@ accessibleProcs =
         'p' -> Pseudo name
         _   -> Scalar qi -- 'b'ase, 'd'omain, 'e'num, 'r'ange
 
-  parseVolatility :: Text -> ProcVolatility
-  parseVolatility "i" = Immutable
-  parseVolatility "s" = Stable
-  parseVolatility "v" = Volatile
+  parseVolatility :: Char -> ProcVolatility
+  parseVolatility 'i' = Immutable
+  parseVolatility 's' = Stable
+  parseVolatility 'v' = Volatile
   parseVolatility _   = Volatile -- should not happen, but be pessimistic
 
   sql = [q|

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -41,10 +41,14 @@ data PgType = Scalar QualifiedIdentifier | Composite QualifiedIdentifier | Pseud
 
 data RetType = Single PgType | SetOf PgType deriving (Eq, Show)
 
+data ProcVolatility = Volatile | Stable | Immutable
+  deriving (Eq, Show)
+
 data ProcDescription = ProcDescription {
   pdName       :: Text
 , pdArgs       :: [PgArg]
 , pdReturnType :: RetType
+, pdVolatility :: ProcVolatility
 } deriving (Show, Eq)
 
 type Schema = Text

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -316,6 +316,7 @@ $$;
 
 CREATE FUNCTION sayhello(name text) RETURNS text
     LANGUAGE sql
+    IMMUTABLE
     AS $_$
     SELECT 'Hello, ' || $1;
 $_$;


### PR DESCRIPTION
A read-only standby postgresql server does not support read-write transactions. Our code used to ask for these kind of transactions to call stored procs, but this PR checks the volatility class of the function and uses read-only transactions when possible.