### PR TITLE
Adds application/json to inspect type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Allow requesting binary output on GET - @steve-chavez
+- Accept clients requesting `Content-Type: application/json` from / - @feynmanliang
 
 ### Fixed
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -284,7 +284,7 @@ responseContentTypeOrError accepts action = serves contentTypesForRequest accept
         ActionUpdate ->  [CTApplicationJSON, CTSingularJSON, CTTextCSV]
         ActionDelete ->  [CTApplicationJSON, CTSingularJSON, CTTextCSV]
         ActionInvoke ->  [CTApplicationJSON, CTSingularJSON]
-        ActionInspect -> [CTOpenAPI]
+        ActionInspect -> [CTOpenAPI, CTApplicationJSON]
         ActionInfo ->    [CTTextCSV]
     serves sProduces cAccepts =
       case mutuallyAgreeable sProduces cAccepts of

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -237,7 +237,7 @@ makeRootPathItem = ("/", p)
   where
     getOp = (mempty :: Operation)
       & tags .~ Set.fromList ["/"]
-      & produces ?~ makeMimeList [CTOpenAPI]
+      & produces ?~ makeMimeList [CTOpenAPI, CTApplicationJSON]
       & at 200 ?~ "OK"
     pr = (mempty :: PathItem) & get ?~ getOp
     p = pr


### PR DESCRIPTION
The latest version of swagger-ui https://github.com/swagger-api/swagger-ui/tree/v3.0.4 cannot consume the OpenAPI spec provided at `/api/`, throwing a content type error in the browser:
```
Failed to load resource: the server responded with a status of 415 (Unsupported Media Type)
GET http://localhost/api/ 415 (Unsupported Media Type)
```

The response sent by `postgrest` shows

```
{"message":"None of these Content-Types are available: application/json"}
```

This is caused by the [Content-Type request by swagger-ui](https://github.com/swagger-api/swagger-ui/blob/e23dada9fed460a5e4a88809db362ee75ccd08aa/src/core/plugins/download-url.js#L18).

This PR adds support for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/begriffs/postgrest/853)
<!-- Reviewable:end -->
