### PR TITLE
Remove the need for pk in &select for parent embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #996, Fix embedded column conflicts table name - @grotsev
 - #974, Fix RPC error when function has single OUT param - @steve-chavez
 - #1021, Reduce join size in allColumns for faster program start - @nextstopsun
+- #411, Remove the need for pk in &select for parent embed - @steve-chavez
 
 ## [0.4.3.0] - 2017-09-06
 

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -277,3 +277,6 @@ data PgVersion = PgVersion {
   pgvNum  :: Int32
 , pgvName :: Text
 } deriving (Eq, Ord, Show)
+
+sourceCTEName :: SqlFragment
+sourceCTEName = "pg_source"


### PR DESCRIPTION
**Edit**: Omit this proposal, no need to upgrade PostgreSQL version, see my comment below.

Main idea to solve this was to include the primary keys on the LEFT JOIN subquery regardless of whether the user requested them or not, and then remove them from the output by using PostgreSQL jsonb `-` operator.

So now when requesting:
```http
GET /projects?select=*,client{name}
```
This query is generated:
```sql
WITH pg_source AS (
   SELECT "test"."projects".*,
          to_jsonb("clients_client".*) - 'id' AS "client"
   FROM "test"."projects"
   LEFT JOIN (
     SELECT "test"."clients"."id",
            "test"."clients"."name"
     FROM "test"."clients"
   ) AS "clients_client" ON "clients_client"."id" = "projects"."client_id")
SELECT NULL AS total_result_set,
       pg_catalog.count(_postgrest_t) AS page_total, array[]::text[] AS header,
       coalesce(array_to_json(array_agg(row_to_json(_postgrest_t))), '[]')::character varying AS body
FROM (SELECT * FROM pg_source) _postgrest_t
```
The cost of this new query remains the same as the previous one in the tests I've made. Also requests that included a rename of the pk:
```http
GET /projects?select=name,client{clientId:id,name}
```
Were not working previously and now this is fixed.

The drawback of this solution is that the used `-` jsonb operator is only available starting from PostgreSQL 9.5, so the required version for PostgREST would have to be increased to 9.5 for this to work.

Maybe it's not worth to increase the version for just this fix, however I think with a similarly crafted query I could modify the `Many/Child` embed queries and as noted in https://github.com/begriffs/postgrest/issues/411#issuecomment-329324791 the query costs for those are really high now, if I can dramatically decrease these costs I think then it'll be worth the jump to 9.5.