### PR TITLE
Allow passing URI with database to tests

### DIFF
--- a/test/create_test_db
+++ b/test/create_test_db
@@ -17,8 +17,7 @@ then
 fi
 
 BASEPATH=$( cd $(dirname $0) ; pwd -P )
-#Remove database path from the connection uri--prevents setting up the new database name with PGDATABASE
-URI=$(echo $1 | cut -d'/' -f1-3)
+URI="$1"
 #Extract host and port--we need this to form the new connection string
 HOST_PORT=$(echo $URI | cut -d'/' -f3 | cut -d'@' -f2 )
 DB=$2
@@ -48,6 +47,9 @@ CREATE DATABASE $DB OWNER $TEST_USER_NAME;
 \\connect $DB
 ALTER SCHEMA public OWNER TO $TEST_USER_NAME;
 EOF
+
+#Remove database path from the connection uri--prevents setting up the new database name with PGDATABASE
+URI=$(echo $URI | cut -d'/' -f1-3)
 
 PGDATABASE=$DB PGOPTIONS='-c client_min_messages=WARNING' psql "$URI" --set=db=$DB -Xq <<EOF
   CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/test/destroy_test_db
+++ b/test/destroy_test_db
@@ -17,8 +17,7 @@ then
 fi
 
 BASEPATH=$( cd $(dirname $0) ; pwd -P )
-#Remove database path from the connection uri
-URI=$(echo $1 | cut -d'/' -f1-3)
+URI="$1"
 DB=$2
 
 PGOPTIONS='-c client_min_messages=WARNING' psql "$URI" -Xq >/dev/null -c 'select rolcreatedb from pg_authid where rolname = current_user;' 2>/dev/null


### PR DESCRIPTION
Without this, psql will try to use the default database name for the user

The database part of the uri only needs to be stripped for the final part of create_test_db