### PR TITLE
Make HTTP headers available as GUCs #800

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Allow requesting binary output on GET - @steve-chavez
-- Make HTTP headers available as GUCs #800 - @ruslantalpa
+- Make HTTP headers and cookies available as GUCs #800 - @ruslantalpa
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Allow requesting binary output on GET - @steve-chavez
+- Make HTTP headers available as GUCs #800 - @ruslantalpa
 
 ### Fixed
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -86,6 +86,7 @@ library
                      , wai-cors
                      , wai-extra
                      , wai-middleware-static
+                     , cookie
 
   Other-Modules:       Paths_postgrest
   Exposed-Modules:     PostgREST.ApiRequest

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -97,7 +97,7 @@ data ApiRequest = ApiRequest {
   -- | HTTP request headers
   , iHeaders :: [(Text, Text)]
   -- | Request Cookies
-  , iCookies :: Maybe [(Text, Text)]
+  , iCookies :: [(Text, Text)]
   }
 
 -- | Examines HTTP request and translates it into user intent.
@@ -126,7 +126,7 @@ userApiRequest schema req reqBody
         $ rawQueryString req
       , iJWT = tokenStr
       , iHeaders = [ (toS $ CI.foldedCase k, toS v) | (k,v) <- hdrs, k /= hAuthorization, k /= hCookie]
-      , iCookies = parseCookiesText <$> lookupHeader "Cookie"
+      , iCookies = fromMaybe [] $ parseCookiesText <$> lookupHeader "Cookie"
       }
  where
   isTargetingProc = fromMaybe False $ (== "rpc") <$> listToMaybe path

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -40,6 +40,7 @@ import           PostgREST.Types           ( QualifiedIdentifier (..)
                                            , ApiRequestError(..)
                                            , toMime)
 import           Data.Ranged.Ranges        (Range(..), rangeIntersection, emptyRange)
+import qualified Data.CaseInsensitive      as CI
 
 type RequestBody = BL.ByteString
 
@@ -92,6 +93,8 @@ data ApiRequest = ApiRequest {
   , iCanonicalQS :: ByteString
   -- | JSON Web Token
   , iJWT :: Text
+  -- | HTTP request headers
+  , iHeaders :: [(Text, Text)]
   }
 
 -- | Examines HTTP request and translates it into user intent.
@@ -119,6 +122,7 @@ userApiRequest schema req reqBody
         . parseSimpleQuery
         $ rawQueryString req
       , iJWT = tokenStr
+      , iHeaders = [ (toS $ CI.foldedCase k, toS v) | (k,v) <- hdrs, k /= hAuthorization]
       }
  where
   isTargetingProc = fromMaybe False $ (== "rpc") <$> listToMaybe path

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -27,7 +27,7 @@ import           Control.Arrow             ((***))
 import qualified Data.Text                 as T
 import qualified Data.Vector               as V
 import           Network.HTTP.Base         (urlEncodeVars)
-import           Network.HTTP.Types.Header (hAuthorization)
+import           Network.HTTP.Types.Header (hAuthorization, hCookie)
 import           Network.HTTP.Types.URI    (parseSimpleQuery)
 import           Network.Wai               (Request (..))
 import           Network.Wai.Parse         (parseHttpAccept)
@@ -41,6 +41,7 @@ import           PostgREST.Types           ( QualifiedIdentifier (..)
                                            , toMime)
 import           Data.Ranged.Ranges        (Range(..), rangeIntersection, emptyRange)
 import qualified Data.CaseInsensitive      as CI
+import           Web.Cookie                (parseCookiesText)
 
 type RequestBody = BL.ByteString
 
@@ -95,6 +96,8 @@ data ApiRequest = ApiRequest {
   , iJWT :: Text
   -- | HTTP request headers
   , iHeaders :: [(Text, Text)]
+  -- | Request Cookies
+  , iCookies :: Maybe [(Text, Text)]
   }
 
 -- | Examines HTTP request and translates it into user intent.
@@ -122,7 +125,8 @@ userApiRequest schema req reqBody
         . parseSimpleQuery
         $ rawQueryString req
       , iJWT = tokenStr
-      , iHeaders = [ (toS $ CI.foldedCase k, toS v) | (k,v) <- hdrs, k /= hAuthorization]
+      , iHeaders = [ (toS $ CI.foldedCase k, toS v) | (k,v) <- hdrs, k /= hAuthorization, k /= hCookie]
+      , iCookies = parseCookiesText <$> lookupHeader "Cookie"
       }
  where
   isTargetingProc = fromMaybe False $ (== "rpc") <$> listToMaybe path

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -12,7 +12,6 @@ In the test suite there is an example of simple login function that can be used 
 very simple authentication system inside the PostgreSQL database.
 -}
 module PostgREST.Auth (
-    -- claimsToSQL
     containsRole
   , jwtClaims
   , tokenJWT

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -12,8 +12,8 @@ In the test suite there is an example of simple login function that can be used 
 very simple authentication system inside the PostgreSQL database.
 -}
 module PostgREST.Auth (
-    claimsToSQL
-  , containsRole
+    -- claimsToSQL
+    containsRole
   , jwtClaims
   , tokenJWT
   , JWTAttempt(..)
@@ -28,24 +28,8 @@ import qualified Data.Vector             as V
 import qualified Data.HashMap.Strict     as M
 import           Data.Maybe              (fromJust)
 import           Data.Time.Clock         (NominalDiffTime)
-import           PostgREST.QueryBuilder  (pgFmtIdent, pgFmtLit, unquoted)
 import qualified Web.JWT                 as JWT
 
-{-|
-  Receives a map of JWT claims and returns a list of PostgreSQL
-  statements to set the claims as user defined GUCs.  Except if we
-  have a claim called role, this one is mapped to a SET ROLE
-  statement.
--}
-claimsToSQL :: M.HashMap Text Value -> [ByteString]
-claimsToSQL claims = roleStmts <> varStmts
- where
-  roleStmts = maybeToList $
-    (\r -> "set local role " <> r <> ";") . toS . valueToVariable <$> M.lookup "role" claims
-  varStmts = map setVar $ M.toList (M.delete "role" claims)
-  setVar (k, val) = "set local " <> toS (pgFmtIdent $ "request.jwt.claim." <> k)
-                    <> " = " <> toS (valueToVariable val) <> ";"
-  valueToVariable = pgFmtLit . unquoted
 
 {-|
   Possible situations encountered with client JWTs

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -38,7 +38,7 @@ runWithClaims conf eClaims app req =
       app req
       where
         headersSql = map (pgFmtEnvVar "request.header.") $ iHeaders req
-        cookiesSql = map (pgFmtEnvVar "request.cookie.") $ fromMaybe [] $ iCookies req
+        cookiesSql = map (pgFmtEnvVar "request.cookie.") $ iCookies req
         claimsSql = map (pgFmtEnvVar "request.jwt.claim.") [(c,unquoted v) | (c,v) <- M.toList claimsWithRole]
         setRoleSql = maybeToList $
           (\r -> "set local role " <> r <> ";") . toS . pgFmtLit . unquoted <$> M.lookup "role" claimsWithRole

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module PostgREST.Middleware where
 
@@ -15,10 +16,11 @@ import           Network.Wai.Middleware.Gzip   (def, gzip)
 import           Network.Wai.Middleware.Static (only, staticPolicy)
 
 import           PostgREST.ApiRequest          (ApiRequest(..))
-import           PostgREST.Auth                (claimsToSQL, JWTAttempt(..))
+import           PostgREST.Auth                (JWTAttempt(..))
 import           PostgREST.Config              (AppConfig (..), corsPolicy)
 import           PostgREST.Error               (simpleError)
 import           PostgREST.Types               (ContentType (..), toHeader)
+import           PostgREST.QueryBuilder        (pgFmtIdent, pgFmtLit, unquoted)
 
 import           Protolude                     hiding (concat, null)
 
@@ -31,14 +33,19 @@ runWithClaims conf eClaims app req =
     JWTInvalid -> return $ unauthed "JWT invalid"
     JWTMissingSecret -> return $ simpleError status500 "Server lacks JWT secret"
     JWTClaims claims -> do
-      -- role claim defaults to anon if not specified in jwt
-      let setClaims = claimsToSQL (M.union claims (M.singleton "role" anon))
-      H.sql $ mconcat setClaims
+      H.sql $ mconcat $ setRoleSql ++ claimsSql ++ headersSql
       mapM_ H.sql customReqCheck
       app req
+      where
+        headersSql = envVarToSql "request.header." $ iHeaders req
+        claimsSql = envVarToSql "request.jwt.claim." [(c,unquoted v) | (c,v) <- M.toList claimsWithRole]
+        setRoleSql = maybeToList $
+          (\r -> "set local role " <> r <> ";") . toS . pgFmtLit . unquoted <$> M.lookup "role" claimsWithRole
+        -- role claim defaults to anon if not specified in jwt
+        claimsWithRole = M.union claims (M.singleton "role" anon)
+        anon = String . toS $ configAnonRole conf
+        customReqCheck = (\f -> "select " <> toS f <> "();") <$> configReqCheck conf
   where
-    anon = String . toS $ configAnonRole conf
-    customReqCheck = (\f -> "select " <> toS f <> "();") <$> configReqCheck conf
     unauthed message = responseLBS unauthorized401
       [ toHeader CTApplicationJSON
       , ( "WWW-Authenticate"
@@ -47,6 +54,13 @@ runWithClaims conf eClaims app req =
         )
       ]
       (toS $ "{\"message\":\""<>message<>"\"}")
+
+envVarToSql :: Text -> [(Text, Text)] -> [ByteString]
+envVarToSql prefix vars = varStmts
+ where
+  varStmts = map setVar vars
+  setVar (k, val) = toS $ "set local " <> pgFmtIdent (prefix <> k)
+                    <> " = " <> pgFmtLit val <> ";"
 
 defaultMiddle :: Application -> Application
 defaultMiddle =

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -694,7 +694,7 @@ spec = do
         , matchHeaders = ["Content-Type" <:> "application/octet-stream; charset=utf-8"]
         }
   describe "HTTP request env vars" $ do
-    it "custom header is set" $ do
+    it "custom header is set" $
       request methodPost "/rpc/get_guc_value"
                 [("Custom-Header", "test")]
           [json| { "name": "request.header.custom-header" } |]
@@ -703,7 +703,7 @@ spec = do
           { matchStatus  = 200
           , matchHeaders = [ matchContentTypeJson ]
           }
-    it "standard header is set" $ do
+    it "standard header is set" $
       request methodPost "/rpc/get_guc_value"
                 [("Origin", "http://example.com")]
           [json| { "name": "request.header.origin" } |]
@@ -712,7 +712,7 @@ spec = do
           { matchStatus  = 200
           , matchHeaders = [ matchContentTypeJson ]
           }
-    it "current role is available as GUC claim" $ do
+    it "current role is available as GUC claim" $
       request methodPost "/rpc/get_guc_value" []
           [json| { "name": "request.jwt.claim.role" } |]
           `shouldRespondWith`

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -720,3 +720,20 @@ spec = do
           { matchStatus  = 200
           , matchHeaders = [ matchContentTypeJson ]
           }
+    it "single cookie ends up as claims" $
+      request methodPost "/rpc/get_guc_value" [("Cookie","acookie=cookievalue")]
+        [json| {"name":"request.cookie.acookie"} |]
+          `shouldRespondWith`
+          [str|"cookievalue"|]
+          { matchStatus = 200
+          , matchHeaders = []
+          }
+
+    it "multiple cookies ends up as claims" $
+      request methodPost "/rpc/get_guc_value" [("Cookie","acookie=cookievalue;secondcookie=anothervalue")]
+        [json| {"name":"request.cookie.secondcookie"} |]
+          `shouldRespondWith`
+          [str|"anothervalue"|]
+          { matchStatus = 200
+          , matchHeaders = []
+          }

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1156,6 +1156,11 @@ create function test.single_article(id integer) returns test.articles as $$
   select a.* from test.articles a where a.id = $1;
 $$ language sql;
 
+create function test.get_guc_value(name text) returns text as $$ 
+  select nullif(current_setting(name), '')::text;
+$$ language sql;
+
+
 --
 -- PostgreSQL database dump complete
 --


### PR DESCRIPTION
This PR makes request headers available as GUC vars for each request
It also sets `request.jwt.claims.role`, it useful when doing RLS through views.

Please look at runWithClaims from middleware if it needs some nicer style/formatting