### PR TITLE
Change singularityError zero rows status to 404

### DIFF
--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -55,10 +55,13 @@ pgError authed e =
 
 singularityError :: Integer -> Response
 singularityError numRows =
-  responseLBS HT.status406
+  if numRows == 0
+    then responseLBS HT.status404 [toHeader CTSingularJSON] ""
+  else
+    responseLBS HT.status406
     [toHeader CTSingularJSON]
     $ toS . formatGeneralError
-      "JSON object requested, multiple (or no) rows returned"
+      "JSON object requested, multiple rows returned"
       $ unwords
         [ "Results contain", show numRows, "rows,"
         , toS (toMime CTSingularJSON), "requires 1 row"

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -22,7 +22,7 @@ spec =
     context "with GET request" $ do
       it "fails for zero rows" $
         request methodGet  "/items?id=gt.0&id=lt.0" [singular] ""
-          `shouldRespondWith` 406
+          `shouldRespondWith` 404
 
       it "will select an existing object" $ do
         request methodGet "/items?id=eq.5" [singular] ""
@@ -70,8 +70,8 @@ spec =
         p <- request methodPatch  "/items?id=gt.0&id=lt.0"
           [("Prefer", "return=representation"), singular] [json|{"id":1}|]
         liftIO $ do
-          simpleStatus p `shouldBe` notAcceptable406
-          isErrorFormat (simpleBody p) `shouldBe` True
+          simpleStatus p `shouldBe` notFound404
+          simpleBody p `shouldBe` ""
 
     context "when creating rows" $ do
 
@@ -122,8 +122,8 @@ spec =
           [("Prefer", "return=representation"), singular]
           [json| [ ] |]
         liftIO $ do
-          simpleStatus p `shouldBe` notAcceptable406
-          isErrorFormat (simpleBody p) `shouldBe` True
+          simpleStatus p `shouldBe` notFound404
+          simpleBody p `shouldBe` ""
 
     context "when deleting rows" $ do
 
@@ -149,8 +149,8 @@ spec =
         p <- request methodDelete "/items?id=lt.0"
           [("Prefer", "return=representation"), singular] ""
         liftIO $ do
-          simpleStatus p `shouldBe` notAcceptable406
-          isErrorFormat (simpleBody p) `shouldBe` True
+          simpleStatus p `shouldBe` notFound404
+          simpleBody p `shouldBe` ""
 
     context "when calling a stored proc" $ do
 
@@ -158,8 +158,8 @@ spec =
         p <- request methodPost "/rpc/getproject"
           [singular] [json|{ "id": 9999999}|]
         liftIO $ do
-          simpleStatus p `shouldBe` notAcceptable406
-          isErrorFormat (simpleBody p) `shouldBe` True
+          simpleStatus p `shouldBe` notFound404
+          simpleBody p `shouldBe` ""
 
       -- this one may be controversial, should vnd.pgrst.object include
       -- the likes of 2 and "hello?"


### PR DESCRIPTION
Fixes #908. I think is more semantically correct(also in sync with the docs) to return 404 with no body when getting zero rows in:
```http
GET /projects?id=eq.0 
Accept: application/vnd.pgrst.object+json
```

But I'm not sure if that's the better response for POST/PATCH/DELETE with ```application/vnd.pgrst.object+json```, maybe for those cases it could be better to show the failed operation with the usual error message:
```json
{
    "details": "Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row",
    "message": "JSON object requested, no rows returned"
}
```
Thoughts?