### PR TITLE
Change phrase/plain full text search syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- #887, #601, Allow specifying dictionary and plain/phrase tsquery in full text search - @steve-chavez
+- #887, #601, #1007, Allow specifying dictionary and plain/phrase tsquery in full text search - @steve-chavez
 - #328, Allow doing GET on rpc - @steve-chavez
 - #917, Add ability to map RAISE errorcode/message to http status - @steve-chavez
 - #940, Add ability to map GUC to http response headers - @steve-chavez

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -433,12 +433,12 @@ pgFmtFilter table (Filter fld (OpExpr hasNot oper)) = notOp <> " " <> case oper 
       Just True  -> emptyValForIn
       Nothing    -> emptyValForIn
 
-   Fts mode lang val ->
-     pgFmtFieldOp "fts" <> " " <> case mode of
-       Normal -> "to_tsquery("
-       Plain  -> "plainto_tsquery("
-       Phrase -> "phraseto_tsquery("
-     <> maybe "" (flip (<>) ", " . pgFmtLit) lang <> unknownLiteral val <> ") "
+   Fts op lang val ->
+     pgFmtFieldOp op
+       <> "("
+       <> maybe "" ((<> ", ") . pgFmtLit) lang
+       <> unknownLiteral val
+       <> ") "
 
    Join fQi (ForeignKey Column{colTable=Table{tableName=fTableName}, colName=fColName}) ->
      pgFmtField fQi fld <> " = " <> pgFmtColumn (removeSourceCTESchema (qiSchema fQi) fTableName) fColName

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -150,7 +150,7 @@ data Proxy = Proxy {
 
 type Operator = Text
 operators :: M.HashMap Operator SqlFragment
-operators = M.fromList [
+operators = M.union (M.fromList [
   ("eq", "="),
   ("gte", ">="),
   ("gt", ">"),
@@ -161,7 +161,6 @@ operators = M.fromList [
   ("ilike", "ILIKE"),
   ("in", "IN"),
   ("is", "IS"),
-  ("fts", "@@"),
   ("cs", "@>"),
   ("cd", "<@"),
   ("ov", "&&"),
@@ -171,21 +170,22 @@ operators = M.fromList [
   ("nxl", "&>"),
   ("adj", "-|-"),
   -- TODO: these are deprecated and should be removed in v0.5.0.0
-  ("@@", "@@"),
   ("@>", "@>"),
-  ("<@", "<@")]
+  ("<@", "<@")]) ftsOperators
+
+ftsOperators :: M.HashMap Operator SqlFragment
+ftsOperators = M.fromList [
+  ("@@", "@@ to_tsquery"), -- TODO: '@@' deprecated
+  ("fts", "@@ to_tsquery"),
+  ("plfts", "@@ plainto_tsquery"),
+  ("phfts", "@@ phraseto_tsquery")
+  ]
 
 data OpExpr = OpExpr Bool Operation deriving (Eq, Show)
 data Operation = Op Operator SingleVal |
                  In ListVal |
-                 Fts FtsMode (Maybe Language) SingleVal |
+                 Fts Operator (Maybe Language) SingleVal |
                  Join QualifiedIdentifier ForeignKey deriving (Eq, Show)
-
-data FtsMode =  Normal | Plain | Phrase deriving Eq
-instance Show FtsMode where
-  show Normal = mzero
-  show Plain  = "plain"
-  show Phrase = "phrase"
 type Language = Text
 
 -- | Represents a single value in a filter, e.g. id=eq.singleval

--- a/test/Feature/AndOrParamsSpec.hs
+++ b/test/Feature/AndOrParamsSpec.hs
@@ -73,7 +73,7 @@ spec =
         it "can handle fts" $ do
           get "/entities?or=(text_search_vector.fts.bar,text_search_vector.fts.baz)&select=id" `shouldRespondWith`
             [json|[{ "id": 1 }, { "id": 2 }]|] { matchHeaders = [matchContentTypeJson] }
-          get "/tsearch?or=(text_search_vector.plain.german.fts.Art%20Spass, text_search_vector.plain.french.fts.amusant%20impossible, text_search_vector.english.fts.impossible)" `shouldRespondWith`
+          get "/tsearch?or=(text_search_vector.plfts(german).Art%20Spass, text_search_vector.plfts(french).amusant%20impossible, text_search_vector.fts(english).impossible)" `shouldRespondWith`
             [json|[
               {"text_search_vector": "'fun':5 'imposs':9 'kind':3" },
               {"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4" },

--- a/test/Feature/PgVersion96Spec.hs
+++ b/test/Feature/PgVersion96Spec.hs
@@ -49,17 +49,17 @@ spec =
 
     context "Use of the phraseto_tsquery function" $ do
       it "finds matches" $
-        get "/tsearch?text_search_vector=phrase.fts.The%20Fat%20Cats" `shouldRespondWith`
+        get "/tsearch?text_search_vector=phfts.The%20Fat%20Cats" `shouldRespondWith`
           [json| [{"text_search_vector": "'ate':3 'cat':2 'fat':1 'rat':4" }] |]
           { matchHeaders = [matchContentTypeJson] }
 
       it "finds matches with different dictionaries" $
-        get "/tsearch?text_search_vector=phrase.german.fts.Art%20Spass" `shouldRespondWith`
+        get "/tsearch?text_search_vector=phfts(german).Art%20Spass" `shouldRespondWith`
           [json| [{"text_search_vector": "'art':4 'spass':5 'unmog':7" }] |]
           { matchHeaders = [matchContentTypeJson] }
 
       it "can be negated with not operator" $
-        get "/tsearch?text_search_vector=not.phrase.english.fts.The%20Fat%20Cats" `shouldRespondWith`
+        get "/tsearch?text_search_vector=not.phfts(english).The%20Fat%20Cats" `shouldRespondWith`
           [json| [
             {"text_search_vector": "'fun':5 'imposs':9 'kind':3"},
             {"text_search_vector": "'also':2 'fun':3 'possibl':8"},
@@ -68,32 +68,14 @@ spec =
           { matchHeaders = [matchContentTypeJson] }
 
       it "can be used with or query param" $
-        get "/tsearch?or=(text_search_vector.phrase.german.fts.Art%20Spass, text_search_vector.phrase.french.fts.amusant, text_search_vector.english.fts.impossible)" `shouldRespondWith`
+        get "/tsearch?or=(text_search_vector.phfts(german).Art%20Spass, text_search_vector.phfts(french).amusant, text_search_vector.fts(english).impossible)" `shouldRespondWith`
           [json|[
             {"text_search_vector": "'fun':5 'imposs':9 'kind':3" },
             {"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4" },
             {"text_search_vector": "'art':4 'spass':5 'unmog':7"}
           ]|] { matchHeaders = [matchContentTypeJson] }
 
-      -- TODO: remove in 0.5.0 as deprecated
-      it "Deprecated @@ operator, pending to remove" $ do
-        get "/tsearch?text_search_vector=phrase.@@.The%20Fat%20Cats" `shouldRespondWith`
-          [json| [{"text_search_vector": "'ate':3 'cat':2 'fat':1 'rat':4" }] |]
-          { matchHeaders = [matchContentTypeJson] }
-        get "/tsearch?text_search_vector=not.phrase.english.@@.The%20Fat%20Cats" `shouldRespondWith`
-          [json| [
-            {"text_search_vector": "'fun':5 'imposs':9 'kind':3"},
-            {"text_search_vector": "'also':2 'fun':3 'possibl':8"},
-            {"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4"},
-            {"text_search_vector": "'art':4 'spass':5 'unmog':7"}]|]
-          { matchHeaders = [matchContentTypeJson] }
-
-    context "GET rpc" $
-      it "should work with phrase fts" $ do
-        get "/rpc/get_tsearch?text_search_vector=phrase.english.fts.impossible" `shouldRespondWith`
-          [json|[{"text_search_vector":"'fun':5 'imposs':9 'kind':3"}]|]
-          { matchHeaders = [matchContentTypeJson] }
-        -- TODO: '@@' deprecated
-        get "/rpc/get_tsearch?text_search_vector=phrase.english.@@.impossible" `shouldRespondWith`
+      it "should work when used with GET RPC" $
+        get "/rpc/get_tsearch?text_search_vector=phfts(english).impossible" `shouldRespondWith`
           [json|[{"text_search_vector":"'fun':5 'imposs':9 'kind':3"}]|]
           { matchHeaders = [matchContentTypeJson] }

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -112,15 +112,15 @@ spec = do
           { matchHeaders = [matchContentTypeJson] }
 
       it "finds matches with plainto_tsquery" $
-        get "/tsearch?text_search_vector=plain.fts.The%20Fat%20Rats" `shouldRespondWith`
+        get "/tsearch?text_search_vector=plfts.The%20Fat%20Rats" `shouldRespondWith`
           [json| [ {"text_search_vector": "'ate':3 'cat':2 'fat':1 'rat':4" }] |]
           { matchHeaders = [matchContentTypeJson] }
 
       it "finds matches with different dictionaries" $ do
-        get "/tsearch?text_search_vector=french.fts.amusant" `shouldRespondWith`
+        get "/tsearch?text_search_vector=fts(french).amusant" `shouldRespondWith`
           [json| [{"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4" }] |]
           { matchHeaders = [matchContentTypeJson] }
-        get "/tsearch?text_search_vector=plain.french.fts.amusant%20impossible" `shouldRespondWith`
+        get "/tsearch?text_search_vector=plfts(french).amusant%20impossible" `shouldRespondWith`
           [json| [{"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4" }] |]
           { matchHeaders = [matchContentTypeJson] }
 
@@ -130,12 +130,12 @@ spec = do
             {"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4"},
             {"text_search_vector": "'art':4 'spass':5 'unmog':7"}]|]
           { matchHeaders = [matchContentTypeJson] }
-        get "/tsearch?text_search_vector=not.english.fts.impossible%7Cfat%7Cfun" `shouldRespondWith`
+        get "/tsearch?text_search_vector=not.fts(english).impossible%7Cfat%7Cfun" `shouldRespondWith`
           [json| [
             {"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4"},
             {"text_search_vector": "'art':4 'spass':5 'unmog':7"}]|]
           { matchHeaders = [matchContentTypeJson] }
-        get "/tsearch?text_search_vector=not.plain.fts.The%20Fat%20Rats" `shouldRespondWith`
+        get "/tsearch?text_search_vector=not.plfts.The%20Fat%20Rats" `shouldRespondWith`
           [json| [
             {"text_search_vector": "'fun':5 'imposs':9 'kind':3"},
             {"text_search_vector": "'also':2 'fun':3 'possibl':8"},
@@ -148,23 +148,13 @@ spec = do
         get "/tsearch?text_search_vector=@@.impossible" `shouldRespondWith`
           [json| [{"text_search_vector": "'fun':5 'imposs':9 'kind':3" }] |]
           { matchHeaders = [matchContentTypeJson] }
-        get "/tsearch?text_search_vector=plain.@@.The%20Fat%20Rats" `shouldRespondWith`
-          [json| [ {"text_search_vector": "'ate':3 'cat':2 'fat':1 'rat':4" }] |]
-          { matchHeaders = [matchContentTypeJson] }
         get "/tsearch?text_search_vector=not.@@.impossible%7Cfat%7Cfun" `shouldRespondWith`
           [json| [
             {"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4"},
             {"text_search_vector": "'art':4 'spass':5 'unmog':7"}]|]
           { matchHeaders = [matchContentTypeJson] }
-        get "/tsearch?text_search_vector=not.english.@@.impossible%7Cfat%7Cfun" `shouldRespondWith`
+        get "/tsearch?text_search_vector=not.@@(english).impossible%7Cfat%7Cfun" `shouldRespondWith`
           [json| [
-            {"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4"},
-            {"text_search_vector": "'art':4 'spass':5 'unmog':7"}]|]
-          { matchHeaders = [matchContentTypeJson] }
-        get "/tsearch?text_search_vector=not.plain.@@.The%20Fat%20Rats" `shouldRespondWith`
-          [json| [
-            {"text_search_vector": "'fun':5 'imposs':9 'kind':3"},
-            {"text_search_vector": "'also':2 'fun':3 'possibl':8"},
             {"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4"},
             {"text_search_vector": "'art':4 'spass':5 'unmog':7"}]|]
           { matchHeaders = [matchContentTypeJson] }
@@ -548,7 +538,7 @@ spec = do
         { matchHeaders = [matchContentTypeJson] }
 
     it "fails if an operator is not given" $
-      get "/ghostBusters?id=0" `shouldRespondWith` [json| {"details":"unexpected end of input expecting operator (eq, gt, ...)","message":"\"failed to parse filter (0)\" (line 1, column 2)"} |]
+      get "/ghostBusters?id=0" `shouldRespondWith` [json| {"details":"unexpected \"0\" expecting \"not\" or operator (eq, gt, ...)","message":"\"failed to parse filter (0)\" (line 1, column 1)"} |]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -325,22 +325,19 @@ spec =
           { matchHeaders = [matchContentTypeJson] }
 
       it "should work with filters that use the plain with language fts operator" $ do
-        get "/rpc/get_tsearch?text_search_vector=english.fts.impossible" `shouldRespondWith`
+        get "/rpc/get_tsearch?text_search_vector=fts(english).impossible" `shouldRespondWith`
           [json|[{"text_search_vector":"'fun':5 'imposs':9 'kind':3"}]|]
           { matchHeaders = [matchContentTypeJson] }
-        get "/rpc/get_tsearch?text_search_vector=plain.fts.impossible" `shouldRespondWith`
+        get "/rpc/get_tsearch?text_search_vector=plfts.impossible" `shouldRespondWith`
           [json|[{"text_search_vector":"'fun':5 'imposs':9 'kind':3"}]|]
           { matchHeaders = [matchContentTypeJson] }
-        get "/rpc/get_tsearch?text_search_vector=not.english.fts.fun%7Crat" `shouldRespondWith`
+        get "/rpc/get_tsearch?text_search_vector=not.fts(english).fun%7Crat" `shouldRespondWith`
           [json|[{"text_search_vector":"'amus':5 'fair':7 'impossibl':9 'peu':4"},{"text_search_vector":"'art':4 'spass':5 'unmog':7"}]|]
           { matchHeaders = [matchContentTypeJson] }
         -- TODO: '@@' deprecated
-        get "/rpc/get_tsearch?text_search_vector=english.@@.impossible" `shouldRespondWith`
+        get "/rpc/get_tsearch?text_search_vector=@@(english).impossible" `shouldRespondWith`
           [json|[{"text_search_vector":"'fun':5 'imposs':9 'kind':3"}]|]
           { matchHeaders = [matchContentTypeJson] }
-        get "/rpc/get_tsearch?text_search_vector=plain.@@.impossible" `shouldRespondWith`
-          [json|[{"text_search_vector":"'fun':5 'imposs':9 'kind':3"}]|]
-          { matchHeaders = [matchContentTypeJson] }
-        get "/rpc/get_tsearch?text_search_vector=not.english.@@.fun%7Crat" `shouldRespondWith`
+        get "/rpc/get_tsearch?text_search_vector=not.@@(english).fun%7Crat" `shouldRespondWith`
           [json|[{"text_search_vector":"'amus':5 'fair':7 'impossibl':9 'peu':4"},{"text_search_vector":"'art':4 'spass':5 'unmog':7"}]|]
           { matchHeaders = [matchContentTypeJson] }


### PR DESCRIPTION
Changes the syntax for `phrase/plain` introduced in #964.

Previous syntax:
```http
GET /tsearch?tsv=french.fts.amusant
GET /tsearch?tsv=plain.german.fts.Art%20Spass
GET /tsearch?tsv=phrase.english.fts.The%20Fat%20Cats
```
New syntax:
```http
GET /tsearch?tsv=fts(french).amusant
GET /tsearch?tsv=plfts(german).Art%20Spass
GET /tsearch?tsv=phfts(english).The%20Fat%20Cats
```
New syntax is a bit shorter, it's more alike to the pg `{plain/phrase}to_tsquery` functions in that the first arg is the language(previous one has the language between plain/phrase and fts) and also it's more consistent because dots `.` are currently used like separators and the `(language)` fits better as an optional argument.

Also have to mention that having `not.english..` was kinda confusing inside `and/or` operations, I think overall this new syntax is better and in addition it makes the code simpler.