### PR TITLE
Add tables aliasing to avoid conflict in embeds with self reference fks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #828, Fix computed column only working in public schema - @steve-chavez
 - #925, Fix RPC high memory usage by using parametrized query and avoiding json encoding - @steve-chavez
+- #987, Fix embedding with self-reference foreign key - @steve-chavez
 
 ### Changed
 

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -149,9 +149,10 @@ data Relation = Relation {
 , relFTable   :: Table
 , relFColumns :: [Column]
 , relType     :: RelationType
-, relLTable   :: Maybe Table
-, relLCols1   :: Maybe [Column]
-, relLCols2   :: Maybe [Column]
+-- The Link attrs are used when RelationType == Many
+, relLinkTable   :: Maybe Table
+, relLinkCols1   :: Maybe [Column]
+, relLinkCols2   :: Maybe [Column]
 } deriving (Show, Eq)
 
 -- | Cached attributes of a JSON payload
@@ -215,8 +216,7 @@ ftsOperators = M.fromList [
 data OpExpr = OpExpr Bool Operation deriving (Eq, Show)
 data Operation = Op Operator SingleVal |
                  In ListVal |
-                 Fts Operator (Maybe Language) SingleVal |
-                 Join QualifiedIdentifier ForeignKey deriving (Eq, Show)
+                 Fts Operator (Maybe Language) SingleVal deriving (Eq, Show)
 type Language = Text
 
 -- | Represents a single value in a filter, e.g. id=eq.singleval
@@ -274,8 +274,9 @@ type SelectItem = (Field, Maybe Cast, Maybe Alias, Maybe RelationDetail)
 -- | Path of the embedded levels, e.g "clients.projects.name=eq.." gives Path ["clients", "projects"]
 type EmbedPath = [Text]
 data Filter = Filter { field::Field, opExpr::OpExpr } deriving (Show, Eq)
+data JoinCond = JoinCond (QualifiedIdentifier, FieldName) (QualifiedIdentifier, FieldName) deriving (Show, Eq)
 
-data ReadQuery = Select { select::[SelectItem], from::[TableName], where_::[LogicTree], order::Maybe [OrderTerm], range_::NonnegRange } deriving (Show, Eq)
+data ReadQuery = Select { select::[SelectItem], from::[TableName], where_::[LogicTree], joinConds::[JoinCond], order::[OrderTerm], range_::NonnegRange } deriving (Show, Eq)
 data MutateQuery = Insert { in_::TableName, insPkCols::[Text], qPayload::PayloadJSON, onConflict:: Maybe PreferResolution, where_::[LogicTree], returning::[FieldName] }
                  | Delete { in_::TableName, where_::[LogicTree], returning::[FieldName] }
                  | Update { in_::TableName, qPayload::PayloadJSON, where_::[LogicTree], returning::[FieldName] } deriving (Show, Eq)

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -274,13 +274,14 @@ type SelectItem = (Field, Maybe Cast, Maybe Alias, Maybe RelationDetail)
 -- | Path of the embedded levels, e.g "clients.projects.name=eq.." gives Path ["clients", "projects"]
 type EmbedPath = [Text]
 data Filter = Filter { field::Field, opExpr::OpExpr } deriving (Show, Eq)
-data JoinCond = JoinCond (QualifiedIdentifier, FieldName) (QualifiedIdentifier, FieldName) deriving (Show, Eq)
+data JoinCond = JoinCond (QualifiedIdentifier, FieldName, Level) (QualifiedIdentifier, FieldName, Level) deriving (Show, Eq)
+type Level = Integer
 
 data ReadQuery = Select { select::[SelectItem], from::[TableName], where_::[LogicTree], joinConds::[JoinCond], order::[OrderTerm], range_::NonnegRange } deriving (Show, Eq)
 data MutateQuery = Insert { in_::TableName, insPkCols::[Text], qPayload::PayloadJSON, onConflict:: Maybe PreferResolution, where_::[LogicTree], returning::[FieldName] }
                  | Delete { in_::TableName, where_::[LogicTree], returning::[FieldName] }
                  | Update { in_::TableName, qPayload::PayloadJSON, where_::[LogicTree], returning::[FieldName] } deriving (Show, Eq)
-type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe RelationDetail))
+type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe RelationDetail, Level))
 type ReadRequest = Tree ReadNode
 type MutateRequest = MutateQuery
 data DbRequest = DbRead ReadRequest | DbMutate MutateRequest

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -346,3 +346,16 @@ INSERT INTO tiobe_pls VALUES ('Java', 1), ('C', 2), ('Python', 4);
 
 TRUNCATE TABLE only_pk CASCADE;
 INSERT INTO only_pk VALUES (1), (2);
+
+TRUNCATE TABLE family_tree CASCADE;
+INSERT INTO family_tree VALUES ('1', 'Parental Unit', NULL);
+INSERT INTO family_tree VALUES ('2', 'Kid One', '1');
+INSERT INTO family_tree VALUES ('3', 'Kid Two', '1');
+INSERT INTO family_tree VALUES ('4', 'Grandkid One', '2');
+INSERT INTO family_tree VALUES ('5', 'Grandkid Two', '3');
+
+TRUNCATE TABLE organizations CASCADE;
+INSERT INTO organizations VALUES (1, 'Referee Org', null, null);
+INSERT INTO organizations VALUES (2, 'Auditor Org', null, null);
+INSERT INTO organizations VALUES (3, 'Acme', 1, 2);
+INSERT INTO organizations VALUES (4, 'Umbrella', 1, 2);

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -66,6 +66,8 @@ GRANT ALL ON TABLE
     , employees
     , tiobe_pls
     , only_pk
+    , family_tree
+    , organizations
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1374,3 +1374,19 @@ create table test.tiobe_pls(
   name text primary key,
   rank smallint
 );
+
+create table test.family_tree (
+  id text not null primary key,
+  name text not null,
+  parent text
+);
+alter table only test.family_tree add constraint pptr foreign key (parent) references test.family_tree(id);
+
+create table test.organizations (
+  id integer primary key,
+  name text,
+  referee integer,
+  auditor integer
+);
+alter table only test.organizations add constraint pptr1 foreign key (referee) references test.organizations(id);
+alter table only test.organizations add constraint pptr2 foreign key (auditor) references test.organizations(id);


### PR DESCRIPTION
Fixes #987.  Using the `family_tree` TABLE provided in https://github.com/begriffs/postgrest/issues/987#issue-260720899 we do a: 
`GET /family_tree?id=eq.3&select=family_tree.parent(*)` and currently this generates the following query:
```sql
SELECT COALESCE((
  SELECT array_to_json(array_agg(row_to_json("family_tree"))) 
  FROM (
    SELECT  "test"."family_tree".* FROM  "test"."family_tree"  
    WHERE  "test"."family_tree"."parent" = "test"."family_tree"."id") "family_tree"),
 '[]') AS "family_tree" FROM  "test"."family_tree"  WHERE  "test"."family_tree"."id" = '3'::unknown;
-- Gives []
-- It should give [{"id":"5","name":"Grandkid Two","parent":"3"}]   
```
The problem is that the subquery should be referring to the parent `"test"."family_tree"`, to get the correct result the query should be like:
```sql
SELECT COALESCE((
  SELECT array_to_json(array_agg(row_to_json("family_tree"))) 
  FROM (
    SELECT  "test"."family_tree".* FROM  "test"."family_tree"  
    WHERE  "test"."family_tree"."parent" = x."id") "family_tree"),
 '[]') AS "family_tree" FROM  "test"."family_tree" x  WHERE  x."id" = '3'::unknown;
-- Gives [{"id":"5","name":"Grandkid Two","parent":"3"}]
```
So to solve this the parent `"test"."family_tree"` needs to be aliased.
To generalize the fix I initially thought of adding an uuid alias to every FROM but what I've done is to add a `Level` attribute to the `ReadNode` type that represents the level of the tree where the node is at and then when building the query the FROM target can be aliased as `target_{level}`.