### PR TITLE
Fix swagger-ui when "server-proxy-uri" is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Resource embedding in views referencing tables in public schema - @fab1an
 - #777, Empty body is allowed when calling a non-parameterized RPC - @koulakis
 - #831, Fix proc resource embedding issue with search_path - @steve-chavez
+- #857, Fix swagger-ui when "server-proxy-uri" is not set - @feynmanliang
 
 ## [0.4.0.0] - 2017-01-19
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -229,7 +229,7 @@ app dbStructure conf apiRequest =
           let host = configHost conf
               port = toInteger $ configPort conf
               proxy = pickProxy $ toS <$> configProxyUri conf
-              uri Nothing = ("http", host, port, "/")
+              uri Nothing = ("http", host, port, "")
               uri (Just Proxy { proxyScheme = s, proxyHost = h, proxyPort = p, proxyPath = b }) = (s, h, p, b)
               uri' = uri proxy
               encodeApi ti = encodeOpenAPI (M.elems $ dbProcs dbStructure) ti uri'


### PR DESCRIPTION
When `server-proxy-uri` is not set in `postgrest.conf`, the `swagger.json` would report a `Base url: 0.0.0.0:3000/`, which results in the generated API calls for the examples to have an extra slash i.e. the "//" in:

```
curl -X GET http://0.0.0.0:3000//skills -H  "accept: application/json" -H  "content-type: application/json" -H  "Range: undefined" -H  "Range-Unit: items" -H  "Prefer: undefined"
```

This results in a failure when trying out the API, see:
![](http://image.prntscr.com/image/ece8d82002de4c7ea20999dedd6148aa.png)

This PR removes this extraneous tailing "/" for the case where `server-proxy-uri` is not set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/begriffs/postgrest/857)
<!-- Reviewable:end -->
