### PR TITLE
Add connection retrying on startup and SIGHUP, Fix #742

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #742, Add connection retrying on startup and SIGHUP - @steve-chavez
+
 ### Fixed
 
 ## [0.4.1.0] - 2017-04-25

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -153,6 +153,7 @@ main = do
     defaultUpdateSettings { updateAction = getPOSIXTime }
 
   runSettings appSettings $ postgrest conf refDbStructure pool getTime
+    (connectionWorker mainTid pool (configSchema conf) refDbStructure refIsWorkerOn)
 
 loadSecretFile :: AppConfig -> IO AppConfig
 loadSecretFile conf = extractAndTransform mSecret

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -55,7 +55,7 @@ isServerVersionSupported = do
 connectionWorker :: ThreadId -> P.Pool -> Schema -> IORef (Maybe DbStructure) -> IORef Bool -> IO ()
 connectionWorker mainTid pool schema refDbStructure refIsWorkerOn = do
   isWorkerOn <- readIORef refIsWorkerOn
-  when (not isWorkerOn) $ do
+  unless isWorkerOn $ do
     atomicWriteIORef refIsWorkerOn True
     void $ forkIO work
   where

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -40,6 +40,7 @@ executable postgrest
                      , warp
                      , bytestring
                      , base64-bytestring
+                     , retry
   if !os(windows)
     build-depends:     unix
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -86,11 +86,8 @@ postgrest conf refDbStructure pool getTime worker =
                   (iTarget apiRequest) (iAction apiRequest)
             response <- P.use pool $ HT.transaction HT.ReadCommitted txMode handleReq
             return $ either (pgError authed) identity response
-        if isResponse503 response then do
-          worker
-          respond response
-        else
-          respond response
+        when (isResponse503 response) worker
+        respond response
 
 isResponse503 :: Response -> Bool
 isResponse503 resp = statusCode (responseStatus resp) == 503

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -8,6 +8,7 @@ module PostgREST.Error (
 , simpleError
 , singularityError
 , binaryFieldError
+, connectionLostError
 , encodeError
 ) where
 
@@ -72,6 +73,10 @@ binaryFieldError :: Response
 binaryFieldError =
   simpleError HT.status406 (toS (toMime CTOctetStream) <>
   " requested but a single column was not selected")
+
+connectionLostError :: Response
+connectionLostError =
+  simpleError HT.status503 "Database connection lost, retrying the connection."
 
 encodeError :: JSON.ToJSON a => a -> LByteString
 encodeError = JSON.encode

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -133,7 +133,7 @@ instance JSON.ToJSON H.Error where
     "details" .= (fmap toS d::Maybe Text)]
 
 httpStatus :: Bool -> P.UsageError -> HT.Status
-httpStatus _ (P.ConnectionError _) = HT.status500
+httpStatus _ (P.ConnectionError _) = HT.status503
 httpStatus authed (P.SessionError (H.ResultError (H.ServerError c _ _ _))) =
   case toS c of
     '0':'8':_ -> HT.status503 -- pg connection err

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -42,12 +42,12 @@ main = do
 
   result <- P.use pool $ getDbStructure "test"
   refDbStructure <- newIORef $ Just $ either (panic.show) id result
-  let withApp      = return $ postgrest (testCfg testDbConn)          refDbStructure pool getTime
-      ltdApp       = return $ postgrest (testLtdRowsCfg testDbConn)   refDbStructure pool getTime
-      unicodeApp   = return $ postgrest (testUnicodeCfg testDbConn)   refDbStructure pool getTime
-      proxyApp     = return $ postgrest (testProxyCfg testDbConn)     refDbStructure pool getTime
-      noJwtApp     = return $ postgrest (testCfgNoJWT testDbConn)     refDbStructure pool getTime
-      binaryJwtApp = return $ postgrest (testCfgBinaryJWT testDbConn) refDbStructure pool getTime
+  let withApp      = return $ postgrest (testCfg testDbConn)          refDbStructure pool getTime $ pure ()
+      ltdApp       = return $ postgrest (testLtdRowsCfg testDbConn)   refDbStructure pool getTime $ pure ()
+      unicodeApp   = return $ postgrest (testUnicodeCfg testDbConn)   refDbStructure pool getTime $ pure ()
+      proxyApp     = return $ postgrest (testProxyCfg testDbConn)     refDbStructure pool getTime $ pure ()
+      noJwtApp     = return $ postgrest (testCfgNoJWT testDbConn)     refDbStructure pool getTime $ pure ()
+      binaryJwtApp = return $ postgrest (testCfgBinaryJWT testDbConn) refDbStructure pool getTime $ pure ()
 
   let reset = resetDb testDbConn
   hspec $ do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -41,7 +41,7 @@ main = do
 
 
   result <- P.use pool $ getDbStructure "test"
-  refDbStructure <- newIORef $ either (panic.show) id result
+  refDbStructure <- newIORef $ Just $ either (panic.show) id result
   let withApp      = return $ postgrest (testCfg testDbConn)          refDbStructure pool getTime
       ltdApp       = return $ postgrest (testLtdRowsCfg testDbConn)   refDbStructure pool getTime
       unicodeApp   = return $ postgrest (testUnicodeCfg testDbConn)   refDbStructure pool getTime


### PR DESCRIPTION
This adds a capped exponential backoff(base is 1 second, cap is 32 seconds, arbitrarily picked, could be improved) for retrying the db connection in a background thread.

This thread is started at postgREST startup and leaves it rejecting all requests with a 503 with no parsing or further processing, it's in an ```unavailable``` state until connection succeeds; this thread can also be started on SIGHUP.

I considered that postgREST is in an ```available``` state when the dbStructure is successfully obtained, and that's what the ```connectionWorker``` works on, I'll explain why:

At first I had an ```available``` IORef for when the connection succeeded but got some issues when the dbStructure was not obtained, for example postgREST succeeded with requests like:

```http
GET /clients
GET /clients?select=id,name
```

But gived an error with requests like:

```http
GET /
GET /clients?select=id,name,projects{*}
```

For what I've seen the first requests escaped the sections of the code that operated on dbStructure, so if the dbStructure is not obtained then postgREST is in a broken state, so instead of having two IORefs to maintain I decided that the IORef dbstructure should indicate the ```available``` state.

I think this is useful as it is but I don't know an easy way to add tests. Thoughts?   