### PR TITLE
Include git sha in version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #328, Allow doing GET on rpc - @steve-chavez
 - #917, Add ability to map RAISE errorcode/message to http status - @steve-chavez
 - #940, Add ability to map GUC to http response headers - @steve-chavez
+- #1022, Include git sha in version report - @begriffs
 
 ### Fixed
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -58,6 +58,7 @@ library
                      , containers
                      , contravariant
                      , either
+                     , gitrev
                      , hasql
                      , hasql-pool == 0.4.1
                      , hasql-transaction == 0.5

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase, TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 {-|
 Module      : PostgREST.Config
@@ -42,15 +42,16 @@ import           Data.Scientific              (floatingOrInteger)
 import           Data.String                  (String)
 import           Data.Text                    (dropAround,
                                                intercalate, lines,
-                                               strip)
+                                               strip, take)
 import           Data.Text.Encoding           (encodeUtf8)
 import           Data.Text.IO                 (hPutStrLn)
 import           Data.Version                 (versionBranch)
+import           Development.GitRev
 import           Network.Wai
 import           Network.Wai.Middleware.Cors  (CorsResourcePolicy (..))
 import           Options.Applicative          hiding (str)
 import           Paths_postgrest              (version)
-import           Protolude                    hiding (hPutStrLn,
+import           Protolude                    hiding (hPutStrLn, take,
                                                intercalate, (<>))
 import           System.IO                    (hPrint)
 import           System.IO.Error              (IOError)
@@ -102,7 +103,9 @@ corsPolicy req = case lookup "origin" headers of
 
 -- | User friendly version number
 prettyVersion :: Text
-prettyVersion = intercalate "." $ map show $ versionBranch version
+prettyVersion =
+  (intercalate "." $ map show $ versionBranch version)
+  <> " (" <> take 7 $(gitHash) <> ")"
 
 -- | Version number used in docs
 docsVersion :: Text

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -104,7 +104,7 @@ corsPolicy req = case lookup "origin" headers of
 -- | User friendly version number
 prettyVersion :: Text
 prettyVersion =
-  (intercalate "." $ map show $ versionBranch version)
+  intercalate "." (map show $ versionBranch version)
   <> " (" <> take 7 $(gitHash) <> ")"
 
 -- | Version number used in docs

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -46,7 +46,7 @@ import           Data.Text                    (dropAround,
 import           Data.Text.Encoding           (encodeUtf8)
 import           Data.Text.IO                 (hPutStrLn)
 import           Data.Version                 (versionBranch)
-import           Development.GitRev
+import           Development.GitRev           (gitHash)
 import           Network.Wai
 import           Network.Wai.Middleware.Cors  (CorsResourcePolicy (..))
 import           Options.Applicative          hiding (str)


### PR DESCRIPTION
When people submit a bug report for a custom binary they built off master it would be helpful to know exactly which git hash they built from. This helps us debug problems better.

This pull request adds the first seven characters of the git sha to the version output in the Server response header and also the usage screen.