### PR TITLE
Avoid CTE on non-csv GET requests

### DIFF
--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -90,9 +90,15 @@ createReadStatement :: SqlQuery -> SqlQuery -> Bool -> Bool -> Bool -> Maybe Fie
 createReadStatement selectQuery countQuery isSingle countTotal asCsv binaryField =
   unicodeStatement sql HE.unit decodeStandard False
  where
-  sql = [qc|
-      WITH {sourceCTEName} AS ({selectQuery}) SELECT {cols}
-      FROM ( SELECT * FROM {sourceCTEName}) _postgrest_t |]
+  sql =
+    if asCsv
+      then [qc|
+        WITH {sourceCTEName} AS ({selectQuery}) SELECT {cols}
+        FROM ( SELECT * FROM {sourceCTEName}) _postgrest_t |]
+      else [qc|
+        SELECT {cols}
+        FROM ({selectQuery}) _postgrest_t |]
+
   countResultF = if countTotal then "("<>countQuery<>")" else "null"
   cols = intercalate ", " [
       countResultF <> " AS total_result_set",
@@ -321,19 +327,19 @@ unquoted (JSON.Number n) =
 unquoted (JSON.Bool b) = show b
 unquoted v = toS $ JSON.encode v
 
--- private functions
 asCsvF :: SqlFragment
 asCsvF = asCsvHeaderF <> " || '\n' || " <> asCsvBodyF
   where
-    asCsvHeaderF =
-      "(SELECT coalesce(string_agg(a.k, ','), '')" <>
-      "  FROM (" <>
-      "    SELECT json_object_keys(r)::TEXT as k" <>
-      "    FROM ( " <>
-      "      SELECT row_to_json(hh) as r from " <> sourceCTEName <> " as hh limit 1" <>
-      "    ) s" <>
-      "  ) a" <>
-      ")"
+    asCsvHeaderF = [qc|
+      (SELECT coalesce(string_agg(keys.name, ','), '')
+        FROM (
+          SELECT json_object_keys(sample)::text as name
+          FROM (
+            SELECT row_to_json(_) AS sample FROM {sourceCTEName} AS _ limit 1
+          ) _
+        ) keys
+      )
+    |]
     asCsvBodyF = "coalesce(string_agg(substring(_postgrest_t::text, 2, length(_postgrest_t::text) - 2), '\n'), '')"
 
 asJsonF :: SqlFragment


### PR DESCRIPTION
For #621, I've been trying to remove the CTE for GET queries with no success due to the CSV generation in sql.

So I thought of just leaving the CTE for CSV requests, considering #1001 I think that complex queries will most likely use json, so this might be a good enough workaround for now.