### PR TITLE
Fix RPC error when function has single OUT param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #954, make OpenAPI rpc output dependent on user privileges - @steve-chavez
 - #955, Support configurable aud claim - @statik
 - #996, Fix embedded column conflicts table name - @grotsev
+- #974, Fix RPC error when function has single OUT param - @steve-chavez
 
 ## [0.4.3.0] - 2017-09-06
 

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -245,7 +245,7 @@ requestToQuery schema isParent (DbRead (Node (Select colSelects tbls logicForest
     getQueryParts (Node n@(_, (name, Just Relation{relType=Child,relTable=Table{tableName=table}}, alias, _)) forst) (j,s) = (j,sel:s)
       where
         sel = "COALESCE(("
-           <> "SELECT array_to_json(array_agg(row_to_json("<>pgFmtIdent table<>".*))) "
+           <> "SELECT array_to_json(array_agg(row_to_json(" <> pgFmtIdent table <> ".*))) "
            <> "FROM (" <> subquery <> ") " <> pgFmtIdent table
            <> "), '[]') AS " <> pgFmtIdent (fromMaybe name alias)
            where subquery = requestToQuery schema False (DbRead (Node n forst))
@@ -262,7 +262,7 @@ requestToQuery schema isParent (DbRead (Node (Select colSelects tbls logicForest
     getQueryParts (Node n@(_, (name, Just Relation{relType=Many,relTable=Table{tableName=table}}, alias, _)) forst) (j,s) = (j,sel:s)
       where
         sel = "COALESCE (("
-           <> "SELECT array_to_json(array_agg(row_to_json("<>pgFmtIdent table<>".*))) "
+           <> "SELECT array_to_json(array_agg(row_to_json(" <> pgFmtIdent table <> ".*))) "
            <> "FROM (" <> subquery <> ") " <> pgFmtIdent table
            <> "), '[]') AS " <> pgFmtIdent (fromMaybe name alias)
            where subquery = requestToQuery schema False (DbRead (Node n forst))

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -768,3 +768,13 @@ spec = do
       it "works with brackets" $
         get "/entities?id=eq.2&select=id,child_entities{id}" `shouldRespondWith`
           [json| [{"id": 2, "child_entities": [{"id": 3}]}] |] { matchHeaders = [matchContentTypeJson] }
+
+  context "Embedding when column name = table name" $ do
+    it "works with child embeds" $
+      get "/being?select=*,descendant(*)&limit=1" `shouldRespondWith`
+        [json|[{"being":1,"descendant":[{"descendant":1,"being":1},{"descendant":2,"being":1},{"descendant":3,"being":1}]}]|]
+        { matchHeaders = [matchContentTypeJson] }
+    it "works with many to many embeds" $
+      get "/being?select=*,part(*)&limit=1" `shouldRespondWith`
+        [json|[{"being":1,"part":[{"part":1}]}]|]
+        { matchHeaders = [matchContentTypeJson] }

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -257,6 +257,25 @@ spec =
       get "/rpc/test" `shouldRespondWith`
         [json|[{"test":"hello","value":1}]|] { matchHeaders = [matchContentTypeJson] }
 
+    context "procs with OUT/INOUT params" $ do
+      it "returns a scalar result when there is a single OUT param" $ do
+        get "/rpc/single_out_param?num=5" `shouldRespondWith`
+          [json|6|] { matchHeaders = [matchContentTypeJson] }
+        get "/rpc/single_json_out_param?a=1&b=two" `shouldRespondWith`
+          [json|{"a": 1, "b": "two"}|] { matchHeaders = [matchContentTypeJson] }
+
+      it "returns a scalar result when there is a single INOUT param" $
+        get "/rpc/single_inout_param?num=2" `shouldRespondWith`
+          [json|3|] { matchHeaders = [matchContentTypeJson] }
+
+      it "returns a row result when there are many OUT params" $
+        get "/rpc/many_out_params" `shouldRespondWith`
+          [json|[{"my_json":{"a": 1, "b": "two"},"num":3,"str":"four"}]|] { matchHeaders = [matchContentTypeJson] }
+
+      it "returns a row result when there are many INOUT params" $
+        get "/rpc/many_inout_params?num=1&str=two" `shouldRespondWith`
+          [json| [{"num":1,"str":"two","b":true}]|] { matchHeaders = [matchContentTypeJson] }
+
     context "only for POST rpc" $ do
       context "expects a single json object" $ do
         it "does not expand posted json into parameters" $

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -200,6 +200,22 @@ spec = do
 
         liftIO $ funcTag `shouldBe` Just [aesonQQ|"(rpc) privileged_hello"|]
 
+      it "doesn't include OUT params of function as required parameters" $ do
+        r <- simpleBody <$> get "/"
+        let params = r ^? key "paths" . key "/rpc/many_out_params"
+                        . key "post" . key "parameters" .  nth 0
+                        . key "schema". key "required"
+
+        liftIO $ params `shouldBe` Nothing
+
+      it "includes INOUT params(with no DEFAULT) of function as required parameters" $ do
+        r <- simpleBody <$> get "/"
+        let params = r ^? key "paths" . key "/rpc/many_inout_params"
+                        . key "post" . key "parameters" .  nth 0
+                        . key "schema". key "required"
+
+        liftIO $ params `shouldBe` Just [aesonQQ|["num", "str"]|]
+
   describe "Allow header" $ do
 
     it "includes read/write verbs for writeable table" $ do

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -323,6 +323,17 @@ INSERT INTO ranges VALUES (2, '[3,6]');
 INSERT INTO ranges VALUES (3, '[6,9]');
 INSERT INTO ranges VALUES (4, '[9,12]');
 
+TRUNCATE TABLE being CASCADE;
+INSERT INTO being VALUES (1), (2), (3), (4);
+
+TRUNCATE TABLE descendant CASCADE;
+INSERT INTO descendant VALUES (1,1), (2,1), (3,1), (4,2);
+
+TRUNCATE TABLE part CASCADE;
+INSERT INTO part VALUES (1), (2), (3), (4);
+
+TRUNCATE TABLE being_part CASCADE;
+INSERT INTO being_part VALUES (1,1), (2,1), (3,2), (4,3);
 --
 -- PostgreSQL database dump complete
 --

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -57,6 +57,10 @@ GRANT ALL ON TABLE
     , child_entities
     , grandchild_entities
     , ranges
+    , being
+    , descendant
+    , being_part
+    , part
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1254,6 +1254,24 @@ $$ language sql;
 create function test.get_tsearch() returns setof test.tsearch AS $$
   SELECT * FROM test.tsearch;
 $$ language sql;
+
+create table test.being (
+  being int primary key not null
+);
+
+create table test.descendant (
+  descendant int primary key not null,
+  being int references test.being(being)
+);
+
+create table test.part (
+  part int primary key not null
+);
+
+create table test.being_part (
+  being int not null references test.being(being),
+  part int not null references test.part(part)
+);
 --
 -- PostgreSQL database dump complete
 --

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1273,8 +1273,20 @@ create table test.being_part (
   part int not null references test.part(part)
 );
 
+create function test.single_out_param(num int, OUT num_plus_one int) AS $$
+  select num + 1;
+$$ language sql;
+
+create function test.single_json_out_param(a int, b text, OUT my_json pg_catalog.json) AS $$
+  select json_build_object('a', a, 'b', b);
+$$ language sql;
+
 create function test.many_out_params(OUT my_json pg_catalog.json, OUT num int, OUT str text) AS $$
   select '{"a": 1, "b": "two"}'::json, 3, 'four'::text;
+$$ language sql;
+
+create function test.single_inout_param(INOUT num int) AS $$
+  select num + 1;
 $$ language sql;
 
 create function test.many_inout_params(INOUT num int, INOUT str text, INOUT b bool DEFAULT true) AS $$

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1272,6 +1272,14 @@ create table test.being_part (
   being int not null references test.being(being),
   part int not null references test.part(part)
 );
+
+create function test.many_out_params(OUT my_json pg_catalog.json, OUT num int, OUT str text) AS $$
+  select '{"a": 1, "b": "two"}'::json, 3, 'four'::text;
+$$ language sql;
+
+create function test.many_inout_params(INOUT num int, INOUT str text, INOUT b bool DEFAULT true) AS $$
+  select num, str, b;
+$$ language sql;
 --
 -- PostgreSQL database dump complete
 --


### PR DESCRIPTION
Fixes #974, I had to accommodate OpenAPI output because this [test](https://github.com/steve-chavez/postgrest/blob/master/test/Feature/StructureSpec.hs#L23-L25) was failing when including functions with OUT/INOUT parameters in `fixtures/schema.sql`, also I included a test for the recent #996.

Would be better to merge this PR before the others currently opened so the commit with the test can follow up the commit in #966. Also from now on, after reviews, I would like to merge my own PRs if that's fine.