### PR TITLE
Allow embeds alias to be used in filters, specifying source column in embed and only alias tables on self join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - The configuration (e.g. `postgrest.conf`) now accepts arbitrary settings that will be passed through as session-local database settings. This can be used to pass in secret keys directly as strings, or via OS environment variables. For instance: `app.settings.jwt_secret = "$(MYAPP_JWT_SECRET)"` will take `MYAPP_JWT_SECRET` from the environment and make it available to postgresql functions as `current_setting('app.settings.jwt_secret')`. Only `app.settings.*` values in the configuration file are treated in this way. - @canadaduane
 - #256, Add support for bulk UPSERT with POST and single UPSERT with PUT - @steve-chavez
+- #1078, Add ability to specify source column in embed - @steve-chavez
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The configuration (e.g. `postgrest.conf`) now accepts arbitrary settings that will be passed through as session-local database settings. This can be used to pass in secret keys directly as strings, or via OS environment variables. For instance: `app.settings.jwt_secret = "$(MYAPP_JWT_SECRET)"` will take `MYAPP_JWT_SECRET` from the environment and make it available to postgresql functions as `current_setting('app.settings.jwt_secret')`. Only `app.settings.*` values in the configuration file are treated in this way. - @canadaduane
 - #256, Add support for bulk UPSERT with POST and single UPSERT with PUT - @steve-chavez
 - #1078, Add ability to specify source column in embed - @steve-chavez
+- #821, Allow embeds alias to be used in filters - @steve-chavez
 
 ### Fixed
 

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -169,16 +169,30 @@ findRelation schema allRelations nodeTableName parentNodeTableName relationDetai
 
       Just rd ->
 
-        -- (request)        => clients { ..., project.client_id{...} }
+        -- (request)        => clients { ..., projects.client_id{...} }
         -- will match
-        -- (relation type)  => parent
+        -- (relation type)  => child
         -- (entity)         => clients  {id}
         -- (foriegn entity) => projects {client_id}
         (
+          relType == Child &&
           nodeTableName == tableName relTable && -- match relation table name
-          parentNodeTableName == tableName relFTable && -- && -- match relation foreign table name
+          parentNodeTableName == tableName relFTable && -- match relation foreign table name
           length relColumns == 1 &&
           rd == colName (unsafeHead relColumns)
+        ) ||
+
+        -- (request)        => message { ..., person_detail.sender{...} }
+        -- will match
+        -- (relation type)  => parent
+        -- (entity)         => message  {sender}
+        -- (foriegn entity) => person_detail {id}
+        (
+          relType == Parent &&
+          nodeTableName == tableName relTable && -- match relation table name
+          parentNodeTableName == tableName relFTable && -- match relation foreign table name
+          length relFColumns == 1 &&
+          rd == colName (unsafeHead relFColumns)
         ) ||
 
         -- (request)        => tasks { ..., users.tasks_users{...} }

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -276,15 +276,17 @@ type SelectItem = (Field, Maybe Cast, Maybe Alias, Maybe RelationDetail)
 -- | Path of the embedded levels, e.g "clients.projects.name=eq.." gives Path ["clients", "projects"]
 type EmbedPath = [Text]
 data Filter = Filter { field::Field, opExpr::OpExpr } deriving (Show, Eq)
-data JoinCond = JoinCond (QualifiedIdentifier, FieldName, Level) (QualifiedIdentifier, FieldName, Level) deriving (Show, Eq)
-type Level = Integer
+data JoinCondition = JoinCondition (QualifiedIdentifier, Maybe Alias, FieldName)
+                                   (QualifiedIdentifier, Maybe Alias, FieldName) deriving (Show, Eq)
 
-data ReadQuery = Select { select::[SelectItem], from::[TableName], where_::[LogicTree], joinConds::[JoinCond], order::[OrderTerm], range_::NonnegRange } deriving (Show, Eq)
+data ReadQuery = Select { select::[SelectItem], from::[TableName], where_::[LogicTree], joinConditions::[JoinCondition], order::[OrderTerm], range_::NonnegRange } deriving (Show, Eq)
 data MutateQuery = Insert { in_::TableName, insPkCols::[Text], qPayload::PayloadJSON, onConflict:: Maybe PreferResolution, where_::[LogicTree], returning::[FieldName] }
                  | Delete { in_::TableName, where_::[LogicTree], returning::[FieldName] }
                  | Update { in_::TableName, qPayload::PayloadJSON, where_::[LogicTree], returning::[FieldName] } deriving (Show, Eq)
-type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe RelationDetail, Level))
+type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe RelationDetail, Depth))
 type ReadRequest = Tree ReadNode
+-- Depth of the ReadRequest tree
+type Depth = Integer
 type MutateRequest = MutateQuery
 data DbRequest = DbRead ReadRequest | DbMutate MutateRequest
 

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -399,3 +399,12 @@ INSERT INTO message VALUES (2, 'Hi John', 2, 1);
 INSERT INTO message VALUES (3, 'How are you doing?', 1, 2);
 INSERT INTO message VALUES (4, 'Hey Julie', 3, 4);
 INSERT INTO message VALUES (5, 'What''s up Jake', 4, 3);
+
+TRUNCATE TABLE space CASCADE;
+INSERT INTO space VALUES (1, 'space 1');
+
+TRUNCATE TABLE zone CASCADE;
+INSERT INTO zone VALUES (1, 'zone 1', 2, 1);
+INSERT INTO zone VALUES (2, 'zone 2', 2, 1);
+INSERT INTO zone VALUES (3, 'store 3', 3, 1);
+INSERT INTO zone VALUES (4, 'store 4', 3, 1);

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -383,3 +383,19 @@ INSERT INTO books VALUES (6, 'Lord of the Flies', 1954, 6);
 INSERT INTO books VALUES (7, 'To Kill a Mockingbird', 1960, 7);
 INSERT INTO books VALUES (8, 'Slaughterhouse-Five', 1969, 8);
 INSERT INTO books VALUES (9, 'One Flew Over the Cuckoo''s Nest', 1962, 9);
+
+SET search_path = test, pg_catalog;
+
+TRUNCATE TABLE person CASCADE;
+
+INSERT INTO person VALUES (1, 'John');
+INSERT INTO person VALUES (2, 'Jane');
+INSERT INTO person VALUES (3, 'Jake');
+INSERT INTO person VALUES (4, 'Julie');
+
+TRUNCATE TABLE message CASCADE;
+INSERT INTO message VALUES (1, 'Hello Jane', 1, 2);
+INSERT INTO message VALUES (2, 'Hi John', 2, 1);
+INSERT INTO message VALUES (3, 'How are you doing?', 1, 2);
+INSERT INTO message VALUES (4, 'Hey Julie', 3, 4);
+INSERT INTO message VALUES (5, 'What''s up Jake', 4, 3);

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -73,6 +73,9 @@ GRANT ALL ON TABLE
     , forties_books
     , fifties_books
     , sixties_books
+    , person
+    , message
+    , person_detail
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -76,6 +76,8 @@ GRANT ALL ON TABLE
     , person
     , message
     , person_detail
+    , space
+    , zone
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1409,3 +1409,19 @@ create view test.books as select id, title, publication_year, author_id from pri
 create view test.forties_books as select id, title, publication_year, author_id from private.books where publication_year >= 1940 and publication_year < 1950;
 create view test.fifties_books as select id, title, publication_year, author_id from private.books where publication_year >= 1950 and publication_year < 1960;
 create view test.sixties_books as select id, title, publication_year, author_id from private.books where publication_year >= 1960 and publication_year < 1970;
+
+create table person (
+  id integer primary key,
+  name character varying not null);
+
+create table message (
+  id integer primary key,
+  body text not null default '',
+  sender bigint not null references person(id),
+  recipient bigint not null references person(id));
+
+create view person_detail as
+  select p.id, p.name, s.count as sent, r.count as received
+  from person p
+  join lateral (select message.sender, count(message.id) as count from message group by message.sender) s on s.sender = p.id
+  join lateral (select message.recipient, count(message.id) as count from message group by message.recipient) r on r.recipient = p.id;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1425,3 +1425,13 @@ create view person_detail as
   from person p
   join lateral (select message.sender, count(message.id) as count from message group by message.sender) s on s.sender = p.id
   join lateral (select message.recipient, count(message.id) as count from message group by message.recipient) r on r.recipient = p.id;
+
+create table space(
+  id integer primary key,
+  name text);
+
+create table zone(
+  id integer primary key,
+  name text,
+  zone_type_id integer,
+  space_id integer references space(id));


### PR DESCRIPTION
On #1054 aliasing was added to all tables to fix the self join cases, however that made the error messages a bit unclear:
```http
GET "/items?select=id,wrong"
{"hint":null,"details":null,"code":"42703","message":"column items_1.wrong does not exist"}

GET "/clients?select=*,projects(id,name,wrong)"
{"hint":null,"details":null,"code":"42703","message":"column projects_2.wrong does not exist"}

GET "localhost:3000/tasks?select=id,name,project(id,name,client(id,name,wrong))"
{"hint":null,"details":null,"code":"42703","message":"column tasks_3.wrong does not exist"}
```

There may be other cases where the error messages and generated queries are harder to understand.
Self reference fks are rare in db designs, so I thought it'd be better to restrict the aliasing to only self joins.