### PR TITLE
Dockerfile: Clean up to save space

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,24 @@
 FROM debian:jessie
 
-ENV POSTGREST_VERSION 0.4.1.0
+# Install libpq5
+RUN apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends libpq5 && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN apt-get update && \
-    apt-get install -y tar xz-utils wget libpq-dev && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN wget http://github.com/begriffs/postgrest/releases/download/v${POSTGREST_VERSION}/postgrest-${POSTGREST_VERSION}-ubuntu.tar.xz && \
-    tar --xz -xvf postgrest-${POSTGREST_VERSION}-ubuntu.tar.xz && \
+# Install postgrest
+RUN POSTGREST_VERSION="0.4.1.0" \
+    BUILD_DEPS="curl ca-certificates xz-utils" && \
+    apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends $BUILD_DEPS && \
+    cd /tmp && \
+    curl -SLO https://github.com/begriffs/postgrest/releases/download/v${POSTGREST_VERSION}/postgrest-${POSTGREST_VERSION}-ubuntu.tar.xz && \
+    tar -xJvf postgrest-${POSTGREST_VERSION}-ubuntu.tar.xz && \
     mv postgrest /usr/local/bin/postgrest && \
-    rm postgrest-${POSTGREST_VERSION}-ubuntu.tar.xz
+    cd / && \
+    apt-get -qq purge --auto-remove -y $BUILD_DEPS && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY postgrest.conf /etc/postgrest.conf
 


### PR DESCRIPTION
Running postgrest requires the libpq library runtime, not the -dev
package.

Make sure that tools that are used to download and extract the postgrest
package do not remain installed in the image.