### PR TITLE
Improve relations initialization time (#924)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #877, Base64 secret read from a file ending with a newline - @eric-brechemier
 - #896, Boolean env var interpolation in config file - @begriffs
 - #885, OpenAPI repetition reduced by using more definitions- @ldesgoui
+- #924, Improve relations initialization time - @9too
 
 ## [0.4.2.0] - 2017-06-11
 

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -253,6 +253,7 @@ addManyToManyRelations rels = rels ++ addMirrorRelation (mapMaybe link2Relation 
     links = join $ map (combinations 2) $ filter (not . null) $ groupWith groupFn $ filter ( (==Child). relType) rels
     groupFn :: Relation -> Text
     groupFn Relation{relTable=Table{tableSchema=s, tableName=t}} = s<>"_"<>t
+    -- Reference : https://wiki.haskell.org/99_questions/Solutions/26
     combinations :: Int -> [a] -> [[a]]
     combinations 0 _  = [ [] ]
     combinations n xs = [ y:ys | y:xs' <- tails xs

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -253,7 +253,10 @@ addManyToManyRelations rels = rels ++ addMirrorRelation (mapMaybe link2Relation 
     links = join $ map (combinations 2) $ filter (not . null) $ groupWith groupFn $ filter ( (==Child). relType) rels
     groupFn :: Relation -> Text
     groupFn Relation{relTable=Table{tableSchema=s, tableName=t}} = s<>"_"<>t
-    combinations k ns = filter ((k==).length) (subsequences ns)
+    combinations :: Int -> [a] -> [[a]]
+    combinations 0 _  = [ [] ]
+    combinations n xs = [ y:ys | y:xs' <- tails xs
+                               , ys <- combinations (n-1) xs']
     addMirrorRelation [] = []
     addMirrorRelation (rel@(Relation t c ft fc _ lt lc1 lc2):rels') = Relation ft fc t c Many lt lc2 lc1 : rel : addMirrorRelation rels'
     link2Relation [


### PR DESCRIPTION
Reduce computation required to generate relations on the first request.

## Sample test case

**PostgREST v0.4.2.0**
```
$ time curl 'http://localhost:3000/x?select=x(*)'

real	0m27.601s
user	0m0.001s
sys	0m0.001s
```
**PostgREST with combinations improvement**
```
$ time curl 'http://localhost:3000/x?select=x(*)'

real	0m0.012s
user	0m0.001s
sys	0m0.001s
```