### PR TITLE
Fix embedded column conflicts table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #962, OpenAPI don't err on nonexistent schema - @steve-chavez
 - #954, make OpenAPI rpc output dependent on user privileges - @steve-chavez
 - #955, Support configurable aud claim - @statik
+- Fix embedded column conflicts table name - @grotsev
 
 ## [0.4.3.0] - 2017-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #962, OpenAPI don't err on nonexistent schema - @steve-chavez
 - #954, make OpenAPI rpc output dependent on user privileges - @steve-chavez
 - #955, Support configurable aud claim - @statik
-- Fix embedded column conflicts table name - @grotsev
+- #996, Fix embedded column conflicts table name - @grotsev
 
 ## [0.4.3.0] - 2017-09-06
 

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -245,7 +245,7 @@ requestToQuery schema isParent (DbRead (Node (Select colSelects tbls logicForest
     getQueryParts (Node n@(_, (name, Just Relation{relType=Child,relTable=Table{tableName=table}}, alias, _)) forst) (j,s) = (j,sel:s)
       where
         sel = "COALESCE(("
-           <> "SELECT array_to_json(array_agg(row_to_json("<>pgFmtIdent table<>"))) "
+           <> "SELECT array_to_json(array_agg(row_to_json("<>pgFmtIdent table<>".*))) "
            <> "FROM (" <> subquery <> ") " <> pgFmtIdent table
            <> "), '[]') AS " <> pgFmtIdent (fromMaybe name alias)
            where subquery = requestToQuery schema False (DbRead (Node n forst))
@@ -262,7 +262,7 @@ requestToQuery schema isParent (DbRead (Node (Select colSelects tbls logicForest
     getQueryParts (Node n@(_, (name, Just Relation{relType=Many,relTable=Table{tableName=table}}, alias, _)) forst) (j,s) = (j,sel:s)
       where
         sel = "COALESCE (("
-           <> "SELECT array_to_json(array_agg(row_to_json("<>pgFmtIdent table<>"))) "
+           <> "SELECT array_to_json(array_agg(row_to_json("<>pgFmtIdent table<>".*))) "
            <> "FROM (" <> subquery <> ") " <> pgFmtIdent table
            <> "), '[]') AS " <> pgFmtIdent (fromMaybe name alias)
            where subquery = requestToQuery schema False (DbRead (Node n forst))


### PR DESCRIPTION
Error is reported while resource embedding when table name and column name in the table are same.
```
{"hint":"No function matches the given name and argument types. You might need to add explicit type casts."
,"details":null
,"code":"42883"
,"message":"function row_to_json(uuid) does not exist"
}
```
`uuid` is type of column, but it should be `row`.

To name table explicitly use `.*`
