### PR TITLE
Read secret file as binary, without premature parsing as UTF-8 (#876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- #876, Read secret files as binary, discard final LF if any - @eric-brechemier
 - #968, Treat blank proxy uri as missing - @begriffs
 
 ## [0.4.3.0] - 2017-09-06

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -16,13 +16,14 @@ import           Protolude hiding         (replace, hPutStrLn)
 import           Control.Retry            (RetryStatus, capDelay,
                                            exponentialBackoff,
                                            retrying, rsPreviousDelay)
-import           Data.ByteString.Base64   (decode)
 import           Data.IORef               (IORef, atomicWriteIORef,
                                            newIORef, readIORef)
 import           Data.String              (IsString (..))
 import           Data.Text                (pack, replace, stripPrefix, strip)
 import           Data.Text.Encoding       (decodeUtf8, encodeUtf8)
-import           Data.Text.IO             (hPutStrLn, readFile)
+import           Data.Text.IO             (hPutStrLn)
+import qualified Data.ByteString.Base64   as B64
+import qualified Data.ByteString          as BS
 import qualified Hasql.Decoders           as HD
 import qualified Hasql.Encoders           as HE
 import qualified Hasql.Pool               as P
@@ -230,6 +231,12 @@ main = do
          refDbStructure
          refIsWorkerOn)
 
+chomp :: ByteString -> ByteString
+chomp bs =
+  case BS.stripSuffix "\n" bs of
+    Nothing -> bs
+    Just rest -> rest
+
 {-|
   The purpose of this function is to load the JWT secret from a file if
   configJwtSecret is actually a filepath and replaces some characters if the JWT
@@ -264,14 +271,14 @@ loadSecretFile conf = extractAndTransform mSecret
       fmap setSecret $
       transformString isB64 =<<
       case stripPrefix "@" secret of
-        Nothing       -> return secret
-        Just filename -> readFile (toS filename)
+        Nothing       -> return . encodeUtf8 $ secret
+        Just filename -> chomp <$> BS.readFile (toS filename)
     --
     -- Turns the Base64url encoded JWT into Base64
-    transformString :: Bool -> Text -> IO ByteString
-    transformString False t = return . encodeUtf8 $ t
+    transformString :: Bool -> ByteString -> IO ByteString
+    transformString False t = return $ t
     transformString True t =
-      case decode (encodeUtf8 $ strip $ replaceUrlChars t) of
+      case B64.decode $ encodeUtf8 $ strip $ replaceUrlChars $ decodeUtf8 t of
         Left errMsg -> panic $ pack errMsg
         Right bs    -> return bs
     setSecret bs = conf {configJwtSecret = Just bs}

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -231,9 +231,6 @@ main = do
          refDbStructure
          refIsWorkerOn)
 
-chomp :: ByteString -> ByteString
-chomp bs = fromMaybe bs (BS.stripSuffix "\n" bs)
-
 {-|
   The purpose of this function is to load the JWT secret from a file if
   configJwtSecret is actually a filepath and replaces some characters if the JWT
@@ -270,6 +267,8 @@ loadSecretFile conf = extractAndTransform mSecret
       case stripPrefix "@" secret of
         Nothing       -> return . encodeUtf8 $ secret
         Just filename -> chomp <$> BS.readFile (toS filename)
+      where
+        chomp bs = fromMaybe bs (BS.stripSuffix "\n" bs)
     --
     -- Turns the Base64url encoded JWT into Base64
     transformString :: Bool -> ByteString -> IO ByteString

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -232,10 +232,7 @@ main = do
          refIsWorkerOn)
 
 chomp :: ByteString -> ByteString
-chomp bs =
-  case BS.stripSuffix "\n" bs of
-    Nothing -> bs
-    Just rest -> rest
+chomp bs = fromMaybe bs (BS.stripSuffix "\n" bs)
 
 {-|
   The purpose of this function is to load the JWT secret from a file if
@@ -276,7 +273,7 @@ loadSecretFile conf = extractAndTransform mSecret
     --
     -- Turns the Base64url encoded JWT into Base64
     transformString :: Bool -> ByteString -> IO ByteString
-    transformString False t = return $ t
+    transformString False t = return t
     transformString True t =
       case B64.decode $ encodeUtf8 $ strip $ replaceUrlChars $ decodeUtf8 t of
         Left errMsg -> panic $ pack errMsg

--- a/test/io-tests.sh
+++ b/test/io-tests.sh
@@ -93,13 +93,13 @@ totalTests=12
 echo "1..$totalTests"
 
 readSecretFromFile word.noeol 'simple (no EOL)'
-skip readSecretFromFile word.txt 'simple'
+readSecretFromFile word.txt 'simple'
 readSecretFromFile ascii.noeol 'ASCII (no EOL)'
-skip readSecretFromFile ascii.txt 'ASCII'
+readSecretFromFile ascii.txt 'ASCII'
 readSecretFromFile utf8.noeol 'UTF-8 (no EOL)'
-skip readSecretFromFile utf8.txt 'UTF-8'
-skip readSecretFromFile binary.noeol 'binary'
-skip readSecretFromFile binary.eol 'binary (+EOL)'
+readSecretFromFile utf8.txt 'UTF-8'
+readSecretFromFile binary.noeol 'binary'
+readSecretFromFile binary.eol 'binary (+EOL)'
 
 readSecretFromFile word.b64 'Base64 (simple)'
 readSecretFromFile ascii.b64 'Base64 (ASCII)'


### PR DESCRIPTION
This allows to read binary secrets as well as text (UTF-8) or Base64
secrets. Also, the final LF character (`\n`), if any, is now removed.

After this change, all I/O unit tests now pass.