### PR TITLE
Reduce memory usage of bulk inserts

### DIFF
--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -49,6 +49,12 @@ spec = do
           , matchHeaders = [matchContentTypeJson]
           }
 
+    context "non uniform json array" $ do
+      it "rejects json array that isn't exclusivily composed of objects" $
+        post "/articles" [json| [{"id": 100, "body": "xxxxx"}, 123, "xxxx", {"id": 111, "body": "xxxx"}] |] `shouldRespondWith` 400
+      it "rejects json array that has objects with different keys" $
+        post "/articles" [json| [{"id": 100, "body": "xxxxx"}, {"id": 111, "body": "xxxx", "owner": "me"}] |] `shouldRespondWith` 400
+
     context "requesting full representation" $ do
       it "includes related data after insert" $
         request methodPost "/projects?select=id,name,clients{id,name}"

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -62,6 +62,7 @@ GRANT ALL ON TABLE
     , being_part
     , part
     , leak
+    , perf_articles
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1351,4 +1351,9 @@ create table test.leak(
   blob bytea
 );
 
-CREATE FUNCTION test.leak(blob bytea) RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+create function test.leak(blob bytea) returns void as $$ begin end; $$ language plpgsql;
+
+create table test.perf_articles(
+  id integer not null,
+  body text not null
+);

--- a/test/memory-tests.sh
+++ b/test/memory-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 currentTest=1
 failedTests=0
 result(){ echo "$1 $currentTest $2"; currentTest=$(( $currentTest + 1 )); }
@@ -9,10 +9,7 @@ pgrPort=49421
 
 pgrStopAll(){ pkill -f "$(stack path --local-install-root)/bin/postgrest"; }
 
-pgrStart(){
-  stack build --profile
-  stack exec -- postgrest test/memory-tests/config +RTS -p -h >/dev/null & pgrPID="$!";
-}
+pgrStart(){ stack exec -- postgrest test/memory-tests/config +RTS -p -h >/dev/null & pgrPID="$!"; }
 pgrStop(){ kill "$pgrPID" 2>/dev/null; }
 
 setUp(){ pgrStopAll; }
@@ -29,7 +26,7 @@ rootStatus(){
   curl -s -o /dev/null -I -w '%{http_code}' "http://localhost:$pgrPort/"
 }
 
-memoryTest(){
+jsonKeyTest(){
   pgrStart
   checkPgrStarted
   factor=$(( 3*$(numfmt --from=si $1)/4 )) # 3/4 on $1 is need to maintain the specified size because of base64
@@ -47,9 +44,9 @@ memoryTest(){
     MAX_BYTES=$(numfmt --from=si $4)
     if test $BYTES -le $MAX_BYTES
     then
-      ok "$2 $3: with a $1 payload size the memory usage($BYTES_FMT bytes) is less than $4"
+      ok "$2 $3: with a json key of $1 the memory usage($BYTES_FMT bytes) is less than $4"
     else
-      ko "$2 $3: with a $1 payload size the memory usage($BYTES_FMT bytes) is more than $4"
+      ko "$2 $3: with a json key of $1 the memory usage($BYTES_FMT bytes) is more than $4"
     fi
   else
     pgrStop
@@ -57,21 +54,63 @@ memoryTest(){
   fi
 }
 
+postJsonArrayTest(){
+  pgrStart
+  checkPgrStarted
+  arr=()
+  arr+=('[')
+  for i in $(seq 1 $(expr $1 - 1))
+  do
+    arr+=("{\"id\": $i, \"body\": \"xxxxxxx\"},")
+  done
+  arr+=("{\"id\": $1, \"body\": \"xxxxxxx\"}")
+  arr+=(']')
+  payload=$(echo ${arr[*]})
+  httpStatus=$(echo $payload | curl -s -H "Content-Type: application/json" -d @- -w '%{http_code}' http://localhost:$pgrPort$2 | tr -d '"')
+  if test "$httpStatus" -ge 200 && test "$httpStatus" -lt 210
+  then
+    pgrStop
+    while [ ! -s postgrest.prof ]
+    do
+      sleep 1
+    done
+    BYTES_FMT=$(cat postgrest.prof | grep -o -P '(?<=alloc =).*(?=bytes)' | tr -d ' ')
+    BYTES=$(echo $BYTES_FMT | tr -d ',')
+    MAX_BYTES=$(numfmt --from=si $3)
+    PAYLOAD_SIZE=$(echo $payload | wc -c | numfmt --to=si)
+    if test $BYTES -le $MAX_BYTES
+    then
+      ok "POST $2: with a json payload of $PAYLOAD_SIZE that has $1 array values the memory usage($BYTES_FMT bytes) is less than $3"
+    else
+      ko "POST $2: with a json payload of $PAYLOAD_SIZE that has $1 array values the memory usage($BYTES_FMT bytes) is more than $3"
+    fi
+  else
+    pgrStop
+    ko "POST $2: request failed with http $httpStatus"
+  fi
+}
+
+stack build --profile
+
 setUp
 
 echo "Running memory usage tests.."
 
-memoryTest "1M" "POST" "/rpc/leak" "15M"
-memoryTest "1M" "POST" "/leak" "15M"
-memoryTest "1M" "PATCH" "/leak?id=eq.1" "15M"
+jsonKeyTest "1M" "POST" "/rpc/leak" "15M"
+jsonKeyTest "1M" "POST" "/leak" "15M"
+jsonKeyTest "1M" "PATCH" "/leak?id=eq.1" "15M"
 
-memoryTest "10M" "POST" "/rpc/leak" "105M"
-memoryTest "10M" "POST" "/leak" "105M"
-memoryTest "10M" "PATCH" "/leak?id=eq.1" "105M"
+jsonKeyTest "10M" "POST" "/rpc/leak" "105M"
+jsonKeyTest "10M" "POST" "/leak" "105M"
+jsonKeyTest "10M" "PATCH" "/leak?id=eq.1" "105M"
 
-memoryTest "100M" "POST" "/rpc/leak" "895M"
-memoryTest "100M" "POST" "/leak" "895M"
-memoryTest "100M" "PATCH" "/leak?id=eq.1" "895M"
+jsonKeyTest "100M" "POST" "/rpc/leak" "895M"
+jsonKeyTest "100M" "POST" "/leak" "895M"
+jsonKeyTest "100M" "PATCH" "/leak?id=eq.1" "895M"
+
+postJsonArrayTest "1000" "/perf_articles" "20M"
+postJsonArrayTest "10000" "/perf_articles" "120M"
+postJsonArrayTest "100000" "/perf_articles" "1.15G"
 
 cleanUp
 


### PR DESCRIPTION
For #690, currently when POSTing a json payload of 3.4M that has 100000 array values, we get a `41G` memory usage:

<details>
<summary>Master branch profile report</summary>
<pre>

  total time  =       10.41 secs   (10414 ticks @ 1000 us, 1 processor)
  total alloc = 41,337,480,760 bytes  (excludes profiling overheads)


COST CENTRE              MODULE                         SRC                                                 %time %alloc

basicUnsafeNew           Data.Vector.Mutable            Data/Vector/Mutable.hs:(99,3)-(102,32)               58.5   96.9
basicUnsafeCopy          Data.Vector                    Data/Vector.hs:(280,3)-(281,29)                      23.5    0.0
">>=.\.succ'"            Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:146:13-76           6.7    0.7
">>=.\"                  Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:(146,9)-(147,44)    4.7    0.9
payloadAttributes.objs.\ PostgREST.ApiRequest           src/PostgREST/ApiRequest.hs:(283,36)-(285,33)         1.2    0.1
</pre>
</details>
</br>

Basically the overhead comes from allocating memory for JSON objects [here](https://github.com/begriffs/postgrest/blob/master/src/PostgREST/ApiRequest.hs#L281-L286)(if you guys would like to run the same perf test on master just cherry-pick 7da02a50d886b646107a9bd6d63b6ce6fa38d084 and then do `./test/memory-tests.sh` and then see the generated `postgrest.prof`)

I've managed to do the same uniform json array validation(added tests to make sure) without that extra allocation and reduced the usage to `1.1G`(this is what I get locally, somehow when running the test in CircleCI is even less, about `617M`)

<details>
<summary>PR branch profile report</summary>
<pre>

	total time  =        1.54 secs   (1538 ticks @ 1000 us, 1 processor)
	total alloc = 1,101,059,440 bytes  (excludes profiling overheads)


COST CENTRE                        MODULE                         SRC                                                 %time %alloc

">>=.\.succ'"                      Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:146:13-76          41.9   24.6
">>=.\"                            Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:(146,9)-(147,44)   25.7   32.0
">>="                              Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:(145,5)-(147,44)    5.1    0.0
pure.\                             Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:183:49-65           4.5    2.0
fmap.\.succ'                       Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:171:11-58           4.0   14.2
fmap.\                             Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:(171,7)-(172,42)    3.2    8.3
"*>"                               Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:187:5-26            3.2    3.9
pure                               Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:183:5-65            2.3    0.0
decimal0.step                      Data.Aeson.Parser.Internal     Data/Aeson/Parser/Internal.hs:313:7-49                1.9    1.8
"<*.\"                             Data.Attoparsec.Internal.Types Data/Attoparsec/Internal/Types.hs:189:26-36           1.5    3.6
">>="                              Data.Vector.Fusion.Util        Data/Vector/Fusion/Util.hs:36:3-18                    0.8    1.2
payloadAttributes.areKeysUniform.\ PostgREST.ApiRequest           src/PostgREST/ApiRequest.hs:286:34-58                 0.7    1.3
</pre>
</details>
</br>

It's an improvement but the memory usage is still high, so maybe #690 should be left open.
I tried another approach first that didn't do any JSON processing and passed the payload directly to PostgreSQL, but got stuck on one test failure(branch with some comments [here](https://github.com/steve-chavez/postgrest/commit/5ceb59152e02275246ad4b5b879ead36cf529e6b#r26841068) just in case).

Anyway this improvement might be good enough for now.