### PR TITLE
fix(doc): server-proxy-uri -- URI, not URL

### DIFF
--- a/docker/postgrest.conf
+++ b/docker/postgrest.conf
@@ -6,7 +6,7 @@ db-pool = "$(PGRST_DB_POOL)"
 server-host = "$(PGRST_SERVER_HOST)"
 server-port = "$(PGRST_SERVER_PORT)"
 
-server-proxy-url = "$(PGRST_SERVER_PROXY_URL)"
+server-proxy-uri = "$(PGRST_SERVER_PROXY_URI)"
 jwt-secret = "$(PGRST_JWT_SECRET)"
 secret-is-base64 = "$(PGRST_SECRET_IS_BASE64)"
 


### PR DESCRIPTION
There was this typo in the ./docker/postgrest.conf example file, hoping to spare others from having to chase this straight back to the source code.