### PR TITLE
Add the postgREST process' environment to the DB's SESSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Computed columns now only work if they belong to the db-schema - @steve-chavez
 - To use RPC now the `json_to_record/json_to_recordset` functions are needed, these are available starting from PostgreSQL 9.4 - @steve-chavez
 - Overloaded functions now depend on the `dbStructure`, restart/sighup may be needed for their correct functioning - @steve-chavez
+- The configuration (e.g. `postgrest.conf`) now accepts arbitrary settings that will be passed through as session-local database settings. This can be used to pass in secret keys directly as strings, or via OS environment variables. For instance: `app.settings.jwt_secret = "$(MYAPP_JWT_SECRET)"` will take `MYAPP_JWT_SECRET` from the environment and make it available to postgresql functions as `current_setting('app.settings.jwt_secret')`. Only `app.settings.*` values in the configuration file are treated in this way. - @canadaduane
 
 ## [0.4.4.0] - 2018-01-08
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -76,13 +76,13 @@ connectionWorker mainTid pool schema settings refDbStructure refIsWorkerOn = do
       connected <- connectingSucceeded pool
       when connected $ do
         result <- P.use pool $ do
-          fillSessionWithSettings settings
           actualPgVersion <- getPgVersion
           unless (actualPgVersion >= minimumPgVersion) $ liftIO $ do
             hPutStrLn stderr
               ("Cannot run in this PostgreSQL version, PostgREST needs at least "
               <> pgvName minimumPgVersion)
             killThread mainTid
+          fillSessionWithSettings settings
           dbStructure <- getDbStructure schema actualPgVersion
           liftIO $ atomicWriteIORef refDbStructure $ Just dbStructure
         case result of

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -64,7 +64,7 @@ connectionWorker
   -> IORef (Maybe DbStructure) -- ^ mutable reference to 'DbStructure'
   -> IORef Bool                -- ^ Used as a binary Semaphore
   -> IO ()
-connectionWorker mainTid pool schema environ refDbStructure refIsWorkerOn = do
+connectionWorker mainTid pool schema settings refDbStructure refIsWorkerOn = do
   isWorkerOn <- readIORef refIsWorkerOn
   unless isWorkerOn $ do
     atomicWriteIORef refIsWorkerOn True
@@ -76,7 +76,7 @@ connectionWorker mainTid pool schema environ refDbStructure refIsWorkerOn = do
       connected <- connectingSucceeded pool
       when connected $ do
         result <- P.use pool $ do
-          fillSessionWithSettings environ
+          fillSessionWithSettings settings
           actualPgVersion <- getPgVersion
           unless (actualPgVersion >= minimumPgVersion) $ liftIO $ do
             hPutStrLn stderr

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -7,7 +7,8 @@ import           PostgREST.App            (postgrest)
 import           PostgREST.Config         (AppConfig (..),
                                            minimumPgVersion,
                                            prettyVersion, readOptions)
-import           PostgREST.DbStructure    (getDbStructure, getPgVersion, fillSessionWithEnvironment)
+import           PostgREST.DbStructure    (getDbStructure, getPgVersion,
+                                           fillSessionWithSettings)
 import           PostgREST.Error          (encodeError)
 import           PostgREST.OpenAPI        (isMalformedProxyUri)
 import           PostgREST.Types          (DbStructure, Schema, PgVersion(..))
@@ -32,7 +33,7 @@ import           Network.Wai.Handler.Warp (defaultSettings,
                                            setTimeout)
 import           System.IO                (BufferMode (..),
                                            hSetBuffering)
-import           System.Environment       (getEnvironment)
+
 #ifndef mingw32_HOST_OS
 import           System.Posix.Signals
 #endif
@@ -59,10 +60,11 @@ connectionWorker
   :: ThreadId -- ^ This thread is killed if pg version is unsupported
   -> P.Pool   -- ^ The PostgreSQL connection pool
   -> Schema   -- ^ Schema PostgREST is serving up
+  -> [(Text, Text)] -- ^ Settings or Environment passed in through the config
   -> IORef (Maybe DbStructure) -- ^ mutable reference to 'DbStructure'
   -> IORef Bool                -- ^ Used as a binary Semaphore
   -> IO ()
-connectionWorker mainTid pool schema refDbStructure refIsWorkerOn = do
+connectionWorker mainTid pool schema environ refDbStructure refIsWorkerOn = do
   isWorkerOn <- readIORef refIsWorkerOn
   unless isWorkerOn $ do
     atomicWriteIORef refIsWorkerOn True
@@ -70,12 +72,11 @@ connectionWorker mainTid pool schema refDbStructure refIsWorkerOn = do
   where
     work = do
       atomicWriteIORef refDbStructure Nothing
-      environ <- getEnvironment
       putStrLn ("Attempting to connect to the database..." :: Text)
       connected <- connectingSucceeded pool
       when connected $ do
         result <- P.use pool $ do
-          fillSessionWithEnvironment environ
+          fillSessionWithSettings environ
           actualPgVersion <- getPgVersion
           unless (actualPgVersion >= minimumPgVersion) $ liftIO $ do
             hPutStrLn stderr
@@ -176,6 +177,7 @@ main = do
     mainTid
     pool
     (configSchema conf)
+    (configSettings conf)
     refDbStructure
     refIsWorkerOn
   --
@@ -198,6 +200,7 @@ main = do
               mainTid
               pool
               (configSchema conf)
+              (configSettings conf)
               refDbStructure
               refIsWorkerOn
     ) Nothing
@@ -214,6 +217,7 @@ main = do
          mainTid
          pool
          (configSchema conf)
+         (configSettings conf)
          refDbStructure
          refIsWorkerOn)
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -57,6 +57,7 @@ library
                      , configurator-ng == 0.0.0.1
                      , containers
                      , contravariant
+                     , contravariant-extras
                      , either
                      , gitrev
                      , hasql

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -168,9 +168,9 @@ readOptions = do
     coerceInt (String x) = readMaybe $ toS x
     coerceInt _          = Nothing
 
-    coerceBool ::  Value -> Maybe Bool
+    coerceBool :: Value -> Maybe Bool
     coerceBool (Bool b)   = Just b
-    coerceBool (String x) = readMaybe $ toS x
+    coerceBool (String b) = readMaybe $ toS b
     coerceBool _          = Nothing
 
     opts = info (helper <*> pathParser) $

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -227,7 +227,7 @@ pathParser =
 
 -- | Tells the minimum PostgreSQL version required by this version of PostgREST
 minimumPgVersion :: PgVersion
-minimumPgVersion = PgVersion 90300 "9.3"
+minimumPgVersion = PgVersion 90400 "9.4"
 
 pgVersion96 :: PgVersion
 pgVersion96 = PgVersion 90600 "9.6"

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -76,6 +76,7 @@ data AppConfig = AppConfig {
   , configMaxRows           :: Maybe Integer
   , configReqCheck          :: Maybe Text
   , configQuiet             :: Bool
+  , configSettings          :: [(Text, Text)]
   }
 
 defaultCorsPolicy :: CorsResourcePolicy
@@ -136,6 +137,7 @@ readOptions = do
           <*> (join . fmap coerceInt <$> C.key "max-rows")
           <*> (mfilter (/= "") <$> C.key "pre-request")
           <*> pure False
+          <*> (fmap parsedPairToTextPair <$> C.subassocs "app.settings")
 
   case mAppConf of
     Nothing -> do
@@ -145,6 +147,13 @@ readOptions = do
       return appConf
 
   where
+    parsedPairToTextPair :: (Name, Value) -> (Text, Text)
+    parsedPairToTextPair (k, v) = (k, newValue)
+      where
+        newValue = case v of
+          String textVal -> textVal
+          _ -> show v
+
     parseJwtAudience :: Name -> C.ConfigParserM (Maybe StringOrURI)
     parseJwtAudience k =
       C.key k >>= \case

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -756,7 +756,7 @@ getPgVersion = H.query () $ H.statement sql HE.unit versionRow False
 
 fillSessionWithEnvironment :: [(S.String, S.String)] -> H.Session ()
 fillSessionWithEnvironment envVars =
-    -- combine all environment-setting SQL queries into one session
+    -- combine all environment-setting SQL queries into one Hasql.Session
     List.foldr (>>) (return ()) $ List.map buildQueryForEnvVar envVars
   where
     buildQueryForEnvVar (k, v) =

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -757,7 +757,7 @@ getPgVersion = H.query () $ H.statement sql HE.unit versionRow False
 fillSessionWithSettings :: [(Text, Text)] -> H.Session ()
 fillSessionWithSettings settings =
     -- Send all of the config settings to the set_config function, using pgsql's `unnest` to transform arrays of values
-    H.query settings $ H.statement "SELECT set_config(unnest($1), unnest($2), false)" encoder HD.unit False
+    H.query settings $ H.statement "SELECT set_config(k, v, false) FROM unnest($1, $2) AS f1(k, v)" encoder HD.unit False
   
   where
     -- Take a list of (key, value) pairs and encode each as an array to later bind to the query

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -721,7 +721,7 @@ allSynonyms cols =
                 select case when match is not null then coalesce(match[8], match[7], match[4]) end
                 from regexp_matches(
                     CONCAT('SELECT ', SPLIT_PART(vcu.view_definition, 'SELECT', 2)),
-                    -- CONCAT('SELECT.*?((',vcu.table_name,')|(\w+))\.(', vcu.column_name, ')(\s+AS\s+("([^"]+)"|([^, \n\t]+)))?.*?FROM.*?(',vcu.table_schema,'\.|)(\2|',vcu.table_name,'\s+(as\s)?\3)'),
+                    CONCAT('SELECT.*?((',vcu.table_name,')|(\w+))\.(', vcu.column_name, ')(\s+AS\s+("([^"]+)"|([^, \n\t]+)))?.*?FROM.*?(',vcu.table_schema,'\.|)(\2|',vcu.table_name,'\s+(as\s)?\3)'),
                     'nsi'
                 ) match
             ) as view_column_name

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -699,7 +699,6 @@ spec = do
           { matchStatus = 200
           , matchHeaders = []
           }
-
     it "multiple cookies ends up as claims" $
       request methodPost "/rpc/get_guc_value" [("Cookie","acookie=cookievalue;secondcookie=anothervalue")]
         [json| {"name":"request.cookie.secondcookie"} |]
@@ -708,7 +707,15 @@ spec = do
           { matchStatus = 200
           , matchHeaders = []
           }
-
+    it "app settings available" $
+      request methodPost "/rpc/get_guc_value" []
+        [json| { "name": "app.settings.app_host" } |]
+          `shouldRespondWith`
+          [str|"localhost"|]
+          { matchStatus  = 200
+          , matchHeaders = [ matchContentTypeJson ]
+          }
+    
   describe "values with quotes in IN and NOT IN" $ do
     it "succeeds when only quoted values are present" $ do
       get "/w_or_wo_comma_names?name=in.\"Hebdon, John\"" `shouldRespondWith`

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,8 +6,8 @@ import SpecHelper
 import qualified Hasql.Pool as P
 
 import PostgREST.App (postgrest)
-import PostgREST.Config (pgVersion96)
-import PostgREST.DbStructure (getDbStructure, getPgVersion)
+import PostgREST.Config (pgVersion96, configSettings)
+import PostgREST.DbStructure (getDbStructure, getPgVersion, fillSessionWithSettings)
 import PostgREST.Types (DbStructure(..))
 import Data.Function (id)
 import Data.IORef
@@ -58,7 +58,12 @@ main = do
       asymJwkApp           = return $ postgrest (testCfgAsymJWK testDbConn)     refDbStructure pool $ pure ()
       nonexistentSchemaApp = return $ postgrest (testNonexistentSchemaCfg testDbConn)   refDbStructure pool $ pure ()
 
-  let reset = resetDb testDbConn
+  let reset :: IO ()
+      reset = do
+          r <- resetDb testDbConn
+          _ <- P.use pool $ fillSessionWithSettings (configSettings $ testCfg testDbConn)
+          pure r
+
       actualPgVersion = pgVersion dbStructure
       pg96spec | actualPgVersion >= pgVersion96 = [("Feature.PgVersion96Spec"  , Feature.PgVersion96Spec.spec)]
                | otherwise = []

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -59,10 +59,7 @@ main = do
       nonexistentSchemaApp = return $ postgrest (testNonexistentSchemaCfg testDbConn)   refDbStructure pool $ pure ()
 
   let reset :: IO ()
-      reset = do
-          r <- resetDb testDbConn
-          _ <- P.use pool $ fillSessionWithSettings (configSettings $ testCfg testDbConn)
-          pure r
+      reset = P.use pool (fillSessionWithSettings (configSettings $ testCfg testDbConn)) >> resetDb testDbConn
 
       actualPgVersion = pgVersion dbStructure
       pg96spec | actualPgVersion >= pgVersion96 = [("Feature.PgVersion96Spec"  , Feature.PgVersion96Spec.spec)]

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -73,7 +73,9 @@ _baseCfg =  -- Connection Settings
             10 Nothing (Just "test.switch_role")
             -- Debug Settings
             True
-            []
+            [ ("app.settings.app_host", "localhost")
+            , ("app.settings.external_api_secret", "0123456789abcdef")
+            ]
 
 testCfg :: Text -> AppConfig
 testCfg testDbConn = _baseCfg { configDatabase = testDbConn }

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -73,6 +73,7 @@ _baseCfg =  -- Connection Settings
             10 Nothing (Just "test.switch_role")
             -- Debug Settings
             True
+            []
 
 testCfg :: Text -> AppConfig
 testCfg testDbConn = _baseCfg { configDatabase = testDbConn }


### PR DESCRIPTION
- allows queries to refer to current_setting('app.env.[ENV]') to
  retrieve environment variables
- useful for 12-factor apps (app data can be in environment)
- provides workaround for AWS Relational Database Service (RDS) not
  allowing `ALTER DATABASE SET 'app.[KEY]' TO '[VALUE]'` on database.

Fixes #1062 

UPDATE: Now uses `current_settings('app.settings.*')` and a more generic way of getting data into those settings--rather than dump the entire ENV into the session, the config file can now specify which ENV vars, if any, are added to the db session, along side other strings and app setting data.