### PR TITLE
Remove hjsonpointer

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -144,7 +144,6 @@ Test-Suite spec
                      , hasql
                      , hasql-pool
                      , heredoc
-                     , hjsonpointer
                      , hjsonschema == 1.5.0.1
                      , hspec
                      , hspec-wai >= 0.7.0


### PR DESCRIPTION
It is a deps of hjsonchema and does not need to be pinned to a specific version.