### PR TITLE
Binary output support for RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - #889, Allow more than two conditions in a single and/or - @steve-chavez
+- #883, Binary output support for RPC - @steve-chavez
 
 ### Fixed
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -238,8 +238,12 @@ app dbStructure conf apiRequest =
               let p = V.head payload
                   singular = contentType == CTSingularJSON
                   paramsAsSingleObject = iPreferSingleObjectParameter apiRequest
+                  proc = M.lookup (qiName qi) allProcs 
+                  returnsScalar = case proc of
+                    Just ProcDescription{pdReturnType = (Single (Scalar _))} -> True
+                    _ -> False
               row <- H.query () $
-                callProc qi p q cq topLevelRange shouldCount singular
+                callProc qi p returnsScalar q cq topLevelRange shouldCount singular
                          paramsAsSingleObject (contentType == CTTextCSV)
               let (tableTotal, queryTotal, body) =
                     fromMaybe (Just 0, 0, "[]") row
@@ -257,7 +261,7 @@ app dbStructure conf apiRequest =
               uri Nothing = ("http", host, port, "/")
               uri (Just Proxy { proxyScheme = s, proxyHost = h, proxyPort = p, proxyPath = b }) = (s, h, p, b)
               uri' = uri proxy
-              encodeApi ti = encodeOpenAPI (M.elems $ dbProcs dbStructure) ti uri'
+              encodeApi ti = encodeOpenAPI (M.elems allProcs) ti uri'
           body <- encodeApi . toTableInfo <$> H.query schema accessibleTables
           return $ responseLBS status200 [toHeader CTOpenAPI] $ toS body
 
@@ -276,6 +280,7 @@ app dbStructure conf apiRequest =
       filterCol :: Schema -> TableName -> Column -> Bool
       filterCol sc tb Column{colTable=Table{tableSchema=s, tableName=t}} = s==sc && t==tb
       allPrKeys = dbPrimaryKeys dbStructure
+      allProcs = dbProcs dbStructure
       allOrigins = ("Access-Control-Allow-Origin", "*") :: Header
       shouldCount = iPreferCount apiRequest
       schema = toS $ configSchema conf
@@ -287,7 +292,7 @@ app dbStructure conf apiRequest =
             status = rangeStatus lower upper (toInteger <$> tableTotal)
         in (status, contentRange)
 
-      readReq = readRequest (configMaxRows conf) (dbRelations dbStructure) (dbProcs dbStructure) apiRequest
+      readReq = readRequest (configMaxRows conf) (dbRelations dbStructure) allProcs apiRequest
       fldNames = fieldNames <$> readReq
       readDbRequest = DbRead <$> readReq
       mutateDbRequest = DbMutate <$> (mutateRequest apiRequest =<< fldNames)

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -137,7 +137,9 @@ accessibleProcs =
       qi = QualifiedIdentifier schema name
       pgType = case typ of
         'c' -> Composite qi
-        'p' -> Pseudo name
+        'p' -> if name == "record" -- Only pg pseudo type that is a row type is 'record'
+                 then Composite qi
+                 else Scalar qi
         _   -> Scalar qi -- 'b'ase, 'd'omain, 'e'num, 'r'ange
 
   parseVolatility :: Char -> ProcVolatility

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -38,7 +38,7 @@ data PgArg = PgArg {
 , pgaReq  :: Bool
 } deriving (Show, Eq)
 
-data PgType = Scalar QualifiedIdentifier | Composite QualifiedIdentifier | Pseudo Text deriving (Eq, Show)
+data PgType = Scalar QualifiedIdentifier | Composite QualifiedIdentifier deriving (Eq, Show)
 
 data RetType = Single PgType | SetOf PgType deriving (Eq, Show)
 

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -667,6 +667,10 @@ spec = do
           [json| "Return value of no parameters procedure." |]
           { matchHeaders = [matchContentTypeJson] }
 
+    it "returns proper output when having the same return col name as the proc name" $
+      post "/rpc/test" [json|{}|] `shouldRespondWith`
+        [json|[{"test":"hello","value":1}]|] { matchHeaders = [matchContentTypeJson] }
+
   describe "weird requests" $ do
     it "can query as normal" $ do
       get "/Escap3e;" `shouldRespondWith`

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -693,27 +693,50 @@ spec = do
         { matchHeaders = [matchContentTypeJson] }
 
   describe "binary output" $ do
-    it "can query if a single column is selected" $
-      request methodGet "/images_base64?select=img&name=eq.A.png" (acceptHdrs "application/octet-stream") ""
-        `shouldRespondWith` "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAABlBMVEUAAAD/AAAb/40iAAAAP0lEQVQI12NgwAbYG2AE/wEYwQMiZB4ACQkQYZEAIgqAhAGIKLCAEQ8kgMT/P1CCEUwc4IMSzA3sUIIdCHECAGSQEkeOTUyCAAAAAElFTkSuQmCC"
-        { matchStatus = 200
-        , matchHeaders = ["Content-Type" <:> "application/octet-stream; charset=utf-8"]
-        }
+    context "on GET" $ do
+      it "can query if a single column is selected" $
+        request methodGet "/images_base64?select=img&name=eq.A.png" (acceptHdrs "application/octet-stream") ""
+          `shouldRespondWith` "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAABlBMVEUAAAD/AAAb/40iAAAAP0lEQVQI12NgwAbYG2AE/wEYwQMiZB4ACQkQYZEAIgqAhAGIKLCAEQ8kgMT/P1CCEUwc4IMSzA3sUIIdCHECAGSQEkeOTUyCAAAAAElFTkSuQmCC"
+          { matchStatus = 200
+          , matchHeaders = ["Content-Type" <:> "application/octet-stream; charset=utf-8"]
+          }
 
-    it "fails if a single column is not selected" $ do
-      request methodGet "/images?select=img,name&name=eq.A.png" (acceptHdrs "application/octet-stream") ""
-        `shouldRespondWith` 406
-      request methodGet "/images?select=*&name=eq.A.png" (acceptHdrs "application/octet-stream") ""
-        `shouldRespondWith` 406
-      request methodGet "/images?name=eq.A.png" (acceptHdrs "application/octet-stream") ""
-        `shouldRespondWith` 406
+      it "fails if a single column is not selected" $ do
+        request methodGet "/images?select=img,name&name=eq.A.png" (acceptHdrs "application/octet-stream") ""
+          `shouldRespondWith` 406
+        request methodGet "/images?select=*&name=eq.A.png" (acceptHdrs "application/octet-stream") ""
+          `shouldRespondWith` 406
+        request methodGet "/images?name=eq.A.png" (acceptHdrs "application/octet-stream") ""
+          `shouldRespondWith` 406
 
-    it "concatenates results if more than one row is returned" $
-      request methodGet "/images_base64?select=img&name=in.A.png,B.png" (acceptHdrs "application/octet-stream") ""
-        `shouldRespondWith` "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAABlBMVEUAAAD/AAAb/40iAAAAP0lEQVQI12NgwAbYG2AE/wEYwQMiZB4ACQkQYZEAIgqAhAGIKLCAEQ8kgMT/P1CCEUwc4IMSzA3sUIIdCHECAGSQEkeOTUyCAAAAAElFTkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAABlBMVEX///8AAP94wDzzAAAAL0lEQVQIW2NgwAb+HwARH0DEDyDxwAZEyGAhLODqHmBRzAcn5GAS///A1IF14AAA5/Adbiiz/0gAAAAASUVORK5CYII="
-        { matchStatus = 200
-        , matchHeaders = ["Content-Type" <:> "application/octet-stream; charset=utf-8"]
-        }
+      it "concatenates results if more than one row is returned" $
+        request methodGet "/images_base64?select=img&name=in.A.png,B.png" (acceptHdrs "application/octet-stream") ""
+          `shouldRespondWith` "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAABlBMVEUAAAD/AAAb/40iAAAAP0lEQVQI12NgwAbYG2AE/wEYwQMiZB4ACQkQYZEAIgqAhAGIKLCAEQ8kgMT/P1CCEUwc4IMSzA3sUIIdCHECAGSQEkeOTUyCAAAAAElFTkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAABlBMVEX///8AAP94wDzzAAAAL0lEQVQIW2NgwAb+HwARH0DEDyDxwAZEyGAhLODqHmBRzAcn5GAS///A1IF14AAA5/Adbiiz/0gAAAAASUVORK5CYII="
+          { matchStatus = 200
+          , matchHeaders = ["Content-Type" <:> "application/octet-stream; charset=utf-8"]
+          }
+
+    context "on RPC" $ do
+      context "Proc that returns scalar" $
+        it "can query without selecting column" $
+          request methodPost "/rpc/ret_base64_bin" (acceptHdrs "application/octet-stream") ""
+            `shouldRespondWith` "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAABlBMVEUAAAD/AAAb/40iAAAAP0lEQVQI12NgwAbYG2AE/wEYwQMiZB4ACQkQYZEAIgqAhAGIKLCAEQ8kgMT/P1CCEUwc4IMSzA3sUIIdCHECAGSQEkeOTUyCAAAAAElFTkSuQmCC"
+            { matchStatus = 200
+            , matchHeaders = ["Content-Type" <:> "application/octet-stream; charset=utf-8"]
+            }
+
+      context "Proc that returns rows" $ do
+        it "can query if a single column is selected" $
+          request methodPost "/rpc/ret_rows_with_base64_bin?select=img" (acceptHdrs "application/octet-stream") ""
+            `shouldRespondWith` "iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAABlBMVEUAAAD/AAAb/40iAAAAP0lEQVQI12NgwAbYG2AE/wEYwQMiZB4ACQkQYZEAIgqAhAGIKLCAEQ8kgMT/P1CCEUwc4IMSzA3sUIIdCHECAGSQEkeOTUyCAAAAAElFTkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAABlBMVEX///8AAP94wDzzAAAAL0lEQVQIW2NgwAb+HwARH0DEDyDxwAZEyGAhLODqHmBRzAcn5GAS///A1IF14AAA5/Adbiiz/0gAAAAASUVORK5CYII="
+            { matchStatus = 200
+            , matchHeaders = ["Content-Type" <:> "application/octet-stream; charset=utf-8"]
+            }
+
+        it "fails if a single column is not selected" $
+          request methodPost "/rpc/ret_rows_with_base64_bin" (acceptHdrs "application/octet-stream") ""
+            `shouldRespondWith` 406
+
   describe "HTTP request env vars" $ do
     it "custom header is set" $
       request methodPost "/rpc/get_guc_value"

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -553,6 +553,18 @@ spec = do
             [json|"Hello, ￥"|]
             { matchHeaders = [matchContentTypeJson] }
 
+      it "returns array" $
+        post "/rpc/ret_array" [json|{}|] `shouldRespondWith`
+          [json|[1, 2, 3]|]
+          { matchHeaders = [matchContentTypeJson] }
+
+      it "returns setof integers" $
+        post "/rpc/ret_setof_integers" [json|{}|] `shouldRespondWith`
+          [json|[{ "ret_setof_integers": 1 },
+                 { "ret_setof_integers": 2 },
+                 { "ret_setof_integers": 3 }]|]
+          { matchHeaders = [matchContentTypeJson] }
+
       it "returns enum value" $
         post "/rpc/ret_enum" [json|{ "val": "foo" }|] `shouldRespondWith`
           [json|"foo"|]

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1215,6 +1215,12 @@ create table grandchild_entities (
   jsonb_col jsonb
 );
 
+-- Used for testing that having the same return column name as the proc name
+-- doesn't conflict with the required output, details in #901
+create function test.test() returns table(test text, value int) as $$
+  values ('hello', 1);
+$$ language sql;
+
 --
 -- PostgreSQL database dump complete
 --

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1115,6 +1115,7 @@ create table images (
 );
 
 create view images_base64 as (
+  -- encoding in base64 puts a '\n' after every 76 character due to legacy reasons, this is isn't necessary here so it's removed
   select name, replace(encode(img, 'base64'), E'\n', '') as img from images
 );
 
@@ -1160,6 +1161,14 @@ create function test.ret_point_3d() returns private.point_3d as $$
 $$ language sql;
 
 create function test.ret_void() returns void as '' language sql;
+
+create function test.ret_base64_bin() returns text as $$
+  select i.img from test.images_base64 i where i.name = 'A.png';
+$$ language sql;
+
+create function test.ret_rows_with_base64_bin() returns setof test.images_base64 as $$
+  select i.name, i.img from test.images_base64 i;
+$$ language sql;
 
 create function test.single_article(id integer) returns test.articles as $$ 
   select a.* from test.articles a where a.id = $1;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1124,12 +1124,20 @@ $$ language sql;
 
 create domain one_nine as integer check (value >= 1 and value <= 9);
 
+create function test.ret_array() returns integer[] as $$ 
+  select '{1,2,3}'::integer[];
+$$ language sql;
+
 create function test.ret_domain(val integer) returns test.one_nine as $$ 
   select val::test.one_nine;
 $$ language sql;
 
 create function test.ret_range(low integer, up integer) returns int4range as $$
   select int4range(low, up);
+$$ language sql;
+
+create function test.ret_setof_integers() returns setof integer as $$
+  values (1), (2), (3);
 $$ language sql;
 
 create function test.ret_scalars() returns table(


### PR DESCRIPTION
Fixes #883. By default, when requesting ```Accept: application/octet-stream``` the user has to do 
```?select=single_col``` similar to binary output on GET, but since a stored procedure can return a scalar    I considered that is not necessary to force the user to do a ```/rpc_name?select=rpc_name``` so in the case of scalar I'm not applying that restriction.  

To do that I changed ```callProc``` to make it consider if the proc is scalar by consulting the ```ProcDescription```, this also avoids doing a [count](https://github.com/begriffs/postgrest/blob/b00742814216be685fddcd3ed61c2ce81894fbf0/src/PostgREST/QueryBuilder.hs#L158-L161) to determine this. 

A disadvantage of that is that now for a proc to return the scalar properly(e.g. a rpc that returns an integer should return ```4``` not ```[ { "rpc" : 4 } ]```, this was #600) it needs the ```DbStructure``` up to date, similar to the resource embedding feature, maybe this needs to be documented.

