### PR TITLE
Use union merge strategy on changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/CHANGELOG.md merge=union


### PR DESCRIPTION
When we have multiple pull requests modifying the changelog the later ones to be merged have had to do a rebase to eliminate the conflict. This PR specifies the "union" merge strategy apply on the changelog which accepts lines from all differences and includes them in random order.