### PR TITLE
Link to new docker hub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 </a>
 [![Join the chat at https://gitter.im/begriffs/postgrest](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/begriffs/postgrest)
 [![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](http://postgrest.com)
+[![Docker Stars](https://img.shields.io/docker/pulls/postgrest/postgrest.svg)](https://hub.docker.com/r/postgrest/postgrest/)
 
 PostgREST serves a fully RESTful API from any existing PostgreSQL
 database. It provides a cleaner, more standards-compliant, faster


### PR DESCRIPTION
Add a shield to the readme to steer people to the new repo on docker hub.

Related to https://github.com/begriffs/postgrest-docs/issues/101