### PR TITLE
Update hjsonschema to support `1.7`

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -148,7 +148,7 @@ Test-Suite spec
                      , hasql
                      , hasql-pool
                      , heredoc
-                     , hjsonschema == 1.5.0.1
+                     , hjsonschema >= 1.7
                      , hspec
                      , hspec-wai >= 0.7.0
                      , hspec-wai-json


### PR DESCRIPTION
`hjsonschema-1.7.2` is the current version in both stack LTS and nightly.

Without this change, `postgrest` requires a version of this package that is more than a year old.